### PR TITLE
Ensure brick borders remain visible

### DIFF
--- a/script.js
+++ b/script.js
@@ -1297,26 +1297,27 @@ function drawBrickEdges(ctx2d, w, h){
 
   // top border
   ctx2d.save();
-  ctx2d.translate(w / 2, -brickHeight / 2);
+  // draw half of the wall inside the canvas so bricks remain visible
+  ctx2d.translate(w / 2, 0);
   drawBrickWall(ctx2d, w, brickHeight);
   ctx2d.restore();
 
   // bottom border
   ctx2d.save();
-  ctx2d.translate(w / 2, h + brickHeight / 2);
+  ctx2d.translate(w / 2, h);
   drawBrickWall(ctx2d, w, brickHeight);
   ctx2d.restore();
 
   // left border
   ctx2d.save();
-  ctx2d.translate(-brickHeight / 2, h / 2);
+  ctx2d.translate(0, h / 2);
   ctx2d.rotate(Math.PI / 2);
   drawBrickWall(ctx2d, h, brickHeight);
   ctx2d.restore();
 
   // right border
   ctx2d.save();
-  ctx2d.translate(w + brickHeight / 2, h / 2);
+  ctx2d.translate(w, h / 2);
   ctx2d.rotate(Math.PI / 2);
   drawBrickWall(ctx2d, h, brickHeight);
   ctx2d.restore();


### PR DESCRIPTION
## Summary
- Adjust brick edge placement so walls remain visible by centering them on canvas boundaries

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a486dcf8c4832dbf253721b700df7b