### PR TITLE
Refine wing contrails for flight indicator

### DIFF
--- a/script.js
+++ b/script.js
@@ -1319,11 +1319,11 @@ function updateFlightRangeFlame(){
     flame.style.height = `${baseHeight * (0.9 + 0.1 * ratio)}px`;
   }
   if(trails.length){
-    const baseTrailWidth = 30;
-    const baseTrailHeight = 3;
+    const baseTrailWidth = 35;  // matches CSS default
+    const baseTrailHeight = 2;  // matches CSS default
     trails.forEach(trail => {
       trail.style.width = `${baseTrailWidth * ratio}px`;
-      trail.style.height = `${baseTrailHeight * (0.9 + 0.1 * ratio)}px`;
+      trail.style.height = `${baseTrailHeight}px`;
     });
   }
 

--- a/styles.css
+++ b/styles.css
@@ -258,36 +258,28 @@ body {
   animation: flame-flicker 0.15s infinite alternate;
 }
 
+/* Wing contrails from wingtips */
 #flightRangeIndicator .wing-trail {
   position: absolute;
   right: calc(100% + 2px);
-  width: 30px;
-  height: 3px;
-  background: linear-gradient(to left, rgba(255,255,255,0.7), rgba(255,255,255,0));
-  opacity: 0.6;
-  border-radius: 2px;
+  width: 35px;
+  height: 2px;
+  background: linear-gradient(to left, rgba(160,160,160,0.5), rgba(160,160,160,0));
+  opacity: 0.5;
+  border-radius: 1px;
   transform-origin: right center;
-
-
-  height: 12px;
   transform: translateY(-50%);
-
-  height: 12px;
-  transform: translateY(-50%);
-
-  height: 10px;
-  background: radial-gradient(ellipse at 100% 50%, #ffea00, #ff4500);
-  border-radius: 5px;
-
-  transform: translateY(-50%) scaleX(1);
-
-
-  transform-origin: right center;
-  animation: flame-flicker 0.15s infinite alternate;
-
+  filter: blur(0.5px);
+  animation: trail-wisp 3s infinite ease-in-out;
 }
-#flightRangeIndicator .wing-trail.top { top: 4px; }
-#flightRangeIndicator .wing-trail.bottom { bottom: 4px; }
+#flightRangeIndicator .wing-trail.top { top: 2px; }
+#flightRangeIndicator .wing-trail.bottom { bottom: 2px; }
+
+@keyframes trail-wisp {
+  0% { transform: translateY(-50%) rotate(0deg); }
+  50% { transform: translateY(-52%) rotate(2deg); }
+  100% { transform: translateY(-50%) rotate(0deg); }
+}
 
 @keyframes flame-flicker {
   from {


### PR DESCRIPTION
## Summary
- Restyled wing contrails to emanate from wing tips with a subtle grey, semi-transparent smoke effect.
- Added gentle wisp animation for contrails and aligned script scaling parameters.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c8086f694832db26ed33ec7d4f7ad