### PR TITLE
feat: redesign flight range indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,14 +41,11 @@
             </div>
 
 
-            <!-- Самолёт и огонь сопла для индикации дальности -->
+            <!-- Самолёт и пламя турбины для индикации дальности -->
             <div id="flightRangeIndicator">
-              <div class="plane">
-                <span class="body"></span>
-                <span class="wing wing-top"></span>
-                <span class="wing wing-bottom"></span>
-                <span class="tail"></span>
-                <span id="flame" class="flame"></span>
+              <div class="jet">
+                <div class="jet-body"></div>
+                <div id="flame" class="jet-flame"></div>
               </div>
             </div>
 

--- a/styles.css
+++ b/styles.css
@@ -151,10 +151,7 @@ body {
 }
 
 #modeMenu .control-pair-row .control-box {
-  flex: 1 1 calc(50% - 5px);
-  width: auto;
-  max-width: calc(50% - 5px);
-  min-width: 0;
+  flex: 1 1 0;
 }
 
 #modeMenu .control-box {
@@ -190,85 +187,59 @@ body {
 #flightRangeIndicator {
   position: relative;
   width: 130px;
-  height: 20px;
+  height: 30px;
   margin-top: 16px;
 }
 
-#flightRangeIndicator .plane {
+#flightRangeIndicator .jet {
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 26px;
-  height: 12px;
+  width: 40px;
+  height: 16px;
 }
 
-#flightRangeIndicator .body {
+#flightRangeIndicator .jet-body {
   position: absolute;
-  right: 0;
   top: 50%;
-  width: 18px;
+  left: 0;
+  width: 100%;
   height: 6px;
   background-color: #6c757d;
   transform: translateY(-50%);
 }
-#flightRangeIndicator .body::after {
+#flightRangeIndicator .jet-body::after {
   content: '';
   position: absolute;
-  right: -8px;
+  right: -12px;
   top: 50%;
   transform: translateY(-50%);
   width: 0;
   height: 0;
-  border-top: 3px solid transparent;
-  border-bottom: 3px solid transparent;
-  border-left: 8px solid #6c757d;
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  border-left: 12px solid #6c757d;
 }
-
-#flightRangeIndicator .wing {
-  position: absolute;
-  left: 4px;
-  width: 0;
-  height: 0;
-}
-#flightRangeIndicator .wing::before {
+#flightRangeIndicator .jet-body::before {
   content: '';
   position: absolute;
-  width: 0;
-  height: 0;
-  border-left: 10px solid #6c757d;
-  border-top: 3px solid transparent;
-  border-bottom: 3px solid transparent;
-}
-#flightRangeIndicator .wing-top {
+  left: 35%;
   top: 50%;
-  transform: translateY(-8px);
-}
-#flightRangeIndicator .wing-bottom {
-  top: 50%;
-  transform: translateY(5px) scaleY(-1);
+  transform: translate(-50%, -50%);
+  width: 12px;
+  height: 4px;
+  background-color: #6c757d;
 }
 
-#flightRangeIndicator .tail {
-  position: absolute;
-  left: -4px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 0;
-  height: 0;
-  border-right: 4px solid #6c757d;
-  border-top: 3px solid transparent;
-  border-bottom: 3px solid transparent;
-}
-
-.flame {
+#flightRangeIndicator .jet-flame {
   position: absolute;
   right: calc(100% + 2px);
   top: 50%;
-  width: 14px;
+  width: 12px;
   height: 12px;
-  background: linear-gradient(270deg, #ffea00, #ff4500);
-  clip-path: polygon(0 0, 100% 50%, 0 100%);
+  background: radial-gradient(circle at 0 50%, #ffea00, #ff4500);
+  clip-path: polygon(0 50%, 100% 0, 100% 100%);
   transform: translateY(-50%) scaleX(1);
   transform-origin: right center;
   animation: flame-flicker 0.2s infinite alternate;
@@ -277,11 +248,11 @@ body {
 @keyframes flame-flicker {
   from {
     opacity: 0.8;
-    clip-path: polygon(0 40%, 100% 50%, 0 100%);
+    clip-path: polygon(0 45%, 100% 0, 100% 100%);
   }
   to {
     opacity: 1;
-    clip-path: polygon(0 60%, 100% 50%, 0 100%);
+    clip-path: polygon(0 55%, 100% 0, 100% 100%);
   }
 }
 


### PR DESCRIPTION
## Summary
- draw a new minimalist jet and flame in the flight range indicator
- ensure paired control boxes share equal width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689989d56cf4832d8126ccc8decc00db