### PR TITLE
Render map edges above walls

### DIFF
--- a/script.js
+++ b/script.js
@@ -1146,6 +1146,13 @@ function handleAAForPlane(p, fp){
   drawAAPlacementZone();
   drawBuildings();
 
+  // redraw field edges above walls
+  if (MAPS[mapIndex] === "burning edges") {
+    drawFlameEdges(gameCtx, gameCanvas.width, gameCanvas.height);
+  } else {
+    drawBrickEdges(gameCtx, gameCanvas.width, gameCanvas.height);
+  }
+
   // установки ПВО
   drawAAUnits();
   drawAAPreview();


### PR DESCRIPTION
## Summary
- Repaint field edges after building rendering so boundaries stay visible.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c3aa2678832d87f86d965eb135fc