### PR TITLE
Make sharp edges map lethal at borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - Each side controls a group of paper planes (green vs. blue).
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
 - Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls", "sharp edges") and adjust aiming amplitude.
+- On the "sharp edges" map, hitting the border destroys the plane instead of bouncing it back.
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.
 

--- a/script.js
+++ b/script.js
@@ -1075,23 +1075,39 @@ function handleAAForPlane(p, fp){
       p.x += fp.vx;
       p.y += fp.vy;
 
-      // field borders: walls surround canvas from outside
-      if (p.x < 0) {
-        p.x = 0;
-        fp.vx = -fp.vx;
-      }
-      else if (p.x > gameCanvas.width) {
-        p.x = gameCanvas.width;
-        fp.vx = -fp.vx;
-      }
-      if (p.y < 0) {
-        p.y = 0;
-        fp.vy = -fp.vy;
-      }
-      else if (p.y > gameCanvas.height) {
-        p.y = gameCanvas.height;
-        fp.vy = -fp.vy;
-      }
+        // field borders
+        if (p.x < 0) {
+          p.x = 0;
+          if (MAPS[mapIndex] === "sharp edges") {
+            destroyPlane(fp);
+            continue;
+          }
+          fp.vx = -fp.vx;
+        }
+        else if (p.x > gameCanvas.width) {
+          p.x = gameCanvas.width;
+          if (MAPS[mapIndex] === "sharp edges") {
+            destroyPlane(fp);
+            continue;
+          }
+          fp.vx = -fp.vx;
+        }
+        if (p.y < 0) {
+          p.y = 0;
+          if (MAPS[mapIndex] === "sharp edges") {
+            destroyPlane(fp);
+            continue;
+          }
+          fp.vy = -fp.vy;
+        }
+        else if (p.y > gameCanvas.height) {
+          p.y = gameCanvas.height;
+          if (MAPS[mapIndex] === "sharp edges") {
+            destroyPlane(fp);
+            continue;
+          }
+          fp.vy = -fp.vy;
+        }
 
       // столкновения со зданиями (cooldown)
       if(fp.collisionCooldown>0){ fp.collisionCooldown--; }


### PR DESCRIPTION
## Summary
- Destroy planes that touch map boundaries on the "sharp edges" map instead of reflecting them
- Document lethal border behavior for the "sharp edges" map

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68a4854ebda8832d9a213ad36102ffc0