### PR TITLE
fix: show single AA toggle in building controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,45 +84,16 @@
           <div class="control-label">Buildings</div>
           <div id="buildingsCountDisplay" class="control-value">
             <span id="buildingsCountValue">0</span>
-
-            <label><input type="checkbox" id="addAAToggle" /> Add AA</label>
-
-
-            <label><input type="checkbox" id="addAAToggle" /> Add AA</label>
-
-
-            <label><input type="checkbox" id="addAAToggle" /> Add AA</label>
-
-
             <div class="aa-toggle">
               <label><input type="checkbox" id="addAAToggle" /> Add AA</label>
             </div>
-
-
-
-
           </div>
           <div class="control-buttons">
             <button id="buildingsMinus" class="control-btn">−</button>
             <button id="buildingsPlus" class="control-btn">+</button>
           </div>
-
-
-
         </div>
-
-        <!-- Add AA Toggle -->
-        <div class="control-box">
-          <div class="control-label">Add AA</div>
-          <div class="control-value">
-            <input type="checkbox" id="addAAToggle" />
-          </div>
-
-
-
-
-        </div>
-      </div> <!-- /control-group-row -->
+        </div> <!-- /control-group-row -->
     </div> <!-- /modeMenu -->
 
   <!-- End Game Window -->


### PR DESCRIPTION
## Summary
- remove duplicate AA checkboxes from start screen
- keep single Add AA toggle within Buildings control

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d74f915cc832dacc441e5f06ab770