### PR TITLE
Add sharp edges map identical to clear sky

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 - Each side controls a group of paper planes (green vs. blue).
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
-- Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls") and adjust aiming amplitude.
+- Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls", "sharp edges") and adjust aiming amplitude.
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.
 

--- a/script.js
+++ b/script.js
@@ -94,7 +94,7 @@ const AA_TRAIL_MS = 5000; // radar sweep afterglow duration
 
 
 
-const MAPS = ["clear sky", "wall", "two walls"];
+const MAPS = ["clear sky", "wall", "two walls", "sharp edges"];
 let mapIndex = 1;
 
 let flightRangeCells = 15;     // значение «в клетках» для меню/физики
@@ -1848,7 +1848,7 @@ function updateMapDisplay(){
 
 function applyCurrentMap(){
   buildings = [];
-  if(MAPS[mapIndex] === "clear sky"){
+  if(MAPS[mapIndex] === "clear sky" || MAPS[mapIndex] === "sharp edges"){
     // no buildings to add
   } else if (MAPS[mapIndex] === "wall") {
     const wallWidth = CELL_SIZE * 8;


### PR DESCRIPTION
## Summary
- add "sharp edges" map option
- handle new map as clear sky placeholder
- document maps in README

## Testing
- `node --check script.js`
- `python -m py_compile color_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_68a47e48ac14832dbc09746d95b22602