### PR TITLE
Use red-white hazard tape for burning edges map

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - Each side controls a group of paper planes (green vs. blue).
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
 - Controls let you tune the flight range, choose the map ("clear sky", "wall" or "burning edges") and adjust aiming amplitude.
+- In the "burning edges" map the field border is marked with red and white tape that destroys planes on contact.
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.
 

--- a/script.js
+++ b/script.js
@@ -1133,104 +1133,33 @@ function drawNotebookBackground(ctx2d, w, h){
   ctx2d.setLineDash([]);
 
   if (MAPS[mapIndex] === "burning edges") {
-    drawBurntEdges(ctx2d, w, h);
+    drawHazardTapeEdges(ctx2d, w, h);
   }
 }
 
-function drawBurntEdges(ctx2d, w, h){
-  const edge = 20;
+function drawHazardTapeEdges(ctx2d, w, h){
+  const edge = 12;
   ctx2d.save();
-  let grad;
 
-  grad = ctx2d.createLinearGradient(0,0,0,edge);
-  grad.addColorStop(0,"rgba(0,0,0,0.7)");
-  grad.addColorStop(1,"rgba(0,0,0,0)");
-  ctx2d.fillStyle = grad;
-  ctx2d.fillRect(0,0,w,edge);
-
-  grad = ctx2d.createLinearGradient(0,h-edge,0,h);
-  grad.addColorStop(0,"rgba(0,0,0,0)");
-  grad.addColorStop(1,"rgba(0,0,0,0.7)");
-  ctx2d.fillStyle = grad;
-  ctx2d.fillRect(0,h-edge,w,edge);
-
-  grad = ctx2d.createLinearGradient(0,0,edge,0);
-  grad.addColorStop(0,"rgba(0,0,0,0.7)");
-  grad.addColorStop(1,"rgba(0,0,0,0)");
-  ctx2d.fillStyle = grad;
-  ctx2d.fillRect(0,0,edge,h);
-
-  grad = ctx2d.createLinearGradient(w-edge,0,w,0);
-  grad.addColorStop(0,"rgba(0,0,0,0)");
-  grad.addColorStop(1,"rgba(0,0,0,0.7)");
-  ctx2d.fillStyle = grad;
-  ctx2d.fillRect(w-edge,0,edge,h);
-
-  const glow = 10;
-  grad = ctx2d.createLinearGradient(0,0,0,glow);
-  grad.addColorStop(0,"rgba(255,180,0,0.4)");
-  grad.addColorStop(1,"rgba(255,180,0,0)");
-  ctx2d.fillStyle = grad;
-  ctx2d.fillRect(0,0,w,glow);
-
-  grad = ctx2d.createLinearGradient(0,h-glow,0,h);
-  grad.addColorStop(0,"rgba(255,180,0,0)");
-  grad.addColorStop(1,"rgba(255,180,0,0.4)");
-  ctx2d.fillStyle = grad;
-  ctx2d.fillRect(0,h-glow,w,glow);
-
-  grad = ctx2d.createLinearGradient(0,0,glow,0);
-  grad.addColorStop(0,"rgba(255,180,0,0.4)");
-  grad.addColorStop(1,"rgba(255,180,0,0)");
-  ctx2d.fillStyle = grad;
-  ctx2d.fillRect(0,0,glow,h);
-
-  grad = ctx2d.createLinearGradient(w-glow,0,w,0);
-  grad.addColorStop(0,"rgba(255,180,0,0)");
-  grad.addColorStop(1,"rgba(255,180,0,0.4)");
-  ctx2d.fillStyle = grad;
-  ctx2d.fillRect(w-glow,0,glow,h);
-
-  const step = 20;
-  ctx2d.shadowColor = "rgba(255,80,0,0.8)";
-  ctx2d.shadowBlur = 15;
-  ctx2d.fillStyle = "#ff4500";
-
-  for(let x=0; x<w; x+=step){
-    const fh = 12 + Math.random()*8;
-    ctx2d.beginPath();
-    ctx2d.moveTo(x,0);
-    ctx2d.lineTo(x+step,0);
-    ctx2d.lineTo(x+step/2,fh);
-    ctx2d.closePath();
-    ctx2d.fill();
-
-    ctx2d.beginPath();
-    ctx2d.moveTo(x,h);
-    ctx2d.lineTo(x+step,h);
-    ctx2d.lineTo(x+step/2,h-fh);
-    ctx2d.closePath();
-    ctx2d.fill();
+  // create diagonal red-white hazard tape pattern
+  const patternCanvas = document.createElement('canvas');
+  patternCanvas.width = patternCanvas.height = 40;
+  const pctx = patternCanvas.getContext('2d');
+  pctx.fillStyle = '#fff';
+  pctx.fillRect(0, 0, 40, 40);
+  pctx.translate(20, 20);
+  pctx.rotate(-Math.PI / 4);
+  pctx.fillStyle = '#d00';
+  for(let i = -40; i <= 40; i += 20){
+    pctx.fillRect(i, -40, 10, 80);
   }
+  const pattern = ctx2d.createPattern(patternCanvas, 'repeat');
 
-  for(let y=0; y<h; y+=step){
-    const fw = 12 + Math.random()*8;
-    ctx2d.beginPath();
-    ctx2d.moveTo(0,y);
-    ctx2d.lineTo(0,y+step);
-    ctx2d.lineTo(fw,y+step/2);
-    ctx2d.closePath();
-    ctx2d.fill();
-
-    ctx2d.beginPath();
-    ctx2d.moveTo(w,y);
-    ctx2d.lineTo(w,y+step);
-    ctx2d.lineTo(w-fw,y+step/2);
-    ctx2d.closePath();
-    ctx2d.fill();
-  }
-
-  ctx2d.shadowBlur = 0;
+  ctx2d.fillStyle = pattern;
+  ctx2d.fillRect(0, 0, w, edge);         // top
+  ctx2d.fillRect(0, h - edge, w, edge);  // bottom
+  ctx2d.fillRect(0, 0, edge, h);         // left
+  ctx2d.fillRect(w - edge, 0, edge, h);  // right
 
   ctx2d.restore();
 }


### PR DESCRIPTION
## Summary
- Replace burning edge flame effect with red and white hazard tape
- Document new "burning edges" border behaviour in README
- Improve tape look with crisp diagonal stripes and narrower border

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f09e7d624832da38d0e71940cef60