### PR TITLE
feat: animate flight range indicator

### DIFF
--- a/script.js
+++ b/script.js
@@ -1288,13 +1288,12 @@ function updateFlightRangeDisplay(){
 function updateFlightRangeFlame(){
   const flame = document.getElementById("flame");
   if(!flame) return;
-  const minScale = 1;
-  const maxScale = 8;
+  const minScale = 0.5;
+  const maxScale = 2;
   const t = (flightRangeCells - MIN_FLIGHT_RANGE_CELLS) /
             (MAX_FLIGHT_RANGE_CELLS - MIN_FLIGHT_RANGE_CELLS);
   const ratio = minScale + t*(maxScale - minScale);
   flame.style.transform = `translateY(-50%) scaleX(${ratio})`;
-  flame.style.setProperty('--flame-scale', ratio);
 }
 function resetFlightRangeFlame(){ updateFlightRangeFlame(); }
 

--- a/styles.css
+++ b/styles.css
@@ -196,9 +196,9 @@ body {
 
 #flightRangeIndicator .plane {
   position: absolute;
-  right: 0;
   top: 50%;
-  transform: translateY(-50%);
+  left: 50%;
+  transform: translate(-50%, -50%);
   width: 26px;
   height: 12px;
 }
@@ -265,25 +265,23 @@ body {
   position: absolute;
   right: calc(100% + 2px);
   top: 50%;
-  width: 10px;
-  height: 6px;
+  width: 14px;
+  height: 12px;
   background: linear-gradient(270deg, #ffea00, #ff4500);
-  border-radius: 0 3px 3px 0;
+  clip-path: polygon(0 0, 100% 50%, 0 100%);
   transform: translateY(-50%) scaleX(1);
-  transform-origin: left center;
-  animation: flame-flicker 0.15s infinite alternate;
+  transform-origin: right center;
+  animation: flame-flicker 0.2s infinite alternate;
 }
 
 @keyframes flame-flicker {
   from {
-    width: 8px;
     opacity: 0.8;
-    transform: translateY(-50%) scaleX(var(--flame-scale,1)) skewX(-5deg);
+    clip-path: polygon(0 40%, 100% 50%, 0 100%);
   }
   to {
-    width: 10px;
     opacity: 1;
-    transform: translateY(-50%) scaleX(var(--flame-scale,1)) skewX(5deg);
+    clip-path: polygon(0 60%, 100% 50%, 0 100%);
   }
 }
 


### PR DESCRIPTION
## Summary
- Center the flight-range indicator's plane and add a flickering triangular flame
- Scale flame size in response to flight range adjustments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899a3c557f4832d8770357656e4cb99