### PR TITLE
Add minimalistic plane with animated flame indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,13 @@
 
             <!-- Самолёт и огонь сопла для индикации дальности -->
             <div id="flightRangeIndicator">
-              <div class="plane"></div>
-              <div id="flame" class="flame"></div>
+              <div class="plane">
+                <span class="body"></span>
+                <span class="wing wing-top"></span>
+                <span class="wing wing-bottom"></span>
+                <span class="tail"></span>
+                <span id="flame" class="flame"></span>
+              </div>
             </div>
 
             <!-- Цифровой индикатор -->

--- a/script.js
+++ b/script.js
@@ -1288,12 +1288,13 @@ function updateFlightRangeDisplay(){
 function updateFlightRangeFlame(){
   const flame = document.getElementById("flame");
   if(!flame) return;
-  const minWidth = 10;
-  const maxWidth = 80;
+  const minScale = 1;
+  const maxScale = 8;
   const t = (flightRangeCells - MIN_FLIGHT_RANGE_CELLS) /
             (MAX_FLIGHT_RANGE_CELLS - MIN_FLIGHT_RANGE_CELLS);
-  const w = Math.round(minWidth + t*(maxWidth - minWidth));
-  flame.style.width = `${w}px`;
+  const ratio = minScale + t*(maxScale - minScale);
+  flame.style.transform = `translateY(-50%) scaleX(${ratio})`;
+  flame.style.setProperty('--flame-scale', ratio);
 }
 function resetFlightRangeFlame(){ updateFlightRangeFlame(); }
 

--- a/styles.css
+++ b/styles.css
@@ -199,52 +199,92 @@ body {
   right: 0;
   top: 50%;
   transform: translateY(-50%);
-  width: 20px;
-  height: 8px;
-  background-color: #6c757d;
-  border-radius: 2px;
+  width: 26px;
+  height: 12px;
 }
-#flightRangeIndicator .plane::before {
+
+#flightRangeIndicator .body {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  width: 18px;
+  height: 6px;
+  background-color: #6c757d;
+  transform: translateY(-50%);
+}
+#flightRangeIndicator .body::after {
   content: '';
   position: absolute;
-  right: -6px;
+  right: -8px;
   top: 50%;
   transform: translateY(-50%);
   width: 0;
   height: 0;
-  border-top: 4px solid transparent;
-  border-bottom: 4px solid transparent;
-  border-left: 6px solid #6c757d;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  border-left: 8px solid #6c757d;
 }
-#flightRangeIndicator .plane::after {
-  content: '';
+
+#flightRangeIndicator .wing {
   position: absolute;
   left: 4px;
+  width: 0;
+  height: 0;
+}
+#flightRangeIndicator .wing::before {
+  content: '';
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-left: 10px solid #6c757d;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+}
+#flightRangeIndicator .wing-top {
+  top: 50%;
+  transform: translateY(-8px);
+}
+#flightRangeIndicator .wing-bottom {
+  top: 50%;
+  transform: translateY(5px) scaleY(-1);
+}
+
+#flightRangeIndicator .tail {
+  position: absolute;
+  left: -4px;
   top: 50%;
   transform: translateY(-50%);
-  width: 12px;
-  height: 2px;
-  background-color: #6c757d;
-  border-radius: 1px;
-  box-shadow: 0 4px 0 0 #6c757d;
+  width: 0;
+  height: 0;
+  border-right: 4px solid #6c757d;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
 }
 
 .flame {
   position: absolute;
-  right: 20px;
+  right: calc(100% + 2px);
   top: 50%;
-  transform: translateY(-50%);
+  width: 10px;
   height: 6px;
-  width: 20px; /* будет меняться из JS */
   background: linear-gradient(270deg, #ffea00, #ff4500);
   border-radius: 0 3px 3px 0;
-  animation: flame-flicker 0.3s infinite alternate;
-  transform-origin: right center;
+  transform: translateY(-50%) scaleX(1);
+  transform-origin: left center;
+  animation: flame-flicker 0.15s infinite alternate;
 }
 
 @keyframes flame-flicker {
-  from { opacity: 0.8; }
-  to { opacity: 1; }
+  from {
+    width: 8px;
+    opacity: 0.8;
+    transform: translateY(-50%) scaleX(var(--flame-scale,1)) skewX(-5deg);
+  }
+  to {
+    width: 10px;
+    opacity: 1;
+    transform: translateY(-50%) scaleX(var(--flame-scale,1)) skewX(5deg);
+  }
 }
 
 /* Цифровой индикатор */


### PR DESCRIPTION
## Summary
- Replace flight range indicator markup with nested plane structure and flame
- Style plane parts and add flickering flame animation positioned behind the tail
- Scale flame via transform in script for flight range feedback

## Testing
- `npm test` *(fails: Could not read package.json)*
- `xdg-open index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689990020fe4832d94af4299c4a3ef87