### PR TITLE
Improve mobile spacing and aiming line; cancel weak drags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Basic rules
 
 - Each side controls a group of paper planes (green vs. blue).
-- Use the mouse to drag a plane, aim and release to launch it.
+- Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
 - Controls let you tune the flight range, place buildings as obstacles and adjust aiming amplitude.
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.

--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
   <!-- Bottom Scoreboard (Initially Hidden) -->
   <canvas id="scoreCanvasBottom" width="300" height="60" style="display:none;"></canvas>
 
+  <!-- Overlay canvas for aiming line -->
+  <canvas id="aimCanvas" style="display:none;"></canvas>
+
   <!-- Game Mode Selection Menu -->
   <div id="modeMenu">
     <h1 class="game-title">Paper Wings!</h1>

--- a/script.js
+++ b/script.js
@@ -14,6 +14,9 @@ const scoreCtxBottom    = scoreCanvasBottom.getContext("2d");
 const gameCanvas  = document.getElementById("gameCanvas");
 const gameCtx     = gameCanvas.getContext("2d");
 
+const aimCanvas   = document.getElementById("aimCanvas");
+const aimCtx      = aimCanvas.getContext("2d");
+
 const modeMenuDiv = document.getElementById("modeMenu");
 const hotSeatBtn  = document.getElementById("hotSeatBtn");
 const computerBtn = document.getElementById("computerBtn");
