### PR TITLE
Replace burning-edge needles with static nails

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
 - Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls" or "burning edges") and adjust aiming amplitude.
 
-
- - In the "burning edges" map the field border is lined with static metallic nails of varying length—some bent or rusty—that destroy planes on contact.
+- The "burning edges" map has lethal borders that instantly destroy planes on contact.
 
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls" or "burning edges") and adjust aiming amplitude.
 
 
- - In the "burning edges" map the field border is lined with tightly packed sewing needles that destroy planes on contact.
+ - In the "burning edges" map the field border is lined with static metallic nails of varying length—some bent or rusty—that destroy planes on contact.
 
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.


### PR DESCRIPTION
## Summary
- Cache randomized nail edge data so burning-edge borders draw varied nails that stay fixed each frame
- Render nails with optional rust coloring for a more metallic, weathered look
- Reset cached nail edges on map changes or canvas resizes

## Testing
- `node --version`
- `node --check script.js`
- `python -m py_compile color_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_68a20a1cd4e4832d96327d722b2db26e