### PR TITLE
Align wing contrails with wing tips and add waver animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,12 +35,22 @@
         <div class="control-box">
           <div class="control-label">Flight Range</div>
           <!-- Самолёт и пламя турбины для индикации дальности -->
-          <div id="flightRangeIndicator" class="control-visual">
+            <div id="flightRangeIndicator" class="control-visual">
             <div class="jet">
+              <svg id="flame" class="jet-flame" viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+                <defs>
+                  <radialGradient id="flameGradient" cx="100%" cy="50%" r="60%">
+                    <stop offset="0%" stop-color="#ffea00" />
+                    <stop offset="100%" stop-color="#ff4500" />
+                  </radialGradient>
+                </defs>
+                <path d="M40 10 C37 4 32 0 20 0 C5 0 0 10 20 20 C32 20 37 16 40 10 Z" fill="url(#flameGradient)" />
+              </svg>
+              <div class="wing-trail top"></div>
+              <div class="wing-trail bottom"></div>
               <svg class="jet-plane" viewBox="0 0 38 20">
                 <polygon points="38,10 8,20 8,15 0,10 8,5 8,0" />
               </svg>
-              <div id="flame" class="jet-flame"></div>
             </div>
           </div>
           <div class="control-value"><span id="flightRangeDisplay">10 cells</span></div>
@@ -65,9 +75,8 @@
       </div>
 
       <!-- Buildings Control -->
-      <div class="control-box">
+      <div class="control-box" id="buildingsControl">
         <div class="control-label">Buildings</div>
-        <div class="control-visual"></div>
         <div id="buildingsCountDisplay" class="control-value">
           <span id="buildingsCountValue">0</span>
         </div>

--- a/script.js
+++ b/script.js
@@ -1304,13 +1304,35 @@ function updateFlightRangeDisplay(){
 }
 function updateFlightRangeFlame(){
   const flame = document.getElementById("flame");
-  if(!flame) return;
+  const trails = document.querySelectorAll("#flightRangeIndicator .wing-trail");
   const minScale = 0.3;
   const maxScale = 1.2;
   const t = (flightRangeCells - MIN_FLIGHT_RANGE_CELLS) /
             (MAX_FLIGHT_RANGE_CELLS - MIN_FLIGHT_RANGE_CELLS);
-  const ratio = minScale + t*(maxScale - minScale);
-  flame.style.transform = `translateY(-50%) scaleX(${ratio})`;
+  const ratio = minScale + t * (maxScale - minScale);
+
+  if(flame){
+    const baseWidth = 40;  // matches CSS default
+    const baseHeight = 12; // matches CSS default
+    flame.style.width = `${baseWidth * ratio}px`;
+    flame.style.height = `${baseHeight * (0.9 + 0.1 * ratio)}px`;
+  }
+  if(trails.length){
+    const baseTrailWidth = 30;
+    const baseTrailHeight = 3;
+    trails.forEach(trail => {
+      const newWidth = baseTrailWidth * ratio;
+      const newHeight = baseTrailHeight * (0.9 + 0.1 * ratio);
+      trail.style.width = `${newWidth}px`;
+      trail.style.height = `${newHeight}px`;
+      const offset = (newHeight - baseTrailHeight) / 2;
+      if(trail.classList.contains('top')){
+        trail.style.top = `${-offset}px`;
+      } else {
+        trail.style.bottom = `${-offset}px`;
+      }
+    });
+  }
 }
 function resetFlightRangeFlame(){ updateFlightRangeFlame(); }
 

--- a/styles.css
+++ b/styles.css
@@ -176,6 +176,10 @@ body {
   box-sizing: border-box;
 }
 
+#modeMenu #buildingsControl {
+  grid-template-rows: auto auto auto;
+}
+
 #modeMenu .control-box > .control-label {
   font-size: 16px;
   font-weight: bold;
@@ -230,6 +234,8 @@ body {
   width: 100%;
   height: 100%;
   color: #6c757d;
+  position: relative;
+  z-index: 1;
 }
 #flightRangeIndicator .jet-plane polygon {
   fill: none;
@@ -245,27 +251,38 @@ body {
   top: 50%;
 
   width: 40px;
-  height: 8px;
-  background: radial-gradient(ellipse at 100% 50%, #ffea00, #ff4500);
-  border-radius: 4px;
-
-
-  width: 8px;
-  height: 8px;
-  background: radial-gradient(circle at 0 50%, #ffea00, #ff4500);
-  border-radius: 50%;
-
-
-  transform: translateY(-50%) scaleX(1);
+  height: 12px;
+  transform: translateY(-50%);
   transform-origin: right center;
-  animation: flame-flicker 0.2s infinite alternate;
+  animation: flame-flicker 0.15s infinite alternate;
+}
+
+#flightRangeIndicator .wing-trail {
+  position: absolute;
+  right: calc(100% - 8px);
+  width: 30px;
+  height: 3px;
+  background: linear-gradient(to left, rgba(160,160,160,0.6), rgba(160,160,160,0));
+  border-radius: 2px;
+  transform-origin: right center;
+  opacity: 0.55;
+  animation: contrail-waver 0.4s infinite alternate ease-in-out;
+}
+#flightRangeIndicator .wing-trail.top { top: 0; }
+#flightRangeIndicator .wing-trail.bottom { bottom: 0; }
+
+@keyframes contrail-waver {
+  from { transform: translateY(0) scaleY(1); opacity: 0.55; }
+  to { transform: translateY(-1px) scaleY(1.1); opacity: 0.65; }
 }
 
 @keyframes flame-flicker {
   from {
-    opacity: 0.8;
+    transform: translateY(-50%) scaleX(1) scaleY(1);
+    opacity: 0.85;
   }
   to {
+    transform: translateY(-50%) scaleX(1.1) scaleY(0.9);
     opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary
- Style wing contrails as gray, semi-transparent trails and anchor them to the wing tips
- Animate contrails with a subtle waver and keep their origin aligned when scaling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c63bf64d8832d8c3cac0a0dedea95