### PR TITLE
Fix nail offset on sharp edges map

### DIFF
--- a/script.js
+++ b/script.js
@@ -1324,16 +1324,14 @@ function drawNail(ctx2d, x, y, angle){
 
 function drawSharpEdges(ctx2d, w, h){
   const spacing = 40;
-  const edgeOffset = 1; // keep nails fully within the playable area
-  for(let x=0; x<w; x+=spacing){
-    drawNail(ctx2d, x + spacing/2, edgeOffset, 0);
-    drawNail(ctx2d, x + spacing/2, h - edgeOffset, Math.PI);
+  const edgeOffset = 0.5; // keep strokes inside the canvas
+  for(let x = 0; x < w; x += spacing){
+    drawNail(ctx2d, x + spacing/2, edgeOffset, 0);           // top edge nails
+    drawNail(ctx2d, x + spacing/2, h - edgeOffset, Math.PI); // bottom edge nails
   }
-  for(let y=0; y<h; y+=spacing){
-
-    drawNail(ctx2d, 0, y + spacing/2, Math.PI/2);
-    drawNail(ctx2d, w, y + spacing/2, -Math.PI/2);
-
+  for(let y = 0; y < h; y += spacing){
+    drawNail(ctx2d, edgeOffset, y + spacing/2, -Math.PI/2);      // left edge nails
+    drawNail(ctx2d, w - edgeOffset, y + spacing/2, Math.PI/2);   // right edge nails
   }
 }
 


### PR DESCRIPTION
## Summary
- keep side nails fully visible by offsetting left and right edge nails
- orient all sharp-edge nails inward so they stand on their heads

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a37c6ce5b8832d8ad9861bb0534f8e