### PR TITLE
Lighten and extend anti-aircraft radar trail

### DIFF
--- a/script.js
+++ b/script.js
@@ -83,7 +83,7 @@ const AA_MIN_DIST_FROM_OPPONENT_BASE = 120;
 const AA_MIN_DIST_FROM_EDGES = 40;
 // Duration for how long the anti-aircraft radar sweep remains visible
 // Quarter-circle afterglow so the sweep persists for 90° of rotation
-const AA_TRAIL_MS = 3000; // radar sweep afterglow duration
+const AA_TRAIL_MS = 5000; // radar sweep afterglow duration
 
 
 
@@ -518,10 +518,11 @@ function drawAAPreview(){
 
   for(const seg of aaPreviewTrail){
     const age = now - seg.time;
-    const alpha = (1 - age/AA_TRAIL_MS) * 0.5;
+    const alpha = (1 - age/AA_TRAIL_MS) * 0.15;
     gameCtx.globalAlpha = alpha;
     gameCtx.strokeStyle = currentPlacer;
     gameCtx.lineWidth = 2;
+    gameCtx.lineCap = "round";
     const trailAng = seg.angleDeg * Math.PI/180;
     const trailEndX = x + Math.cos(trailAng) * AA_DEFAULTS.radius;
     const trailEndY = y + Math.sin(trailAng) * AA_DEFAULTS.radius;
@@ -540,6 +541,7 @@ function drawAAPreview(){
   gameCtx.globalAlpha = 0.6;
   gameCtx.strokeStyle = currentPlacer;
   gameCtx.lineWidth = 2;
+  gameCtx.lineCap = "round";
   gameCtx.beginPath();
   gameCtx.moveTo(x, y);
   gameCtx.lineTo(endX, endY);
@@ -549,6 +551,7 @@ function drawAAPreview(){
   gameCtx.globalAlpha = 0.5;
   gameCtx.strokeStyle = "white";
   gameCtx.lineWidth = 1;
+  gameCtx.lineCap = "round";
   gameCtx.beginPath();
   gameCtx.moveTo(x, y);
   gameCtx.lineTo(endX, endY);
@@ -1383,7 +1386,7 @@ function drawAAUnits(){
     // draw fading trail
     for(const seg of aa.trail){
       const age = now - seg.time;
-      const alpha = (1 - age/AA_TRAIL_MS) * 0.5;
+      const alpha = (1 - age/AA_TRAIL_MS) * 0.15;
       const trailAng = seg.angleDeg * Math.PI/180;
 
       gameCtx.save();
@@ -1400,6 +1403,7 @@ function drawAAUnits(){
       gameCtx.globalAlpha = alpha;
       gameCtx.strokeStyle = grad;
       gameCtx.lineWidth = width;
+      gameCtx.lineCap = "round";
       gameCtx.beginPath();
       gameCtx.moveTo(0, 0);
       gameCtx.lineTo(aa.radius, 0);
@@ -1414,6 +1418,7 @@ function drawAAUnits(){
     const endY = aa.y + Math.sin(ang) * aa.radius;
     gameCtx.strokeStyle = aa.owner;
     gameCtx.lineWidth = 2;
+    gameCtx.lineCap = "round";
     gameCtx.beginPath();
     gameCtx.moveTo(aa.x, aa.y);
     gameCtx.lineTo(endX, endY);
@@ -1423,6 +1428,7 @@ function drawAAUnits(){
     gameCtx.globalAlpha = 0.5;
     gameCtx.strokeStyle = "white";
     gameCtx.lineWidth = 1;
+    gameCtx.lineCap = "round";
     gameCtx.beginPath();
     gameCtx.moveTo(aa.x, aa.y);
     gameCtx.lineTo(endX, endY);


### PR DESCRIPTION
## Summary
- Extend anti-aircraft sweep afterglow to 5 seconds
- Lighten radar trails and use round caps to remove stray arrow artifacts
- Further dim trail opacity for subtler afterglow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0def336f0832d94ea7a0e88b85cf5