@@ -170,6 +173,7 @@ function resetGame(){
   scoreCanvas.style.display = "none";
   gameCanvas.style.display = "none";
   scoreCanvasBottom.style.display = "none";
+  aimCanvas.style.display = "none";
 
   // Остановить основной цикл
   stopGameLoop();
@@ -235,6 +239,7 @@ playBtn.addEventListener("click",()=>{
   scoreCanvas.style.display = "block";
   gameCanvas.style.display = "block";
   scoreCanvasBottom.style.display = "block";
+  aimCanvas.style.display = "block";
 
   stopMenuAnimation();
   startGameLoop();
@@ -348,6 +353,11 @@ function onHandleUp(){
   let dy= handleCircle.shakyY - plane.y;
 
   let dragDistance = Math.hypot(dx, dy);
+  // Cancel the move if released before the first tick mark
+  if(dragDistance < CELL_SIZE){
+    cleanupHandle();
+    return;
+  }
   if(dragDistance > MAX_DRAG_DISTANCE){
     dx *= MAX_DRAG_DISTANCE/dragDistance;
     dy *= MAX_DRAG_DISTANCE/dragDistance;
@@ -647,6 +657,7 @@ function gameDraw(){
   // фон
   gameCtx.clearRect(0,0, gameCanvas.width, gameCanvas.height);
   drawNotebookBackground(gameCtx, gameCanvas.width, gameCanvas.height);
+  aimCtx.clearRect(0,0, aimCanvas.width, aimCanvas.height);
 
   // Планирование хода ИИ
   if (!isGameOver 
@@ -751,16 +762,23 @@ function gameDraw(){
       vdist = MAX_DRAG_DISTANCE;
     }
 
-    // линия натяжки
-    gameCtx.beginPath();
-    gameCtx.strokeStyle="black";
-    gameCtx.lineWidth=2;
-    gameCtx.moveTo(plane.x, plane.y);
-    gameCtx.lineTo(plane.x + vdx, plane.y + vdy);
-    gameCtx.stroke();
+    const rect = gameCanvas.getBoundingClientRect();
+    const scaleX = rect.width / gameCanvas.width;
+    const scaleY = rect.height / gameCanvas.height;
+    const startX = rect.left + plane.x * scaleX;
+    const startY = rect.top  + plane.y * scaleY;
+    const endX   = rect.left + (plane.x + vdx) * scaleX;
+    const endY   = rect.top  + (plane.y + vdy) * scaleY;
+
+    aimCtx.beginPath();
+    aimCtx.strokeStyle = "black";
+    aimCtx.lineWidth = 2;
+    aimCtx.moveTo(startX, startY);
+    aimCtx.lineTo(endX, endY);
+    aimCtx.stroke();
 
     // треугольник-рукоятка
-    drawHandleTriangle(gameCtx, plane.x + vdx, plane.y + vdy, vdx, vdy);
+    drawHandleTriangle(aimCtx, endX, endY, endX - startX, endY - startY);
 
     // деления на линии натяжки (до 5)
     const dragAngle = Math.atan2(vdy, vdx);
@@ -772,17 +790,22 @@ function gameDraw(){
       const posX = plane.x + d*Math.cos(dragAngle);
       const posY = plane.y + d*Math.sin(dragAngle);
       const halfTick = (CELL_SIZE/2)/2;
-      const startX = posX - halfTick*Math.cos(tickAngle);
-      const startY = posY - halfTick*Math.sin(tickAngle);
-      const endX   = posX + halfTick*Math.cos(tickAngle);
-      const endY   = posY + halfTick*Math.sin(tickAngle);
+      const startGX = posX - halfTick*Math.cos(tickAngle);
+      const startGY = posY - halfTick*Math.sin(tickAngle);
+      const endGX   = posX + halfTick*Math.cos(tickAngle);
+      const endGY   = posY + halfTick*Math.sin(tickAngle);
 
-      gameCtx.beginPath();
-      gameCtx.strokeStyle="black";
-      gameCtx.lineWidth=2;
-      gameCtx.moveTo(startX, startY);
-      gameCtx.lineTo(endX, endY);
-      gameCtx.stroke();
+      const startSX = rect.left + startGX * scaleX;
+      const startSY = rect.top  + startGY * scaleY;
+      const endSX   = rect.left + endGX   * scaleX;
+      const endSY   = rect.top  + endGY   * scaleY;
+
+      aimCtx.beginPath();
+      aimCtx.strokeStyle="black";
+      aimCtx.lineWidth=2;
+      aimCtx.moveTo(startSX, startSY);
+      aimCtx.lineTo(endSX, endSY);
+      aimCtx.stroke();
     }
   }
 
@@ -1314,11 +1337,16 @@ function resizeCanvas() {
   
   canvas.style.width = maxWidth + 'px';
   canvas.style.height = maxHeight + 'px';
-  
+
   // Масштабируем canvas пропорционально
   const scale = Math.min(maxWidth / 300, maxHeight / 400);
   canvas.width = 300 * scale;
   canvas.height = 400 * scale;
+
+  aimCanvas.style.width = window.innerWidth + 'px';
+  aimCanvas.style.height = window.innerHeight + 'px';
+  aimCanvas.width = window.innerWidth;
+  aimCanvas.height = window.innerHeight;
   
   // Переинициализируем самолёты
   if(points.length === 0) {

--- a/styles.css
+++ b/styles.css
@@ -16,7 +16,7 @@ body {
   background-color: #fff0f0;
   margin: 0;
   padding: 0;
-  height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   touch-action: none;
 }
@@ -41,8 +41,8 @@ body {
   background-color: #fffbea;
   width: 95vw;
   max-width: 350px;
-  height: calc(100vh - 120px);
-  max-height: 70vh;
+  height: calc(100dvh - 140px);
+  max-height: calc(100dvh - 140px);
   display: block;
 }
 
@@ -56,6 +56,17 @@ body {
   height: 60px;
   display: block;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Overlay canvas for aiming line */
+#aimCanvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100dvh;
+  pointer-events: none;
+  z-index: 10;
 }
 
 /* Меню выбора режима */


### PR DESCRIPTION
## Summary
- adjust body and game canvas heights to fill dynamic viewport
- ensure top and bottom scoreboards have equal spacing on mobile
- draw aiming line on full-screen overlay so it remains visible beyond the game field
- ignore drags shorter than first tick so players can cancel and reselect planes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_689cb867e07c832dac6d54b3cf68da45