### PR TITLE
Prevent turn switching when AA destroys a plane

### DIFF
--- a/script.js
+++ b/script.js
@@ -842,12 +842,6 @@ function handleAAForPlane(p, fp){
             p.collisionX=p.x; p.collisionY=p.y;
             if(fp) flyingPoints = flyingPoints.filter(x=>x!==fp);
             checkVictory();
-            if(!isGameOver && !flyingPoints.some(x=>x.plane.color===p.color)){
-              turnIndex = (turnIndex + 1) % turnColors.length;
-              if(gameMode === "computer" && turnColors[turnIndex] === "blue"){
-                aiMoveScheduled = false;
-              }
-            }
             return true;
           }
         }


### PR DESCRIPTION
## Summary
- Ensure anti-aircraft kills no longer change the active player's turn

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e4e34a2d8832dac061af08a848700