### PR TITLE
fix: prevent control pair boxes from expanding

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -151,9 +151,10 @@ body {
 }
 
 #modeMenu .control-pair-row .control-box {
-  flex: 1;
+  flex: 1 1 calc(50% - 5px);
   width: auto;
-  aspect-ratio: 1 / 1;
+  max-width: calc(50% - 5px);
+  min-width: 0;
 }
 
 #modeMenu .control-box {


### PR DESCRIPTION
## Summary
- remove aspect-ratio from mode menu control boxes
- limit control pair box width with flex-basis and max-width

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68998cb022b0832d9403a0b0f5e373f1