### PR TITLE
Add two walls map option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 - Each side controls a group of paper planes (green vs. blue).
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
-- Controls let you tune the flight range, choose the map ("clear sky", "wall" or "burning edges") and adjust aiming amplitude.
+- Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls" or "burning edges") and adjust aiming amplitude.
 
 - In the "burning edges" map the field border is lined with deadly spikes that destroy planes on contact.
 

--- a/script.js
+++ b/script.js
@@ -92,7 +92,7 @@ const AA_TRAIL_MS = 5000; // radar sweep afterglow duration
 
 
 
-const MAPS = ["clear sky", "wall", "burning edges"];
+const MAPS = ["clear sky", "wall", "two walls", "burning edges"];
 let mapIndex = 1;
 
 
@@ -1826,6 +1826,26 @@ function applyCurrentMap(){
       type: "wall",
       x: gameCanvas.width / 2,
       y: gameCanvas.height / 2,
+      width: wallWidth,
+      height: wallHeight,
+      color: "darkred"
+    });
+  } else if (MAPS[mapIndex] === "two walls") {
+    const wallWidth = gameCanvas.width / 2;
+    const wallHeight = CELL_SIZE;
+    const offset = CELL_SIZE * 2;
+    buildings.push({
+      type: "wall",
+      x: wallWidth / 2,
+      y: gameCanvas.height / 2 + offset,
+      width: wallWidth,
+      height: wallHeight,
+      color: "darkred"
+    });
+    buildings.push({
+      type: "wall",
+      x: gameCanvas.width - wallWidth / 2,
+      y: gameCanvas.height / 2 - offset,
       width: wallWidth,
       height: wallHeight,
       color: "darkred"


### PR DESCRIPTION
## Summary
- add new "two walls" map with horizontally aligned walls on opposing sides
- document new map option in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ec3aab30832d9afbc13cb2b41f1b