### PR TITLE
Fix nail offset on sharp edges map

### DIFF
--- a/script.js
+++ b/script.js
@@ -1324,16 +1324,17 @@ function drawNail(ctx2d, x, y, angle){
 
 function drawSharpEdges(ctx2d, w, h){
   const spacing = 40;
-  const edgeOffset = 1; // keep nails fully within the playable area
-  for(let x=0; x<w; x+=spacing){
-    drawNail(ctx2d, x + spacing/2, edgeOffset, 0);
-    drawNail(ctx2d, x + spacing/2, h - edgeOffset, Math.PI);
+  const edgeOffset = 0.5;      // keep strokes inside the canvas
+  const nailWidth = 4;         // must match drawNail
+  const sideOffset = edgeOffset + nailWidth / 2;
+
+  for(let x = 0; x < w; x += spacing){
+    drawNail(ctx2d, x + spacing/2, edgeOffset, 0);           // top edge nails
+    drawNail(ctx2d, x + spacing/2, h - edgeOffset, Math.PI); // bottom edge nails
   }
-  for(let y=0; y<h; y+=spacing){
-
-    drawNail(ctx2d, 0, y + spacing/2, Math.PI/2);
-    drawNail(ctx2d, w, y + spacing/2, -Math.PI/2);
-
+  for(let y = 0; y < h; y += spacing){
+    drawNail(ctx2d, sideOffset, y + spacing/2, -Math.PI/2);      // left edge nails
+    drawNail(ctx2d, w - sideOffset, y + spacing/2, Math.PI/2);   // right edge nails
   }
 }
 

--- a/script.js
+++ b/script.js
@@ -87,6 +87,10 @@ const AA_MIN_DIST_FROM_EDGES = 40;
 // Quarter-circle afterglow so the sweep persists for 90° of rotation
 const AA_TRAIL_MS = 5000; // radar sweep afterglow duration
 
+// Nail dimensions for the "sharp edges" map
+const NAIL_LENGTH = 12;
+const NAIL_WIDTH  = 4;
+
 
 
 /* ======= STATE ======= */
@@ -1301,20 +1305,18 @@ function drawBrickEdges(ctx2d, w, h){
 }
 
 function drawNail(ctx2d, x, y, angle){
-  const length = 12;
-  const width = 4;
   ctx2d.save();
   ctx2d.translate(x, y);
   ctx2d.rotate(angle);
   ctx2d.fillStyle = '#bbbbbb';
   ctx2d.strokeStyle = '#666666';
   ctx2d.lineWidth = 1;
-  ctx2d.fillRect(-width/2, 0, width, length);
-  ctx2d.strokeRect(-width/2, 0, width, length);
+  ctx2d.fillRect(-NAIL_WIDTH/2, 0, NAIL_WIDTH, NAIL_LENGTH);
+  ctx2d.strokeRect(-NAIL_WIDTH/2, 0, NAIL_WIDTH, NAIL_LENGTH);
   ctx2d.beginPath();
-  ctx2d.moveTo(-width/2, length);
-  ctx2d.lineTo(width/2, length);
-  ctx2d.lineTo(0, length + width);
+  ctx2d.moveTo(-NAIL_WIDTH/2, NAIL_LENGTH);
+  ctx2d.lineTo(NAIL_WIDTH/2, NAIL_LENGTH);
+  ctx2d.lineTo(0, NAIL_LENGTH + NAIL_WIDTH);
   ctx2d.closePath();
   ctx2d.fill();
   ctx2d.stroke();
@@ -1325,8 +1327,7 @@ function drawNail(ctx2d, x, y, angle){
 function drawSharpEdges(ctx2d, w, h){
   const spacing = 40;
   const edgeOffset = 0.5;      // keep strokes inside the canvas
-  const nailWidth = 4;         // must match drawNail
-  const sideOffset = edgeOffset + nailWidth / 2;
+  const sideOffset = edgeOffset + NAIL_WIDTH / 2;
 
   for(let x = 0; x < w; x += spacing){
     drawNail(ctx2d, x + spacing/2, edgeOffset, 0);           // top edge nails
@@ -1336,12 +1337,6 @@ function drawSharpEdges(ctx2d, w, h){
     drawNail(ctx2d, sideOffset, y + spacing/2, -Math.PI/2);      // left edge nails
     drawNail(ctx2d, w - sideOffset, y + spacing/2, Math.PI/2);   // right edge nails
   }
-}
-
-function drawNailEdges(ctx2d, nails){
-  nails.forEach(nail => {
-    drawNail(ctx2d, nail.x, nail.y, nail.angle);
-  });
 }
 
 function drawThinPlane(ctx2d, cx, cy, color, angle){


### PR DESCRIPTION
## Summary
- offset sharp-edge side nails inward by half their width
- keep nail heads aligned with canvas border while pointing inward

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a37c6ce5b8832d8ad9861bb0534f8e