### PR TITLE
Rotate side brick walls vertically and thin

### DIFF
--- a/script.js
+++ b/script.js
@@ -1279,7 +1279,6 @@ function drawNotebookBackground(ctx2d, w, h){
 }
 
 function drawBrickEdges(ctx2d, w, h){
-  const brickWidth = 20;
   const brickHeight = 10;
 
   // top border
@@ -1296,14 +1295,16 @@ function drawBrickEdges(ctx2d, w, h){
 
   // left border
   ctx2d.save();
-  ctx2d.translate(brickWidth / 2, h / 2);
-  drawBrickWall(ctx2d, brickWidth, h);
+  ctx2d.translate(brickHeight / 2, h / 2);
+  ctx2d.rotate(Math.PI / 2);
+  drawBrickWall(ctx2d, h, brickHeight);
   ctx2d.restore();
 
   // right border
   ctx2d.save();
-  ctx2d.translate(w - brickWidth / 2, h / 2);
-  drawBrickWall(ctx2d, brickWidth, h);
+  ctx2d.translate(w - brickHeight / 2, h / 2);
+  ctx2d.rotate(Math.PI / 2);
+  drawBrickWall(ctx2d, h, brickHeight);
   ctx2d.restore();
 }
 


### PR DESCRIPTION
## Summary
- Make left and right map borders thin vertical brick walls matching top and bottom edges

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a47a2ffb88832d88850f11d8be2055