### PR TITLE
Align control blocks via grid layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -169,9 +169,9 @@ body {
   border-radius: 12px;
   padding: 10px;
   width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  display: grid;
+  grid-template-rows: auto 120px auto auto;
+  place-items: center;
   box-shadow: 0 4px 8px rgba(0,0,0,0.1);
   box-sizing: border-box;
 }
@@ -184,6 +184,7 @@ body {
 }
 
 #modeMenu .control-box > .control-visual {
+  height: 120px;
   width: 100%;
   display: flex;
   justify-content: center;
@@ -210,6 +211,9 @@ body {
   position: relative;
   width: 130px;
   height: 30px;
+  margin: auto;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 #flightRangeIndicator .jet {
@@ -292,7 +296,14 @@ body {
   font-weight: bold;
 }
 
-#amplitudeIndicator { position: relative; width: 100px; height: 100px; }
+#amplitudeIndicator {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  margin: auto;
+  max-width: 100%;
+  max-height: 100%;
+}
 .line3 {
   position: absolute; width: 80px; height: 3px; background-color: #6c757d;
   top: 50%; left: 10px; transform-origin: 0 50%; border-radius: 2px;


### PR DESCRIPTION
## Summary
- use CSS grid in control boxes to allocate fixed rows for label, indicator, value, and buttons
- normalize indicator areas with consistent 120px slots and centering
- center and constrain flight range and amplitude indicators within their new slots

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c4668ac832d8f234366f3ad527a