### PR TITLE
Unify control boxes with translucent overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,26 +35,22 @@
         <div class="control-box">
           <div class="flight-range-control">
             <div class="control-label">Flight Range</div>
+            <div class="control-visual">
+              <span id="flightRangeDisplay" class="control-value">10 cells</span>
+              <!-- Самолёт и пламя турбины для индикации дальности -->
+              <div id="flightRangeIndicator">
+                <div class="jet">
+                  <svg class="jet-plane" viewBox="0 0 38 20">
+                    <polygon points="38,10 8,20 8,15 0,10 8,5 8,0" />
+                  </svg>
+                  <div id="flame" class="jet-flame"></div>
+                </div>
+              </div>
+            </div>
             <div class="control-buttons">
               <button id="flightRangeMinus" class="control-btn">−</button>
               <button id="flightRangePlus" class="control-btn">+</button>
             </div>
-
-
-            <!-- Самолёт и пламя турбины для индикации дальности -->
-            <div id="flightRangeIndicator">
-              <div class="jet">
-
-                <svg class="jet-plane" viewBox="0 0 38 20">
-                  <polygon points="38,10 8,20 8,15 0,10 8,5 8,0" />
-                </svg>
-
-                <div id="flame" class="jet-flame"></div>
-              </div>
-            </div>
-
-            <!-- Цифровой индикатор -->
-            <span id="flightRangeDisplay">10 cells</span>
           </div>
         </div>
 
@@ -62,15 +58,15 @@
         <div class="control-box">
           <div class="aiming-amplitude-control">
             <div class="control-label">Aiming Amplitude</div>
+            <div class="control-visual amplitude-visual">
+              <span id="amplitudeAngleDisplay" class="control-value">20°</span>
+              <div id="amplitudeIndicator">
+                <div class="line3"></div>
+              </div>
+            </div>
             <div class="control-buttons">
               <button id="amplitudeMinus" class="control-btn">−</button>
               <button id="amplitudePlus" class="control-btn">+</button>
-            </div>
-            <div class="control-value">
-              <div id="amplitudeIndicator">
-                <div class="line3"></div>
-                <span id="amplitudeAngleDisplay">20°</span>
-              </div>
             </div>
           </div>
         </div>
@@ -79,12 +75,12 @@
       <!-- Buildings Control -->
       <div class="control-box">
         <div class="control-label">Buildings</div>
+        <div class="control-visual">
+          <span id="buildingsCountValue" class="control-value">0</span>
+        </div>
         <div class="control-buttons">
           <button id="buildingsMinus" class="control-btn">−</button>
           <button id="buildingsPlus" class="control-btn">+</button>
-        </div>
-        <div id="buildingsCountDisplay" class="control-value">
-          <span id="buildingsCountValue">0</span>
         </div>
       </div>
     </div> <!-- /control-group-row -->

--- a/script.js
+++ b/script.js
@@ -1072,7 +1072,8 @@ function stopButtonInterval(button){
 }
 
 /* Flight Range */
