### PR TITLE
Move control buttons below value displays for better mobile clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,12 +35,6 @@
         <div class="control-box">
           <div class="flight-range-control">
             <div class="control-label">Flight Range</div>
-            <div class="control-buttons">
-              <button id="flightRangeMinus" class="control-btn">−</button>
-              <button id="flightRangePlus" class="control-btn">+</button>
-            </div>
-
-
             <!-- Самолёт и пламя турбины для индикации дальности -->
             <div id="flightRangeIndicator">
               <div class="jet">
@@ -55,6 +49,10 @@
 
             <!-- Цифровой индикатор -->
             <span id="flightRangeDisplay">10 cells</span>
+            <div class="control-buttons">
+              <button id="flightRangeMinus" class="control-btn">−</button>
+              <button id="flightRangePlus" class="control-btn">+</button>
+            </div>
           </div>
         </div>
 
@@ -62,15 +60,15 @@
         <div class="control-box">
           <div class="aiming-amplitude-control">
             <div class="control-label">Aiming Amplitude</div>
-            <div class="control-buttons">
-              <button id="amplitudeMinus" class="control-btn">−</button>
-              <button id="amplitudePlus" class="control-btn">+</button>
-            </div>
             <div class="control-value">
               <div id="amplitudeIndicator">
                 <div class="line3"></div>
                 <span id="amplitudeAngleDisplay">20°</span>
               </div>
+            </div>
+            <div class="control-buttons">
+              <button id="amplitudeMinus" class="control-btn">−</button>
+              <button id="amplitudePlus" class="control-btn">+</button>
             </div>
           </div>
         </div>
@@ -79,12 +77,12 @@
       <!-- Buildings Control -->
       <div class="control-box">
         <div class="control-label">Buildings</div>
+        <div id="buildingsCountDisplay" class="control-value">
+          <span id="buildingsCountValue">0</span>
+        </div>
         <div class="control-buttons">
           <button id="buildingsMinus" class="control-btn">−</button>
           <button id="buildingsPlus" class="control-btn">+</button>
-        </div>
-        <div id="buildingsCountDisplay" class="control-value">
-          <span id="buildingsCountValue">0</span>
         </div>
       </div>
     </div> <!-- /control-group-row -->

--- a/styles.css
+++ b/styles.css
@@ -183,7 +183,7 @@ body {
 .flight-range-control .control-label {
   font-size: 16px; font-weight: bold; margin-bottom: 10px; color: #ff0000c8;
 }
-.flight-range-control .control-buttons { display:flex; gap:15px; margin-bottom:10px; }
+.flight-range-control .control-buttons { display:flex; gap:15px; margin-top:10px; }
 .flight-range-control .control-buttons button {
   width: 40px; height: 40px; font-size: 20px; color:#fff; border:none; border-radius:50%;
   background: linear-gradient(145deg, #6c757d, #5a6268);
@@ -272,6 +272,7 @@ body {
   cursor:pointer; transition: transform 0.2s, box-shadow 0.2s;
 }
 #modeMenu .control-buttons button:hover { transform: translateY(-3px); box-shadow: 0 6px 12px rgba(0,0,0,0.3); }
+#modeMenu .control-box .control-buttons { display:flex; gap:15px; margin-top:10px; }
 #modeMenu .control-box .control-label { font-size: 16px; font-weight: bold; margin-bottom: 10px; color: #555; }
 
 #buildingsCountDisplay {
@@ -288,7 +289,7 @@ body {
 /* Aiming amplitude */
 .aiming-amplitude-control { display:flex; flex-direction:column; align-items:center; }
 .aiming-amplitude-control .control-label { font-size:16px; font-weight:bold; margin-bottom:10px; color:#555; }
-.aiming-amplitude-control .control-buttons { display:flex; gap:15px; margin-bottom:15px; }
+#modeMenu .aiming-amplitude-control .control-buttons { display:flex; gap:15px; margin-top:15px; }
 .aiming-amplitude-control .control-buttons button {
   width: 40px; height: 40px; font-size:20px; color:#fff; border:none; border-radius:50%;
   background: linear-gradient(145deg, #6c757d, #5a6268);


### PR DESCRIPTION
## Summary
- Reorder Flight Range, Aiming Amplitude, and Buildings controls so buttons sit below their displays
- Switch margin-bottom to margin-top for control button groups and add shared spacing rule for buildings

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx playwright --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c4a9be578832d9100ea0f875c1e84