### PR TITLE
fix: remove duplicate AA_TRAIL_MS constant

### DIFF
--- a/script.js
+++ b/script.js
@@ -81,9 +81,8 @@ const AA_DEFAULTS = {
 };
 const AA_MIN_DIST_FROM_OPPONENT_BASE = 120;
 const AA_MIN_DIST_FROM_EDGES = 40;
-const AA_TRAIL_MS = 1000; // radar sweep afterglow duration
-
-
+// Duration for how long the anti-aircraft radar sweep remains visible
+// Reduced to keep the trail effect brief and responsive.
 const AA_TRAIL_MS = 600; // radar sweep afterglow duration
 
 
@@ -1195,8 +1194,6 @@ function drawNotebookBackground(ctx2d, w, h){
 }
 
 function drawHazardTapeEdges(ctx2d, w, h){
-
-=======
   const edge = 12;
   ctx2d.save();
 


### PR DESCRIPTION
## Summary
- remove duplicate AA_TRAIL_MS definition and clarify comment
- drop leftover merge artifact from hazard tape renderer

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68a04f9f5490832dacb4fc6fbfbc0a46