### PR TITLE
Soften radar sweep trail and clean center marker

### DIFF
--- a/script.js
+++ b/script.js
@@ -1384,16 +1384,27 @@ function drawAAUnits(){
     for(const seg of aa.trail){
       const age = now - seg.time;
       const alpha = 1 - age/AA_TRAIL_MS;
-      gameCtx.globalAlpha = alpha;
-      gameCtx.strokeStyle = aa.owner;
-      gameCtx.lineWidth = 2;
       const trailAng = seg.angleDeg * Math.PI/180;
-      const trailEndX = aa.x + Math.cos(trailAng) * aa.radius;
-      const trailEndY = aa.y + Math.sin(trailAng) * aa.radius;
+
+      gameCtx.save();
+      gameCtx.translate(aa.x, aa.y);
+      gameCtx.rotate(trailAng);
+
+      // wider beam with gradient from owner colour to transparent
+      const width = 8;
+      const grad = gameCtx.createLinearGradient(0, -width/2, 0, width/2);
+      grad.addColorStop(0, "rgba(0,0,0,0)");
+      grad.addColorStop(0.5, aa.owner);
+      grad.addColorStop(1, "rgba(0,0,0,0)");
+
+      gameCtx.globalAlpha = alpha;
+      gameCtx.strokeStyle = grad;
+      gameCtx.lineWidth = width;
       gameCtx.beginPath();
-      gameCtx.moveTo(aa.x, aa.y);
-      gameCtx.lineTo(trailEndX, trailEndY);
+      gameCtx.moveTo(0, 0);
+      gameCtx.lineTo(aa.radius, 0);
       gameCtx.stroke();
+      gameCtx.restore();
     }
 
     gameCtx.globalAlpha = 1;
@@ -1429,12 +1440,6 @@ function drawAAUnits(){
     gameCtx.beginPath();
     gameCtx.fillStyle = "white";
     gameCtx.arc(aa.x, aa.y, 4, 0, Math.PI*2);
-    gameCtx.fill();
-
-    // colored center dot matching owner color
-    gameCtx.beginPath();
-    gameCtx.fillStyle = aa.owner;
-    gameCtx.arc(aa.x, aa.y, 1.5, 0, Math.PI*2);
     gameCtx.fill();
 
     gameCtx.restore();


### PR DESCRIPTION
## Summary
- Widen radar sweep trail and render it with a gradient fading to transparency
- Remove coloured center dot from radar base for a cleaner look

## Testing
- `node --check script.js`
- `python -m py_compile color_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0ac55ba8c832da8ef436f581f7aed