### PR TITLE
Fix menu controls after update

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,20 +80,6 @@
       </div>
 
 
-      <!-- Buildings Control -->
-      <div class="control-box" id="buildingsControl">
-        <div class="control-label">Buildings</div>
-        <div id="buildingsCountDisplay" class="control-value">
-          <span id="buildingsCountValue">0</span>
-        </div>
-        <div class="control-buttons">
-          <button id="buildingsMinus" class="control-btn">−</button>
-          <button id="buildingsPlus" class="control-btn">+</button>
-        </div>
-      </div>
-    </div> <!-- /control-group-row -->
-  </div> <!-- /modeMenu -->
-
         <!-- Buildings Control -->
         <div class="control-box" id="buildingsControl">
           <div class="control-label">Buildings</div>
@@ -108,7 +94,7 @@
             <button id="buildingsPlus" class="control-btn">+</button>
           </div>
         </div>
-        </div> <!-- /control-group-row -->
+      </div> <!-- /control-group-row -->
     </div> <!-- /modeMenu -->
 
 

--- a/script.js
+++ b/script.js
@@ -30,6 +30,7 @@ const buildingsMinusBtn   = document.getElementById("buildingsMinus");
 const buildingsPlusBtn    = document.getElementById("buildingsPlus");
 const amplitudeMinusBtn   = document.getElementById("amplitudeMinus");
 const amplitudePlusBtn    = document.getElementById("amplitudePlus");
+const addAAToggle         = document.getElementById("addAAToggle");
 
 const endGameDiv  = document.getElementById("endGameButtons");
 const yesBtn      = document.getElementById("yesButton");
@@ -171,11 +172,14 @@ function resetGame(){
   flyingPoints= [];
   buildings = [];
   buildingsCount = 0;
+  aaUnits = [];
 
   hasShotThisRound = false;
 
   selectedMode = null;
   gameMode = null;
+  phase = 'MENU';
+  currentPlacer = null;
 
   // UI reset
   hotSeatBtn.classList.remove("selected");
@@ -271,6 +275,12 @@ playBtn.addEventListener("click",()=>{
   aimCanvas.style.display = "block";
 
   stopMenuAnimation();
+  if (settings.addAA) {
+    phase = 'AA_PLACEMENT';
+    currentPlacer = 'green';
+  } else {
+    phase = 'TURN';
+  }
   startGameLoop();
 });
 
@@ -809,9 +819,9 @@ function handleAAForPlane(p, fp){
       }
     }
   }
-  return false;
+    return false;
+  }
 }
-
 
 /* ======= GAME LOOP ======= */
 function gameDraw(){
@@ -1457,6 +1467,7 @@ function startNewRound(){
   globalFrame=0;
   flyingPoints=[];
   hasShotThisRound=false;
+  aaUnits = [];
 
   aiMoveScheduled = false;
 
@@ -1476,7 +1487,12 @@ function startNewRound(){
 
   initPoints(); // ориентации на базе
   renderScoreboard();
-
+  if (settings.addAA) {
+    phase = 'AA_PLACEMENT';
+    currentPlacer = 'green';
+  } else {
+    phase = 'TURN';
+  }
   if(animationFrameId===null) startGameLoop();
 }
 


### PR DESCRIPTION
## Summary
- Reset AA state and menu phase when returning to menu
- Enter AA placement phase when starting a match or new round if the Add AA toggle is enabled

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689d9bf2c2ec832dbdc9cce2f0ad4f43