### PR TITLE
Adjust flight range defaults and limits

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
 
             </div>
           </div>
-          <div class="control-value"><span id="flightRangeDisplay">10 cells</span></div>
+          <div class="control-value"><span id="flightRangeDisplay">15 cells</span></div>
           <div class="control-buttons">
             <button id="flightRangeMinus" class="control-btn">−</button>
             <button id="flightRangePlus" class="control-btn">+</button>

--- a/script.js
+++ b/script.js
@@ -60,8 +60,8 @@ const BUILDING_BUFFER      = CELL_SIZE / 2;
 const MAX_BUILDINGS_GLOBAL = 100;
 const PLANES_PER_SIDE      = 4;      // количество самолётов у каждой команды
 
-const MIN_FLIGHT_RANGE_CELLS = 1;
-const MAX_FLIGHT_RANGE_CELLS = 25;
+const MIN_FLIGHT_RANGE_CELLS = 5;
+const MAX_FLIGHT_RANGE_CELLS = 30;
 
 const MIN_AMPLITUDE        = 0;
 const MAX_AMPLITUDE        = 30;     // UI показывает как *2°
@@ -82,7 +82,7 @@ const AA_MIN_DIST_FROM_EDGES = 40;
 
 
 /* ======= STATE ======= */
-let flightRangeCells = 10;     // значение «в клетках» для меню/физики
+let flightRangeCells = 15;     // значение «в клетках» для меню/физики
 let buildingsCount   = 0;
 let aimingAmplitude  = 10;     // 0..30 (UI показывает *2)
 


### PR DESCRIPTION
## Summary
- set minimum flight range to 5 cells and maximum to 30 cells
- default flight range now 15 cells and display updated accordingly

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_689e4331a458832d89faa10330558faa