### PR TITLE
Align range indicator plane shape

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
               <div class="jet">
 
                 <svg class="jet-plane" viewBox="0 0 38 20">
-                  <polygon points="38,10 8,20 8,15 0,10 8,5 8,0" />
+                  <polygon points="38,10 30,20 30,15 0,10 30,5 30,0" />
                 </svg>
 
                 <div class="jet-body"></div>

--- a/styles.css
+++ b/styles.css
@@ -206,7 +206,7 @@ body {
   height: 100%;
 }
 #flightRangeIndicator .jet-plane polygon {
-  fill: none;
+  fill: #fff;
   stroke: #6c757d;
   stroke-width: 2;
 


### PR DESCRIPTION
## Summary
- Update flight range indicator plane to mirror in-game design with wings near nose
- Fill plane polygon with white to hide underlying arrow while keeping stroke

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae312c690832d81077ff4c285dc80