### PR TITLE
Red AA sweep core, black aiming line

### DIFF
--- a/script.js
+++ b/script.js
@@ -1358,8 +1358,8 @@ function drawAAUnits(){
     gameCtx.lineTo(endX, endY);
     gameCtx.stroke();
 
-    // white highlight on sweep line
-    gameCtx.strokeStyle = "white";
+    // inner red highlight on sweep line
+    gameCtx.strokeStyle = "red";
     gameCtx.lineWidth = 1;
     gameCtx.beginPath();
     gameCtx.moveTo(aa.x, aa.y);


### PR DESCRIPTION
## Summary
- Restore black stroke for the aiming guide and its tick marks
- Color the anti-aircraft sweep line's inner core red
- Revert amplitude indicator bar to original gray

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a06459ce0c832da48a6d2a9bbf4da7