### PR TITLE
Restore nail-lined burning edges map

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
 - Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls" or "burning edges") and adjust aiming amplitude.
 
-
- - In the "burning edges" map the field border is lined with tightly packed sewing needles that destroy planes on contact.
+- The "burning edges" map lines its lethal borders with static metallic nails that instantly destroy planes on contact.
 
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
 - Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls" or "burning edges") and adjust aiming amplitude.
 
-- The "burning edges" map lines its lethal borders with static metallic nails that instantly destroy planes on contact.
+- The "burning edges" map lines its lethal borders with static metallic nails. Some are shiny, others bent or rusty, and all instantly destroy planes on contact.
 
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.

--- a/script.js
+++ b/script.js
@@ -1301,16 +1301,51 @@ function drawBrickEdges(ctx2d, w, h){
   }
 }
 
+function seededRand(seed) {
+  const x = Math.sin(seed) * 10000;
+  return x - Math.floor(x);
+}
+
 function generateNailEdges(w, h) {
   const spacing = 20;
   const nails = [];
-  for (let x = 0; x <= w; x += spacing) {
-    nails.push({ x, y: 0, edge: 'top', length: 10 + Math.random() * 10, bend: (Math.random() - 0.5) * 0.4, rust: Math.random() });
-    nails.push({ x, y: h, edge: 'bottom', length: 10 + Math.random() * 10, bend: (Math.random() - 0.5) * 0.4, rust: Math.random() });
+  for (let x = 0, i = 0; x <= w; x += spacing, i++) {
+    const seed = i * 6;
+    nails.push({
+      x,
+      y: 0,
+      edge: 'top',
+      length: 10 + seededRand(seed) * 10,
+      bend: (seededRand(seed + 1) - 0.5) * 0.4,
+      rust: seededRand(seed + 2)
+    });
+    nails.push({
+      x,
+      y: h,
+      edge: 'bottom',
+      length: 10 + seededRand(seed + 3) * 10,
+      bend: (seededRand(seed + 4) - 0.5) * 0.4,
+      rust: seededRand(seed + 5)
+    });
   }
-  for (let y = spacing; y <= h - spacing; y += spacing) {
-    nails.push({ x: 0, y, edge: 'left', length: 10 + Math.random() * 10, bend: (Math.random() - 0.5) * 0.4, rust: Math.random() });
-    nails.push({ x: w, y, edge: 'right', length: 10 + Math.random() * 10, bend: (Math.random() - 0.5) * 0.4, rust: Math.random() });
+  for (let y = spacing, i = 0; y <= h - spacing; y += spacing, i++) {
+    const seed = 1000 + i * 6;
+    nails.push({
+      x: 0,
+      y,
+      edge: 'left',
+      length: 10 + seededRand(seed) * 10,
+      bend: (seededRand(seed + 1) - 0.5) * 0.4,
+      rust: seededRand(seed + 2)
+    });
+    nails.push({
+      x: w,
+      y,
+      edge: 'right',
+      length: 10 + seededRand(seed + 3) * 10,
+      bend: (seededRand(seed + 4) - 0.5) * 0.4,
+      rust: seededRand(seed + 5)
+    });
   }
   return nails;
 }
@@ -1335,13 +1370,23 @@ function drawNail(ctx2d, nail) {
   const metallic = 70 - nail.rust * 20;
   const rustHue = 25; // brownish
   const useRust = nail.rust > 0.6;
-  ctx2d.strokeStyle = useRust ? `hsl(${rustHue},40%,${40 + nail.rust * 20}%)` : `hsl(0,0%,${metallic}%)`;
+  const baseColor = useRust ? `hsl(${rustHue},40%,${40 + nail.rust * 20}%)` : `hsl(0,0%,${metallic}%)`;
+  ctx2d.strokeStyle = baseColor;
   ctx2d.lineCap = 'round';
   ctx2d.lineWidth = 2;
   ctx2d.beginPath();
   ctx2d.moveTo(0, 0);
   ctx2d.lineTo(0, nail.length);
   ctx2d.stroke();
+  if (!useRust) {
+    ctx2d.strokeStyle = `hsl(0,0%,${metallic + 20}%)`;
+    ctx2d.lineWidth = 1;
+    ctx2d.beginPath();
+    ctx2d.moveTo(1, 0);
+    ctx2d.lineTo(1, nail.length);
+    ctx2d.stroke();
+  }
+  ctx2d.strokeStyle = baseColor;
   ctx2d.lineWidth = 3;
   ctx2d.beginPath();
   ctx2d.moveTo(-3, 0);

--- a/script.js
+++ b/script.js
@@ -97,7 +97,6 @@ const AA_TRAIL_MS = 5000; // radar sweep afterglow duration
 const MAPS = ["clear sky", "wall", "two walls", "burning edges"];
 let mapIndex = 1;
 
-// Needle edge drawing for the "burning edges" map
 let flightRangeCells = 15;     // значение «в клетках» для меню/физики
 let buildingsCount   = 0;
 
@@ -122,6 +121,7 @@ let turnIndex    = lastFirstTurn;
 let points       = [];
 let flyingPoints = [];
 let buildings    = [];
+let nailEdges    = [];
 
 let aaUnits     = [];
 let aaPlacementPreview = null;
@@ -1143,9 +1143,9 @@ function handleAAForPlane(p, fp){
   drawBuildings();
 
   // redraw field edges above walls
-    if (MAPS[mapIndex] === "burning edges") {
-      drawNeedleEdges(gameCtx, gameCanvas.width, gameCanvas.height);
-  } else {
+  if (MAPS[mapIndex] === "burning edges") {
+    drawNailEdges(gameCtx);
+  } else if (MAPS[mapIndex] !== "clear sky") {
     drawBrickEdges(gameCtx, gameCanvas.width, gameCanvas.height);
   }
 
@@ -1274,25 +1274,6 @@ function drawNotebookBackground(ctx2d, w, h){
   ctx2d.setLineDash([10,5]);
   ctx2d.beginPath(); ctx2d.moveTo(0,h-1); ctx2d.lineTo(w,h-1); ctx2d.stroke();
   ctx2d.setLineDash([]);
-
-    if (MAPS[mapIndex] === "burning edges") {
-      drawNeedleEdges(ctx2d, w, h);
-  } else {
-    drawBrickEdges(ctx2d, w, h);
-  }
-}
-
-function drawNeedleEdges(ctx2d, w, h){
-  const spacing = 4;
-  const length = 12;
-  for(let x=0; x<=w; x+=spacing){
-    drawNeedle(ctx2d, x, 0, length, Math.PI/2);
-    drawNeedle(ctx2d, x, h, length, -Math.PI/2);
-  }
-  for(let y=0; y<=h; y+=spacing){
-    drawNeedle(ctx2d, 0, y, length, 0);
-    drawNeedle(ctx2d, w, y, length, Math.PI);
-  }
 }
 
 function drawBrickEdges(ctx2d, w, h){
@@ -1320,30 +1301,52 @@ function drawBrickEdges(ctx2d, w, h){
   }
 }
 
-function drawNeedle(ctx2d, x, y, length, rotation){
+function generateNailEdges(w, h) {
+  const spacing = 20;
+  const nails = [];
+  for (let x = 0; x <= w; x += spacing) {
+    nails.push({ x, y: 0, edge: 'top', length: 10 + Math.random() * 10, bend: (Math.random() - 0.5) * 0.4, rust: Math.random() });
+    nails.push({ x, y: h, edge: 'bottom', length: 10 + Math.random() * 10, bend: (Math.random() - 0.5) * 0.4, rust: Math.random() });
+  }
+  for (let y = spacing; y <= h - spacing; y += spacing) {
+    nails.push({ x: 0, y, edge: 'left', length: 10 + Math.random() * 10, bend: (Math.random() - 0.5) * 0.4, rust: Math.random() });
+    nails.push({ x: w, y, edge: 'right', length: 10 + Math.random() * 10, bend: (Math.random() - 0.5) * 0.4, rust: Math.random() });
+  }
+  return nails;
+}
+
+function drawNailEdges(ctx2d) {
+  for (const nail of nailEdges) {
+    drawNail(ctx2d, nail);
+  }
+}
+
+function drawNail(ctx2d, nail) {
   ctx2d.save();
-  ctx2d.translate(x, y);
-  ctx2d.rotate(rotation);
-
-  const baseRadius = 1.5;
-  const baseWidth  = baseRadius * 2; // slightly wider base
-  const tipWidth   = 0.5;           // slimmer tip for a sharp look
-  ctx2d.fillStyle = '#808080';
-
-  // tapered needle body
+  ctx2d.translate(nail.x, nail.y);
+  let angle = 0;
+  switch (nail.edge) {
+    case 'top': angle = 0; break;
+    case 'bottom': angle = Math.PI; break;
+    case 'left': angle = -Math.PI / 2; break;
+    case 'right': angle = Math.PI / 2; break;
+  }
+  ctx2d.rotate(angle + nail.bend);
+  const metallic = 70 - nail.rust * 20;
+  const rustHue = 25; // brownish
+  const useRust = nail.rust > 0.6;
+  ctx2d.strokeStyle = useRust ? `hsl(${rustHue},40%,${40 + nail.rust * 20}%)` : `hsl(0,0%,${metallic}%)`;
+  ctx2d.lineCap = 'round';
+  ctx2d.lineWidth = 2;
   ctx2d.beginPath();
-  ctx2d.moveTo(0, -baseWidth / 2);
-  ctx2d.lineTo(length, -tipWidth / 2);
-  ctx2d.lineTo(length, tipWidth / 2);
-  ctx2d.lineTo(0, baseWidth / 2);
-  ctx2d.closePath();
-  ctx2d.fill();
-
-  // circular base
+  ctx2d.moveTo(0, 0);
+  ctx2d.lineTo(0, nail.length);
+  ctx2d.stroke();
+  ctx2d.lineWidth = 3;
   ctx2d.beginPath();
-  ctx2d.arc(0, 0, baseRadius, 0, Math.PI * 2);
-  ctx2d.fill();
-
+  ctx2d.moveTo(-3, 0);
+  ctx2d.lineTo(3, 0);
+  ctx2d.stroke();
   ctx2d.restore();
 }
 
@@ -1889,6 +1892,7 @@ function updateMapDisplay(){
 
 function applyCurrentMap(){
   buildings = [];
+  nailEdges = [];
   if(MAPS[mapIndex] === "clear sky"){
     // no buildings to add
   } else if (MAPS[mapIndex] === "wall") {
@@ -1923,7 +1927,8 @@ function applyCurrentMap(){
       color: "darkred"
     });
   } else if (MAPS[mapIndex] === "burning edges") {
-    // no buildings; edges are lethal
+    // no buildings; edges are lethal and lined with nails
+    nailEdges = generateNailEdges(gameCanvas.width, gameCanvas.height);
   }
   updateMapDisplay();
   renderScoreboard();
@@ -1979,11 +1984,16 @@ function resizeCanvas() {
   canvas.width = 300 * scale;
   canvas.height = 400 * scale;
 
+  // Regenerate nails when resizing on burning edges
+  if (MAPS[mapIndex] === "burning edges") {
+    nailEdges = generateNailEdges(canvas.width, canvas.height);
+  }
+
   aimCanvas.style.width = window.innerWidth + 'px';
   aimCanvas.style.height = window.innerHeight + 'px';
   aimCanvas.width = window.innerWidth;
   aimCanvas.height = window.innerHeight;
-  
+
   // Переинициализируем самолёты
   if(points.length === 0) {
     initPoints();


### PR DESCRIPTION
## Summary
- Generate and draw static metallic nails for the burning-edges map
- Keep nails fixed each frame with optional rust and bends
- Rebuild nail borders when the canvas is resized to prevent broken layouts
- Document nail-lined lethal border in the README

## Testing
- `node --version`
- `node --check script.js`
- `python -m py_compile color_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_68a20a1cd4e4832d96327d722b2db26e