### PR TITLE
Restore straight aiming amplitude indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,16 +69,7 @@
         <div class="control-box">
           <div class="control-label">Aiming Amplitude</div>
           <div id="amplitudeIndicator" class="control-visual">
-            <svg class="line3" viewBox="0 0 80 80">
-              <defs>
-                <linearGradient id="amplitudeTrail" x1="0%" y1="100%" x2="100%" y2="0%">
-                  <stop offset="0%" style="stop-color:var(--arrow-color);stop-opacity:1" />
-                  <stop offset="75%" style="stop-color:var(--arrow-color);stop-opacity:1" />
-                  <stop offset="100%" style="stop-color:var(--arrow-color);stop-opacity:0" />
-                </linearGradient>
-              </defs>
-              <path d="M0 80 A80 80 0 0 1 80 0" />
-            </svg>
+            <div class="line3"></div>
           </div>
           <div class="control-value"><span id="amplitudeAngleDisplay">20°</span></div>
           <div class="control-buttons">

--- a/script.js
+++ b/script.js
@@ -1902,9 +1902,9 @@ async function pollLineColor() {
     const response = await fetch('config/color.json?cache=' + Date.now());
     const data = await response.json();
     const color = data.color;
-    const line = document.querySelector('#amplitudeIndicator .line3 path');
+    const line = document.querySelector('#amplitudeIndicator .line3');
     if (line && color) {
-      line.style.setProperty('--arrow-color', color);
+      line.style.backgroundColor = color;
     }
   } catch (err) {
     // ignore fetch errors

--- a/styles.css
+++ b/styles.css
@@ -369,18 +369,12 @@ body {
 #amplitudeIndicator .line3 {
   position: absolute;
   width: 80px;
-  height: 80px;
-  top: 10px;
+  height: 3px;
+  background-color: #6c757d;
+  top: 50%;
   left: 10px;
-  transform-origin: 0 100%;
-}
-
-#amplitudeIndicator .line3 path {
-  fill: none;
-  stroke: url(#amplitudeTrail);
-  stroke-width: 3px;
-  stroke-linecap: round;
-  --arrow-color: #666666;
+  transform-origin: 0 50%;
+  border-radius: 2px;
 }
 #amplitudeAngleDisplay {
   font-size: 22px;


### PR DESCRIPTION
## Summary
- Replace arc-based aiming amplitude indicator with classic straight line.
- Simplify CSS to style line segment and remove SVG gradient setup.
- Update script to color line segment dynamically.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ba70e4bc832da25c8bceb98e363f