### PR TITLE
Make amplitude indicator line red

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -367,7 +367,7 @@ body {
   max-height: 100%;
 }
 .line3 {
-  position: absolute; width: 80px; height: 3px; background-color: #6c757d;
+  position: absolute; width: 80px; height: 3px; background-color: #ff0000;
   top: 50%; left: 10px; transform-origin: 0 50%; border-radius: 2px;
 }
 #amplitudeAngleDisplay {


### PR DESCRIPTION
## Summary
- change amplitude indicator line color to red

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a06459ce0c832da48a6d2a9bbf4da7