### PR TITLE
Set wall map as default

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
         <div class="control-box" id="mapControl">
           <div class="control-label">Map</div>
           <div id="mapNameDisplay" class="control-value">
-            <span id="mapNameValue">clear sky</span>
+            <span id="mapNameValue">wall</span>
             <div class="aa-toggle">
               <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
             </div>

--- a/script.js
+++ b/script.js
@@ -93,7 +93,7 @@ const AA_TRAIL_MS = 600; // radar sweep afterglow duration
 
 
 const MAPS = ["clear sky", "wall", "burning edges"];
-let mapIndex = 0;
+let mapIndex = 1;
 
 
 let flightRangeCells = 15;     // значение «в клетках» для меню/физики
@@ -193,7 +193,7 @@ function resetGame(){
   globalFrame=0;
   flyingPoints= [];
   buildings = [];
-  mapIndex = 0;
+  mapIndex = 1;
   applyCurrentMap();
   aaUnits = [];
 


### PR DESCRIPTION
## Summary
- Make "wall" the default map for new games and resets
- Update initial map label in the menu to show "wall"

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a055b360f4832d8f946765dbf3460e