### PR TITLE
Fix duplicate flightRangeCells declaration breaking UI

### DIFF
--- a/script.js
+++ b/script.js
@@ -85,10 +85,8 @@ const AA_MIN_DIST_FROM_EDGES = 40;
 
 /* ======= STATE ======= */
 
-let flightRangeCells = 10;     // значение «в клетках» для меню/физики
 const MAPS = ["clear sky"];
 let mapIndex = 0;
-
 
 let flightRangeCells = 15;     // значение «в клетках» для меню/физики
 let buildingsCount   = 0;


### PR DESCRIPTION
## Summary
- remove duplicate `flightRangeCells` declaration causing script parsing failure
- keep single initialization and reorganize state block

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689edda575c8832da7720b4689d70513