### PR TITLE
Add fading radar trail and wall occlusion to AA sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - Each side controls a group of paper planes (green vs. blue).
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
 - Controls let you tune the flight range, choose the map ("clear sky", "wall" or "burning edges") and adjust aiming amplitude.
+- In the "burning edges" map the field border is marked with red-and-white hazard tape that destroys planes on contact.
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.
 


### PR DESCRIPTION
## Summary
- Extend AA sweep afterglow to 1s and render current beam separately so the arrow leaves a visible radar-style trail
- Mark the "burning edges" map with red-and-white hazard tape instead of steel spikes
- Stop AA beams at buildings so they no longer damage planes through walls
- Restore "Add AA" wording in menu and placement prompts

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f09e7d624832da38d0e71940cef60