### PR TITLE
Fix missing braces in nail drawing logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -1331,14 +1331,13 @@ function drawSharpEdges(ctx2d, w, h){
   for(let y=0; y<h; y+=spacing){
     drawNail(ctx2d, 0, y + spacing/2, Math.PI/2);
     drawNail(ctx2d, w, y + spacing/2, -Math.PI/2);
+  }
+}
 
 function drawNailEdges(ctx2d, nails){
-  const shaftLength = 14; // trimmed to allow a small point
-  const headRadius = 3;
-
-    ctx2d.restore();
-
-  }
+  nails.forEach(nail => {
+    drawNail(ctx2d, nail.x, nail.y, nail.angle);
+  });
 }
 
 function drawThinPlane(ctx2d, cx, cy, color, angle){


### PR DESCRIPTION
## Summary
- close missing braces in drawSharpEdges and clean up nail-edge helper

## Testing
- `node --check script.js`
- `python -m py_compile color_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3730f9c44832da40aaec120dfaecf