### PR TITLE
Use English for AA placement messages

### DIFF
--- a/script.js
+++ b/script.js
@@ -1223,10 +1223,10 @@ function drawPlayerPanel(ctx, color, victories, isTurn){
   let statusText;
   if (phase === 'AA_PLACEMENT') {
     if (currentPlacer === color) {
-      statusText = color === 'green' ? 'Грин устанавливает ПВО' : 'Блю устанавливает ПВО';
+      statusText = 'You are placing AA';
       ctx.fillStyle = color;
     } else {
-      statusText = 'Противник устанавливает ПВО';
+      statusText = 'Enemy is placing AA';
       ctx.fillStyle = '#888';
     }
   } else if (isTurn) {


### PR DESCRIPTION
## Summary
- show English status messages during AA placement phases

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689db3bd7ea8832d8880030945fa6832