### PR TITLE
Align two walls map obstacles with side edges

### DIFF
--- a/script.js
+++ b/script.js
@@ -1900,12 +1900,12 @@ function applyCurrentMap(){
       color: "darkred"
     });
   } else if (MAPS[mapIndex] === "two walls") {
-    const wallWidth = gameCanvas.width / 2 - CELL_SIZE;
+    const wallWidth = gameCanvas.width / 2;
     const wallHeight = CELL_SIZE;
     const offset = CELL_SIZE * 2;
     buildings.push({
       type: "wall",
-      x: CELL_SIZE + wallWidth / 2,
+      x: wallWidth / 2,
       y: gameCanvas.height / 2 + offset,
       width: wallWidth,
       height: wallHeight,
@@ -1913,7 +1913,7 @@ function applyCurrentMap(){
     });
     buildings.push({
       type: "wall",
-      x: gameCanvas.width - CELL_SIZE - wallWidth / 2,
+      x: gameCanvas.width - wallWidth / 2,
       y: gameCanvas.height / 2 - offset,
       width: wallWidth,
       height: wallHeight,


### PR DESCRIPTION
## Summary
- Extend each wall on the "two walls" map to reach the side edges of the playfield

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bf8c54a0832dbc50f7630a8f6451