### PR TITLE
feat: show turn status in player panel

### DIFF
--- a/script.js
+++ b/script.js
@@ -1004,8 +1004,15 @@ function drawPlayerPanel(ctx, color, victories, isTurn){
   ctx.font = "14px 'Patrick Hand', cursive";
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
-  ctx.fillStyle = isTurn ? color : "#888";
-  ctx.fillText(isTurn ? "TURN" : "", sectionW*1.5, canvas.height/2);
+  let statusText;
+  if (isTurn) {
+    statusText = "Your Turn";
+    ctx.fillStyle = color;
+  } else {
+    statusText = "Enemy Pilot's Turn";
+    ctx.fillStyle = "#888";
+  }
+  ctx.fillText(statusText, sectionW*1.5, canvas.height/2);
 
   // victories
   ctx.fillStyle = color;


### PR DESCRIPTION
## Summary
- always display 'Your Turn' or 'Enemy Pilot's Turn' in the player panel

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c9679fa10832da3291dce2455938b