### PR TITLE
Replace burning-edge needles with varied nails

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls" or "burning edges") and adjust aiming amplitude.
 
 
- - In the "burning edges" map the field border is lined with tightly packed sewing needles that destroy planes on contact.
+ - In the "burning edges" map the field border is lined with metallic nails — some shiny, others rusty or bent — that destroy planes on contact.
 
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.

--- a/script.js
+++ b/script.js
@@ -97,7 +97,7 @@ const AA_TRAIL_MS = 5000; // radar sweep afterglow duration
 const MAPS = ["clear sky", "wall", "two walls", "burning edges"];
 let mapIndex = 1;
 
-// Needle edge drawing for the "burning edges" map
+// Nail edge drawing for the "burning edges" map
 let flightRangeCells = 15;     // значение «в клетках» для меню/физики
 let buildingsCount   = 0;
 
@@ -1144,7 +1144,7 @@ function handleAAForPlane(p, fp){
 
   // redraw field edges above walls
     if (MAPS[mapIndex] === "burning edges") {
-      drawNeedleEdges(gameCtx, gameCanvas.width, gameCanvas.height);
+      drawNailEdges(gameCtx, gameCanvas.width, gameCanvas.height);
   } else {
     drawBrickEdges(gameCtx, gameCanvas.width, gameCanvas.height);
   }
@@ -1276,22 +1276,21 @@ function drawNotebookBackground(ctx2d, w, h){
   ctx2d.setLineDash([]);
 
     if (MAPS[mapIndex] === "burning edges") {
-      drawNeedleEdges(ctx2d, w, h);
+      drawNailEdges(ctx2d, w, h);
   } else {
     drawBrickEdges(ctx2d, w, h);
   }
 }
 
-function drawNeedleEdges(ctx2d, w, h){
-  const spacing = 4;
-  const length = 12;
+function drawNailEdges(ctx2d, w, h){
+  const spacing = 6;
   for(let x=0; x<=w; x+=spacing){
-    drawNeedle(ctx2d, x, 0, length, Math.PI/2);
-    drawNeedle(ctx2d, x, h, length, -Math.PI/2);
+    drawNail(ctx2d, x, 0, 10 + Math.random()*6, Math.PI/2);
+    drawNail(ctx2d, x, h, 10 + Math.random()*6, -Math.PI/2);
   }
   for(let y=0; y<=h; y+=spacing){
-    drawNeedle(ctx2d, 0, y, length, 0);
-    drawNeedle(ctx2d, w, y, length, Math.PI);
+    drawNail(ctx2d, 0, y, 10 + Math.random()*6, 0);
+    drawNail(ctx2d, w, y, 10 + Math.random()*6, Math.PI);
   }
 }
 
@@ -1320,28 +1319,37 @@ function drawBrickEdges(ctx2d, w, h){
   }
 }
 
-function drawNeedle(ctx2d, x, y, length, rotation){
+function drawNail(ctx2d, x, y, length, rotation){
   ctx2d.save();
   ctx2d.translate(x, y);
   ctx2d.rotate(rotation);
 
-  const baseRadius = 1.5;
-  const baseWidth  = baseRadius * 2; // slightly wider base
-  const tipWidth   = 0.5;           // slimmer tip for a sharp look
-  ctx2d.fillStyle = '#808080';
+  const shaftWidth = 2;
+  const headRadius = 2.5;
+  const tipSize = 3;
+  const bend = (Math.random() - 0.5) * 0.3;
+  const rusty = Math.random() < 0.35;
+  const color = rusty ? '#8b4513' : '#b0b0b0';
 
-  // tapered needle body
+  ctx2d.fillStyle = color;
   ctx2d.beginPath();
-  ctx2d.moveTo(0, -baseWidth / 2);
-  ctx2d.lineTo(length, -tipWidth / 2);
-  ctx2d.lineTo(length, tipWidth / 2);
-  ctx2d.lineTo(0, baseWidth / 2);
+  ctx2d.moveTo(0, -shaftWidth/2);
+  ctx2d.quadraticCurveTo(length * bend, -shaftWidth/2, length - tipSize, -shaftWidth/2);
+  ctx2d.lineTo(length - tipSize, shaftWidth/2);
+  ctx2d.quadraticCurveTo(length * bend, shaftWidth/2, 0, shaftWidth/2);
   ctx2d.closePath();
   ctx2d.fill();
 
-  // circular base
   ctx2d.beginPath();
-  ctx2d.arc(0, 0, baseRadius, 0, Math.PI * 2);
+  ctx2d.moveTo(length - tipSize, -shaftWidth/2);
+  ctx2d.lineTo(length, 0);
+  ctx2d.lineTo(length - tipSize, shaftWidth/2);
+  ctx2d.closePath();
+  ctx2d.fill();
+
+  ctx2d.beginPath();
+  ctx2d.fillStyle = rusty ? '#8b4513' : '#d3d3d3';
+  ctx2d.arc(0, 0, headRadius, 0, Math.PI * 2);
   ctx2d.fill();
 
   ctx2d.restore();


### PR DESCRIPTION
## Summary
- Add `drawNail` and `drawNailEdges` to render metallic nails of varying length, bend and rust on burning-edge maps
- Update drawing logic and docs to reference nails instead of needles

## Testing
- `node --version`
- `node --check script.js`
- `python -m py_compile color_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_68a20a1cd4e4832d96327d722b2db26e