### PR TITLE
Tweak plane indicator size with small minimalist flame

### DIFF
--- a/script.js
+++ b/script.js
@@ -1288,8 +1288,8 @@ function updateFlightRangeDisplay(){
 function updateFlightRangeFlame(){
   const flame = document.getElementById("flame");
   if(!flame) return;
-  const minScale = 0.5;
-  const maxScale = 2;
+  const minScale = 0.3;
+  const maxScale = 1.2;
   const t = (flightRangeCells - MIN_FLIGHT_RANGE_CELLS) /
             (MAX_FLIGHT_RANGE_CELLS - MIN_FLIGHT_RANGE_CELLS);
   const ratio = minScale + t*(maxScale - minScale);

--- a/styles.css
+++ b/styles.css
@@ -197,8 +197,8 @@ body {
   left: 50%;
   transform: translate(-50%, -50%);
 
-  width: 38px;
-  height: 20px;
+  width: 48px;
+  height: 24px;
 }
 
 #flightRangeIndicator .jet-plane {
@@ -218,10 +218,10 @@ body {
   position: absolute;
   right: calc(100% + 2px);
   top: 50%;
-  width: 12px;
-  height: 12px;
+  width: 8px;
+  height: 8px;
   background: radial-gradient(circle at 0 50%, #ffea00, #ff4500);
-  clip-path: polygon(0 50%, 100% 0, 100% 100%);
+  border-radius: 50%;
   transform: translateY(-50%) scaleX(1);
   transform-origin: right center;
   animation: flame-flicker 0.2s infinite alternate;
@@ -230,11 +230,9 @@ body {
 @keyframes flame-flicker {
   from {
     opacity: 0.8;
-    clip-path: polygon(0 45%, 100% 0, 100% 100%);
   }
   to {
     opacity: 1;
-    clip-path: polygon(0 55%, 100% 0, 100% 100%);
   }
 }
 


### PR DESCRIPTION
## Summary
- Enlarge the flight-range plane indicator for better proportion
- Replace the triangular exhaust with a small circular flame
- Reduce flame scaling range to keep animation subtle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b914c69d0832d9bf46efec5a17b80