### PR TITLE
Adjust flame and plane styling in flight range indicator

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -188,14 +188,14 @@ body {
 /* Индикатор дальности — самолёт с огнём */
 #flightRangeIndicator {
   position: relative;
-  width: 120px;
+  width: 130px;
   height: 20px;
   margin-top: 16px;
 }
 
 #flightRangeIndicator .plane {
   position: absolute;
-  left: 0;
+  right: 0;
   top: 50%;
   transform: translateY(-50%);
   width: 20px;
@@ -215,18 +215,30 @@ body {
   border-bottom: 4px solid transparent;
   border-left: 6px solid #6c757d;
 }
+#flightRangeIndicator .plane::after {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 12px;
+  height: 2px;
+  background-color: #6c757d;
+  border-radius: 1px;
+  box-shadow: 0 4px 0 0 #6c757d;
+}
 
 .flame {
   position: absolute;
-  left: 20px;
+  right: 20px;
   top: 50%;
   transform: translateY(-50%);
   height: 6px;
   width: 20px; /* будет меняться из JS */
-  background: linear-gradient(90deg, #ffea00, #ff4500);
-  border-radius: 3px 0 0 3px;
+  background: linear-gradient(270deg, #ffea00, #ff4500);
+  border-radius: 0 3px 3px 0;
   animation: flame-flicker 0.3s infinite alternate;
-  transform-origin: left center;
+  transform-origin: right center;
 }
 
 @keyframes flame-flicker {


### PR DESCRIPTION
## Summary
- Revise flight range indicator plane to include nose and wing pseudo-elements
- Move engine flame behind the plane and adjust gradient/origin for rearward growth
- Expand indicator width to keep the full plane and flame within bounds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68998cb14234832da14ba27ec64ae37e