### PR TITLE
Fix duplicated map constants causing game not to start

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,14 +92,6 @@ const MAPS = ["clear sky", "wall"];
 let mapIndex = 0;
 
 
-
-const MAPS = ["clear sky", "wall"];
-
-const MAPS = ["clear sky"];
-
-let mapIndex = 0;
-
-
 let flightRangeCells = 15;     // значение «в клетках» для меню/физики
 let buildingsCount   = 0;
 


### PR DESCRIPTION
## Summary
- Clean up duplicate `MAPS` and `mapIndex` declarations
- Ensure wall map mode initializes without crashing

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_689ef3584548832da17284ffe7379313