### PR TITLE
Remove jet body element from flight range indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,6 @@
                   <polygon points="38,10 30,20 30,15 0,10 30,5 30,0" />
                 </svg>
 
-                <div class="jet-body"></div>
-
                 <div id="flame" class="jet-flame"></div>
               </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -214,38 +214,6 @@ body {
   height: 16px;
 }
 
-#flightRangeIndicator .jet-body {
-  position: absolute;
-  top: 50%;
-  left: 0;
-  width: 100%;
-  height: 6px;
-  background-color: #6c757d;
-  transform: translateY(-50%);
-}
-#flightRangeIndicator .jet-body::after {
-  content: '';
-  position: absolute;
-  right: -12px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 0;
-  height: 0;
-  border-top: 8px solid transparent;
-  border-bottom: 8px solid transparent;
-  border-left: 12px solid #6c757d;
-}
-#flightRangeIndicator .jet-body::before {
-  content: '';
-  position: absolute;
-  left: 35%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  width: 12px;
-  height: 4px;
-  background-color: #6c757d;
-
-}
 
 #flightRangeIndicator .jet-flame {
   position: absolute;


### PR DESCRIPTION
## Summary
- simplify flight range indicator by removing unused `<div class="jet-body">`
- drop `.jet-body` styling, leaving only SVG plane and flame rules

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node` script confirms absence of `jet-body` and presence of `jet-flame`
- `npm install playwright --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ae894c7f4832d83339f0b9e0951ca