### PR TITLE
Animate burning edges with turbine flames

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
 - Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls" or "burning edges") and adjust aiming amplitude.
 
-- In the "burning edges" map the field border is lined with deadly spikes that destroy planes on contact.
+- Standard maps show a single brick border that planes bounce off.
+- In the "burning edges" map the field border blazes with small flames that destroy planes on contact.
 
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.


### PR DESCRIPTION
## Summary
- Load the turbine indicator's SVG as an image for reuse
- Render animated flame segments along the "burning edges" map borders
- Draw a single-brick border on standard maps for clearer field edges

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1837b9a88832da86e5886bc70f9eb