### PR TITLE
Improve control sizing for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,15 @@
               <svg class="jet-plane" viewBox="0 0 38 20">
                 <polygon points="38,10 8,20 8,15 0,10 8,5 8,0" />
               </svg>
-              <div id="flame" class="jet-flame"></div>
+              <svg id="flame" class="jet-flame" viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+                <defs>
+                  <radialGradient id="flameGradient" cx="100%" cy="50%" r="60%">
+                    <stop offset="0%" stop-color="#ffea00" />
+                    <stop offset="100%" stop-color="#ff4500" />
+                  </radialGradient>
+                </defs>
+                <path d="M0 10 Q20 0 40 10 Q20 20 0 10 Z" fill="url(#flameGradient)" />
+              </svg>
             </div>
           </div>
           <div class="control-value"><span id="flightRangeDisplay">10 cells</span></div>
@@ -65,9 +73,8 @@
       </div>
 
       <!-- Buildings Control -->
-      <div class="control-box">
+      <div class="control-box" id="buildingsControl">
         <div class="control-label">Buildings</div>
-        <div class="control-visual"></div>
         <div id="buildingsCountDisplay" class="control-value">
           <span id="buildingsCountValue">0</span>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -176,6 +176,10 @@ body {
   box-sizing: border-box;
 }
 
+#modeMenu #buildingsControl {
+  grid-template-rows: auto auto auto;
+}
+
 #modeMenu .control-box > .control-label {
   font-size: 16px;
   font-weight: bold;
@@ -245,27 +249,19 @@ body {
   top: 50%;
 
   width: 40px;
-  height: 8px;
-  background: radial-gradient(ellipse at 100% 50%, #ffea00, #ff4500);
-  border-radius: 4px;
-
-
-  width: 8px;
-  height: 8px;
-  background: radial-gradient(circle at 0 50%, #ffea00, #ff4500);
-  border-radius: 50%;
-
-
-  transform: translateY(-50%) scaleX(1);
+  height: 12px;
+  transform: translateY(-50%);
   transform-origin: right center;
-  animation: flame-flicker 0.2s infinite alternate;
+  animation: flame-flicker 0.15s infinite alternate;
 }
 
 @keyframes flame-flicker {
   from {
-    opacity: 0.8;
+    transform: translateY(-50%) scaleX(1) scaleY(1);
+    opacity: 0.85;
   }
   to {
+    transform: translateY(-50%) scaleX(1.1) scaleY(0.9);
     opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary
- shrink Buildings control by removing empty visual element
- adjust CSS grid rows to keep menu within screen
- lengthen Flight Range flame for better visibility on phones
- reshape Flight Range flame into flickering teardrop for natural burning effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c63bf64d8832d8c3cac0a0dedea95