### PR TITLE
feat: disable text selection for body and buttons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,11 @@
+body, button {
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
 /* Базовый шрифт/раскладка */
 body {
   position: relative;


### PR DESCRIPTION
## Summary
- add global CSS rule to prevent text selection and tap highlights on `body` and `button`
- confirm all interactive controls use `<button>` elements and inherit the rule

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c36e2a360832d9c2ce3b491f0533c