-flightRangeMinusBtn.addEventListener("mousedown",()=>{
+flightRangeMinusBtn.addEventListener("pointerdown", (event)=>{
+  event.preventDefault();
   if(hasShotThisRound) return;
   startButtonInterval(flightRangeMinusBtn, ()=>{
     if(flightRangeCells > MIN_FLIGHT_RANGE_CELLS){
@@ -1082,10 +1083,11 @@ flightRangeMinusBtn.addEventListener("mousedown",()=>{
     }
   });
 });
-flightRangeMinusBtn.addEventListener("mouseup", ()=>stopButtonInterval(flightRangeMinusBtn));
-flightRangeMinusBtn.addEventListener("mouseleave", ()=>stopButtonInterval(flightRangeMinusBtn));
+flightRangeMinusBtn.addEventListener("pointerup", ()=>stopButtonInterval(flightRangeMinusBtn));
+flightRangeMinusBtn.addEventListener("pointerleave", ()=>stopButtonInterval(flightRangeMinusBtn));
 
-flightRangePlusBtn.addEventListener("mousedown",()=>{
+flightRangePlusBtn.addEventListener("pointerdown", (event)=>{
+  event.preventDefault();
   if(hasShotThisRound) return;
   startButtonInterval(flightRangePlusBtn, ()=>{
     if(flightRangeCells < MAX_FLIGHT_RANGE_CELLS){
@@ -1095,11 +1097,12 @@ flightRangePlusBtn.addEventListener("mousedown",()=>{
     }
   });
 });
-flightRangePlusBtn.addEventListener("mouseup", ()=>stopButtonInterval(flightRangePlusBtn));
-flightRangePlusBtn.addEventListener("mouseleave", ()=>stopButtonInterval(flightRangePlusBtn));
+flightRangePlusBtn.addEventListener("pointerup", ()=>stopButtonInterval(flightRangePlusBtn));
+flightRangePlusBtn.addEventListener("pointerleave", ()=>stopButtonInterval(flightRangePlusBtn));
 
 /* Buildings */
-buildingsMinusBtn.addEventListener("mousedown",()=>{
+buildingsMinusBtn.addEventListener("pointerdown", (event)=>{
+  event.preventDefault();
   if(hasShotThisRound) return;
   startButtonInterval(buildingsMinusBtn, ()=>{
     if(buildingsCount >= 4){
@@ -1112,10 +1115,11 @@ buildingsMinusBtn.addEventListener("mousedown",()=>{
     renderScoreboard();
   });
 });
-buildingsMinusBtn.addEventListener("mouseup", ()=>stopButtonInterval(buildingsMinusBtn));
-buildingsMinusBtn.addEventListener("mouseleave", ()=>stopButtonInterval(buildingsMinusBtn));
+buildingsMinusBtn.addEventListener("pointerup", ()=>stopButtonInterval(buildingsMinusBtn));
+buildingsMinusBtn.addEventListener("pointerleave", ()=>stopButtonInterval(buildingsMinusBtn));
 
-buildingsPlusBtn.addEventListener("mousedown",()=>{
+buildingsPlusBtn.addEventListener("pointerdown", (event)=>{
+  event.preventDefault();
   if(hasShotThisRound) return;
   startButtonInterval(buildingsPlusBtn, ()=>{
     if(buildingsCount < MAX_BUILDINGS_GLOBAL){
@@ -1127,11 +1131,12 @@ buildingsPlusBtn.addEventListener("mousedown",()=>{
     }
   });
 });
-buildingsPlusBtn.addEventListener("mouseup", ()=>stopButtonInterval(buildingsPlusBtn));
-buildingsPlusBtn.addEventListener("mouseleave", ()=>stopButtonInterval(buildingsPlusBtn));
+buildingsPlusBtn.addEventListener("pointerup", ()=>stopButtonInterval(buildingsPlusBtn));
+buildingsPlusBtn.addEventListener("pointerleave", ()=>stopButtonInterval(buildingsPlusBtn));
 
 /* Aiming amplitude */
-amplitudeMinusBtn.addEventListener("mousedown",()=>{
+amplitudeMinusBtn.addEventListener("pointerdown", (event)=>{
+  event.preventDefault();
   if(hasShotThisRound) return;
   startButtonInterval(amplitudeMinusBtn, ()=>{
     if(aimingAmplitude > MIN_AMPLITUDE){
@@ -1140,10 +1145,11 @@ amplitudeMinusBtn.addEventListener("mousedown",()=>{
     }
   });
 });
-amplitudeMinusBtn.addEventListener("mouseup", ()=>stopButtonInterval(amplitudeMinusBtn));
-amplitudeMinusBtn.addEventListener("mouseleave", ()=>stopButtonInterval(amplitudeMinusBtn));
+amplitudeMinusBtn.addEventListener("pointerup", ()=>stopButtonInterval(amplitudeMinusBtn));
+amplitudeMinusBtn.addEventListener("pointerleave", ()=>stopButtonInterval(amplitudeMinusBtn));
 
-amplitudePlusBtn.addEventListener("mousedown",()=>{
+amplitudePlusBtn.addEventListener("pointerdown", (event)=>{
+  event.preventDefault();
   if(hasShotThisRound) return;
   startButtonInterval(amplitudePlusBtn, ()=>{
     if(aimingAmplitude < MAX_AMPLITUDE){
@@ -1152,8 +1158,8 @@ amplitudePlusBtn.addEventListener("mousedown",()=>{
     }
   });
 });
-amplitudePlusBtn.addEventListener("mouseup", ()=>stopButtonInterval(amplitudePlusBtn));
-amplitudePlusBtn.addEventListener("mouseleave", ()=>stopButtonInterval(amplitudePlusBtn));
+amplitudePlusBtn.addEventListener("pointerup", ()=>stopButtonInterval(amplitudePlusBtn));
+amplitudePlusBtn.addEventListener("pointerleave", ()=>stopButtonInterval(amplitudePlusBtn));
 
 /* Поля/здания */
 const buildingTypes = ['rectangle', 'rectangle_double', 'rectangle_triple'];

--- a/styles.css
+++ b/styles.css
@@ -176,30 +176,47 @@ body {
   box-sizing: border-box;
 }
 
-/* Flight range */
-.flight-range-control {
-  display:flex; flex-direction:column; align-items:center;
+#modeMenu .control-box .control-buttons {
+  display: flex;
+  gap: 15px;
+  margin-top: 10px;
 }
-.flight-range-control .control-label {
-  font-size: 16px; font-weight: bold; margin-bottom: 10px; color: #ff0000c8;
-}
-.flight-range-control .control-buttons { display:flex; gap:15px; margin-bottom:10px; }
-.flight-range-control .control-buttons button {
-  width: 40px; height: 40px; font-size: 20px; color:#fff; border:none; border-radius:50%;
-  background: linear-gradient(145deg, #6c757d, #5a6268);
-  box-shadow: 0 3px 6px rgba(0,0,0,0.2); cursor:pointer; transition: transform 0.2s, box-shadow 0.2s;
-}
-.flight-range-control .control-buttons button:hover { transform: translateY(-3px); box-shadow: 0 6px 12px rgba(0,0,0,0.3); }
-.flight-range-control .control-buttons button:disabled { background: #a1a1a1; cursor: not-allowed; }
 
-/* Индикатор дальности — самолёт с огнём */
+.control-visual {
+  position: relative;
+  width: 130px;
+  height: 60px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.amplitude-visual {
+  height: 100px;
+}
+
+.control-value {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 48px;
+  color: #ee0000;
+  opacity: 0.3;
+  font-family: 'Patrick Hand', cursive;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Flight range */
 #flightRangeIndicator {
   position: relative;
   width: 130px;
   height: 30px;
-  margin-top: 16px;
+  z-index: 1;
 }
 
+/* Индикатор дальности — самолёт с огнём */
 #flightRangeIndicator .jet {
   position: absolute;
   top: 50%;
@@ -254,17 +271,6 @@ body {
   }
 }
 
-/* Цифровой индикатор */
-#flightRangeDisplay {
-  position: relative;
-  display: block;
-  margin-top: 6px;
-  font-size: 18px;
-  color: #ee0000;
-  font-family: 'Patrick Hand', cursive;
-}
-
-/* Buildings control */
 #modeMenu .control-buttons button {
   width: 40px; height: 40px; font-size: 20px; color:#fff; border:none; border-radius:50%;
   background: linear-gradient(145deg, #6c757d, #5a6268);
@@ -274,40 +280,13 @@ body {
 #modeMenu .control-buttons button:hover { transform: translateY(-3px); box-shadow: 0 6px 12px rgba(0,0,0,0.3); }
 #modeMenu .control-box .control-label { font-size: 16px; font-weight: bold; margin-bottom: 10px; color: #555; }
 
-#buildingsCountDisplay {
-  font-size: 28px;
-  color: #ee0000;
-  font-family: 'Patrick Hand', cursive;
-  margin-top: 8px;
-}
+#modeMenu .control-buttons button:disabled { background:#a1a1a1; cursor:not-allowed; }
 
-#buildingsCountValue {
-  font-weight: bold;
-}
-
-/* Aiming amplitude */
-.aiming-amplitude-control { display:flex; flex-direction:column; align-items:center; }
-.aiming-amplitude-control .control-label { font-size:16px; font-weight:bold; margin-bottom:10px; color:#555; }
-.aiming-amplitude-control .control-buttons { display:flex; gap:15px; margin-bottom:15px; }
-.aiming-amplitude-control .control-buttons button {
-  width: 40px; height: 40px; font-size:20px; color:#fff; border:none; border-radius:50%;
-  background: linear-gradient(145deg, #6c757d, #5a6268);
-  box-shadow: 0 3px 6px rgba(0,0,0,0.2);
-  cursor:pointer; transition: transform 0.2s, box-shadow 0.2s;
-}
-.aiming-amplitude-control .control-buttons button:disabled { background:#a1a1a1; cursor:not-allowed; }
-
-#amplitudeIndicator { position: relative; width: 100px; height: 100px; }
+#amplitudeIndicator { position: relative; width: 100px; height: 100px; z-index: 1; }
 .line3 {
   position: absolute; width: 80px; height: 3px; background-color: #6c757d;
   top: 50%; left: 10px; transform-origin: 0 50%; border-radius: 2px;
 }
-#amplitudeAngleDisplay {
-  position: absolute; left: 50%; top: 75%;
-  transform: translateX(-50%);
-  font-size: 22px; color: #ee0000; font-family: 'Patrick Hand', cursive;
-}
-
 /* Окно конца игры */
 #endGameButtons {
   position: fixed; top:50%; left:50%; transform: translate(-50%, -50%);


### PR DESCRIPTION
## Summary
- Position flight range, amplitude, and building buttons at the bottom of their containers
- Overlay large, semi-transparent value readouts behind visual indicators for consistent styling
- Simplify and centralize control CSS rules

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c39356f60832d8f16af1389e116e9