### PR TITLE
Add fading trail to amplitude indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,13 @@
           <div class="control-label">Aiming Amplitude</div>
           <div id="amplitudeIndicator" class="control-visual">
             <svg class="line3" viewBox="0 0 80 80">
+              <defs>
+                <linearGradient id="amplitudeTrail" x1="0%" y1="100%" x2="100%" y2="0%">
+                  <stop offset="0%" style="stop-color:var(--arrow-color);stop-opacity:1" />
+                  <stop offset="75%" style="stop-color:var(--arrow-color);stop-opacity:1" />
+                  <stop offset="100%" style="stop-color:var(--arrow-color);stop-opacity:0" />
+                </linearGradient>
+              </defs>
               <path d="M0 80 A80 80 0 0 1 80 0" />
             </svg>
           </div>

--- a/script.js
+++ b/script.js
@@ -1904,7 +1904,7 @@ async function pollLineColor() {
     const color = data.color;
     const line = document.querySelector('#amplitudeIndicator .line3 path');
     if (line && color) {
-      line.style.stroke = color;
+      line.style.setProperty('--arrow-color', color);
     }
   } catch (err) {
     // ignore fetch errors

--- a/styles.css
+++ b/styles.css
@@ -377,9 +377,10 @@ body {
 
 #amplitudeIndicator .line3 path {
   fill: none;
-  stroke: #666666;
+  stroke: url(#amplitudeTrail);
   stroke-width: 3px;
   stroke-linecap: round;
+  --arrow-color: #666666;
 }
 #amplitudeAngleDisplay {
   font-size: 22px;


### PR DESCRIPTION
## Summary
- Add gradient definition to amplitude indicator SVG and use it for line stroke
- Allow dynamic color updates via CSS variable for arrow trail

## Testing
- `node --check script.js`
- `python -m py_compile color_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0b23e00b8832dbc82d32172199fd7