### PR TITLE
Arrange mode selection and option controls for mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-  <title>Paper Wings</title>
+  <title>Paper Wings!</title>
   <link rel="stylesheet" href="styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Patrick+Hand&family=Roboto&display=swap" rel="stylesheet">
 </head>
@@ -19,7 +19,7 @@
 
   <!-- Game Mode Selection Menu -->
   <div id="modeMenu">
-    <h1 class="game-title">Paper Wings</h1>
+    <h1 class="game-title">Paper Wings!</h1>
 
     <div class="mode-options">
       <button id="hotSeatBtn" class="mode-btn">Hot Seat</button>
@@ -30,20 +30,39 @@
     <button id="playBtn" class="disabled" disabled>Play</button>
 
     <div class="control-group-row">
-      <!-- Flight Range Control -->
-      <div class="control-box">
-        <div class="flight-range-control">
-          <div class="control-label">Flight Range</div>
-          <div class="control-buttons">
-            <button id="flightRangeMinus" class="control-btn">−</button>
-            <button id="flightRangePlus" class="control-btn">+</button>
+      <div class="control-pair-row">
+        <!-- Flight Range Control -->
+        <div class="control-box">
+          <div class="flight-range-control">
+            <div class="control-label">Flight Range</div>
+            <div class="control-buttons">
+              <button id="flightRangeMinus" class="control-btn">−</button>
+              <button id="flightRangePlus" class="control-btn">+</button>
+            </div>
+
+            <!-- Простой индикатор-длина (строка) -->
+            <div id="flightRangeArrow"></div>
+
+            <!-- Цифровой индикатор -->
+            <span id="flightRangeDisplay">10 cells</span>
           </div>
+        </div>
 
-          <!-- Простой индикатор-длина (строка) -->
-          <div id="flightRangeArrow"></div>
-
-          <!-- Цифровой индикатор -->
-          <span id="flightRangeDisplay">10 cells</span>
+        <!-- Aiming Amplitude Control -->
+        <div class="control-box">
+          <div class="aiming-amplitude-control">
+            <div class="control-label">Aiming Amplitude</div>
+            <div class="control-buttons">
+              <button id="amplitudeMinus" class="control-btn">−</button>
+              <button id="amplitudePlus" class="control-btn">+</button>
+            </div>
+            <div class="control-value">
+              <div id="amplitudeIndicator">
+                <div class="line3"></div>
+                <span id="amplitudeAngleDisplay">20°</span>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -56,23 +75,6 @@
         </div>
         <div id="buildingsCountDisplay" class="control-value">
           <span id="buildingsCountValue">0</span>
-        </div>
-      </div>
-
-      <!-- Aiming Amplitude Control -->
-      <div class="control-box">
-        <div class="aiming-amplitude-control">
-          <div class="control-label">Aiming Amplitude</div>
-          <div class="control-buttons">
-            <button id="amplitudeMinus" class="control-btn">−</button>
-            <button id="amplitudePlus" class="control-btn">+</button>
-          </div>
-          <div class="control-value">
-            <div id="amplitudeIndicator">
-              <div class="line3"></div>
-              <span id="amplitudeAngleDisplay">20°</span>
-            </div>
-          </div>
         </div>
       </div>
     </div> <!-- /control-group-row -->

--- a/styles.css
+++ b/styles.css
@@ -80,15 +80,13 @@ body {
 
 /* Кнопки режимов */
 #modeMenu .mode-options {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 10px;
   margin-bottom: 15px;
 }
 
-#modeMenu .mode-options button,
-#modeMenu #playBtn {
-  flex: 1;
+#modeMenu .mode-options button {
   padding: 12px 8px;
   margin: 0;
   font-size: 16px;
@@ -100,12 +98,6 @@ body {
   box-shadow: 0 4px 8px rgba(0,0,0,0.2);
   cursor: pointer;
   transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
-  min-width: 100px;
-}
-
-#modeMenu .mode-options button:hover:not(.selected) {
-  transform: translateY(-5px);
-  box-shadow: 0 8px 16px rgba(0,0,0,0.35);
 }
 
 #modeMenu #playBtn {
@@ -114,6 +106,11 @@ body {
   margin-bottom: 15px;
   font-size: 18px;
   background: linear-gradient(145deg, #5bc0de, #31b0d5);
+}
+
+#modeMenu .mode-options button:hover:not(.selected) {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 16px rgba(0,0,0,0.35);
 }
 
 #modeMenu #playBtn.active {
@@ -145,6 +142,18 @@ body {
   flex-direction: column;
   gap: 10px;
   margin-top: 10px;
+}
+
+#modeMenu .control-pair-row {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+}
+
+#modeMenu .control-pair-row .control-box {
+  flex: 1;
+  width: auto;
+  aspect-ratio: 1 / 1;
 }
 
 #modeMenu .control-box {


### PR DESCRIPTION
## Summary
- Use CSS grid to lay out Hot Seat, Computer, and Online buttons in a single row for mobile-friendly menu height
- Display "Paper Wings!" in the page title and heading for easier visual confirmation of deployed changes
- Place Flight Range and Aiming Amplitude controls side-by-side as square boxes while keeping Buildings control wide

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6896432abbac832d911e6cb3330472b7