### PR TITLE
Improve control sizing for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,9 +65,8 @@
       </div>
 
       <!-- Buildings Control -->
-      <div class="control-box">
+      <div class="control-box" id="buildingsControl">
         <div class="control-label">Buildings</div>
-        <div class="control-visual"></div>
         <div id="buildingsCountDisplay" class="control-value">
           <span id="buildingsCountValue">0</span>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -176,6 +176,10 @@ body {
   box-sizing: border-box;
 }
 
+#modeMenu #buildingsControl {
+  grid-template-rows: auto auto auto;
+}
+
 #modeMenu .control-box > .control-label {
   font-size: 16px;
   font-weight: bold;
@@ -245,16 +249,9 @@ body {
   top: 50%;
 
   width: 40px;
-  height: 8px;
+  height: 10px;
   background: radial-gradient(ellipse at 100% 50%, #ffea00, #ff4500);
-  border-radius: 4px;
-
-
-  width: 8px;
-  height: 8px;
-  background: radial-gradient(circle at 0 50%, #ffea00, #ff4500);
-  border-radius: 50%;
-
+  border-radius: 5px;
 
   transform: translateY(-50%) scaleX(1);
   transform-origin: right center;


### PR DESCRIPTION
## Summary
- shrink Buildings control by removing empty visual element
- adjust CSS grid rows to keep menu within screen
- lengthen Flight Range flame for better visibility on phones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c63bf64d8832d8c3cac0a0dedea95