### PR TITLE
Color aiming line red

### DIFF
--- a/script.js
+++ b/script.js
@@ -1126,7 +1126,7 @@ function handleAAForPlane(p, fp){
     const endY   = rect.top  + (plane.y + vdy) * scaleY;
 
     aimCtx.beginPath();
-    aimCtx.strokeStyle = "black";
+    aimCtx.strokeStyle = "red";
     aimCtx.lineWidth = 2;
     aimCtx.moveTo(startX, startY);
     aimCtx.lineTo(endX, endY);
@@ -1156,7 +1156,7 @@ function handleAAForPlane(p, fp){
       const endSY   = rect.top  + endGY   * scaleY;
 
       aimCtx.beginPath();
-      aimCtx.strokeStyle="black";
+      aimCtx.strokeStyle="red";
       aimCtx.lineWidth=2;
       aimCtx.moveTo(startSX, startSY);
       aimCtx.lineTo(endSX, endSY);

--- a/styles.css
+++ b/styles.css
@@ -367,7 +367,7 @@ body {
   max-height: 100%;
 }
 .line3 {
-  position: absolute; width: 80px; height: 3px; background-color: #6c757d;
+  position: absolute; width: 80px; height: 3px; background-color: #ff0000;
   top: 50%; left: 10px; transform-origin: 0 50%; border-radius: 2px;
 }
 #amplitudeAngleDisplay {


### PR DESCRIPTION
## Summary
- Use a red stroke for the aiming guideline and its tick marks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a06459ce0c832da48a6d2a9bbf4da7