### PR TITLE
Fix AA placement preview variable typo causing crash

### DIFF
--- a/script.js
+++ b/script.js
@@ -536,7 +536,7 @@ function drawAAPreview(){
     const alpha = (1 - age/AA_TRAIL_MS) * 0.3;
 
     gameCtx.globalAlpha = alpha;
-    gameCtx.strokeStyle = currentPlcer;
+    gameCtx.strokeStyle = currentPlacer;
     gameCtx.lineWidth = 2;
     gameCtx.lineCap = "round";
     const trailAng = seg.angleDeg * Math.PI/180;


### PR DESCRIPTION
## Summary
- Correct typo in Anti-Aircraft placement preview that referenced an undefined variable

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68a4790c7c68832d8ca8abb7ff612b0d