### PR TITLE
Add fading radar trail and wall occlusion to Anti-Aircraft sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - Each side controls a group of paper planes (green vs. blue).
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
 - Controls let you tune the flight range, choose the map ("clear sky", "wall" or "burning edges") and adjust aiming amplitude.
+- In the "burning edges" map the field border is lined with cold steel spikes that destroy planes on contact.
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.
 

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
           <div id="mapNameDisplay" class="control-value">
             <span id="mapNameValue">clear sky</span>
             <div class="aa-toggle">
-              <label><input type="checkbox" id="addAAToggle" /> Add AA</label>
+              <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
             </div>
           </div>
           <div class="control-buttons">


### PR DESCRIPTION
## Summary
- Extend Anti-Aircraft sweep afterglow to 1s and render current beam separately so the arrow leaves a visible radar-style trail
- Mark the "burning edges" map with inward-facing steel spikes instead of hazard tape
- Stop Anti-Aircraft beams at buildings so they no longer damage planes through walls

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f09e7d624832da38d0e71940cef60