### PR TITLE
chore: remove sharp edges map

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@
 
 - Each side controls a group of paper planes (green vs. blue).
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
-- Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls",
-    or "sharp edges") and adjust aiming amplitude.
-- The "sharp edges" map lines the border with nails that destroy any plane on contact.
+- Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls") and adjust aiming amplitude.
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.
 

--- a/script.js
+++ b/script.js
@@ -87,14 +87,12 @@ const AA_MIN_DIST_FROM_EDGES = 40;
 // Quarter-circle afterglow so the sweep persists for 90° of rotation
 const AA_TRAIL_MS = 5000; // radar sweep afterglow duration
 
-
-
 /* ======= STATE ======= */
 
 
 
 
-const MAPS = ["clear sky", "wall", "two walls", "sharp edges"];
+const MAPS = ["clear sky", "wall", "two walls"];
 let mapIndex = 1;
 
 let flightRangeCells = 15;     // значение «в клетках» для меню/физики
@@ -1059,34 +1057,11 @@ function handleAAForPlane(p, fp){
       p.x += fp.vx;
       p.y += fp.vy;
 
-      // отражения или смерть от границ поля
-      if(MAPS[mapIndex] === "sharp edges"){
-        if(
-          p.x < POINT_RADIUS ||
-          p.x > gameCanvas.width - POINT_RADIUS ||
-          p.y < POINT_RADIUS ||
-          p.y > gameCanvas.height - POINT_RADIUS
-        ){
-          p.isAlive = false;
-          p.burning = true;
-          p.collisionX = p.x;
-          p.collisionY = p.y;
-          flyingPoints = flyingPoints.filter(x => x !== fp);
-          checkVictory();
-          if(!isGameOver && !flyingPoints.some(x=>x.plane.color===p.color)){
-            turnIndex = (turnIndex + 1) % turnColors.length;
-            if(gameMode==="computer" && turnColors[turnIndex]==="blue"){
-              aiMoveScheduled = false;
-            }
-          }
-          continue;
-        }
-      } else {
-        if(p.x < POINT_RADIUS){ p.x = POINT_RADIUS; fp.vx = -fp.vx; }
-        else if(p.x > gameCanvas.width - POINT_RADIUS){ p.x = gameCanvas.width - POINT_RADIUS; fp.vx = -fp.vx; }
-        if(p.y < POINT_RADIUS){ p.y = POINT_RADIUS; fp.vy = -fp.vy; }
-        else if(p.y > gameCanvas.height - POINT_RADIUS){ p.y = gameCanvas.height - POINT_RADIUS; fp.vy = -fp.vy; }
-      }
+      // field borders
+      if(p.x < POINT_RADIUS){ p.x = POINT_RADIUS; fp.vx = -fp.vx; }
+      else if(p.x > gameCanvas.width - POINT_RADIUS){ p.x = gameCanvas.width - POINT_RADIUS; fp.vx = -fp.vx; }
+      if(p.y < POINT_RADIUS){ p.y = POINT_RADIUS; fp.vy = -fp.vy; }
+      else if(p.y > gameCanvas.height - POINT_RADIUS){ p.y = gameCanvas.height - POINT_RADIUS; fp.vy = -fp.vy; }
 
       // столкновения со зданиями (cooldown)
       if(fp.collisionCooldown>0){ fp.collisionCooldown--; }
@@ -1142,9 +1117,7 @@ function handleAAForPlane(p, fp){
   drawBuildings();
 
   // redraw field edges
-  if (MAPS[mapIndex] === "sharp edges") {
-    drawSharpEdges(gameCtx, gameCanvas.width, gameCanvas.height);
-  } else if (MAPS[mapIndex] !== "clear sky") {
+  if (MAPS[mapIndex] !== "clear sky") {
     drawBrickEdges(gameCtx, gameCanvas.width, gameCanvas.height);
   }
 
@@ -1298,49 +1271,6 @@ function drawBrickEdges(ctx2d, w, h){
     ctx2d.fillRect(w - brickHeight, y, brickHeight, brickWidth);
     ctx2d.strokeRect(w - brickHeight, y, brickHeight, brickWidth);
   }
-}
-
-function drawNail(ctx2d, x, y, angle){
-  const length = 12;
-  const width = 4;
-  ctx2d.save();
-  ctx2d.translate(x, y);
-  ctx2d.rotate(angle);
-  ctx2d.fillStyle = '#bbbbbb';
-  ctx2d.strokeStyle = '#666666';
-  ctx2d.lineWidth = 1;
-  ctx2d.fillRect(-width/2, 0, width, length);
-  ctx2d.strokeRect(-width/2, 0, width, length);
-  ctx2d.beginPath();
-  ctx2d.moveTo(-width/2, length);
-  ctx2d.lineTo(width/2, length);
-  ctx2d.lineTo(0, length + width);
-  ctx2d.closePath();
-  ctx2d.fill();
-  ctx2d.stroke();
-  ctx2d.restore();
-}
-
-
-function drawSharpEdges(ctx2d, w, h){
-  const spacing = 40;
-  const edgeOffset = 1; // keep nails fully within the playable area
-  for(let x=0; x<w; x+=spacing){
-    drawNail(ctx2d, x + spacing/2, edgeOffset, 0);
-    drawNail(ctx2d, x + spacing/2, h - edgeOffset, Math.PI);
-  }
-  for(let y=0; y<h; y+=spacing){
-
-    drawNail(ctx2d, 0, y + spacing/2, Math.PI/2);
-    drawNail(ctx2d, w, y + spacing/2, -Math.PI/2);
-
-  }
-}
-
-function drawNailEdges(ctx2d, nails){
-  nails.forEach(nail => {
-    drawNail(ctx2d, nail.x, nail.y, nail.angle);
-  });
 }
 
 function drawThinPlane(ctx2d, cx, cy, color, angle){
@@ -1918,8 +1848,6 @@ function applyCurrentMap(){
       height: wallHeight,
       color: "darkred"
     });
-  } else if (MAPS[mapIndex] === "sharp edges") {
-    // no buildings; edges are lethal
   }
   updateMapDisplay();
   renderScoreboard();


### PR DESCRIPTION
## Summary
- drop "sharp edges" map and associated nail-rendering code
- simplify border logic to always bounce planes off the edges
- update docs to list only the remaining maps

## Testing
- `node --check script.js`
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a37c6ce5b8832d8ad9861bb0534f8e