### PR TITLE
feat: add rotary instruments for range and amplitude

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,47 +34,47 @@
 
     <div class="control-group-row">
       <div class="control-pair-row">
-        <!-- Flight Range Control -->
-        <div class="control-box">
-          <div class="control-label">Flight Range</div>
-          <!-- Самолёт и пламя турбины для индикации дальности -->
-            <div id="flightRangeIndicator" class="control-visual">
-            <div class="jet">
-              <div class="wing-trail top"></div>
-              <div class="wing-trail bottom"></div>
-              <svg class="jet-plane" viewBox="0 0 38 20">
-                <polygon points="38,10 8,20 8,15 0,10 8,5 8,0" />
-              </svg>
-
-                <svg id="flame" class="jet-flame" viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
-                <defs>
-                  <radialGradient id="flameGradient" cx="100%" cy="50%" r="60%">
-                    <stop offset="0%" stop-color="#ffea00" />
-                    <stop offset="100%" stop-color="#ff4500" />
-                  </radialGradient>
-                </defs>
-                <path d="M40 10 C37 4 32 0 20 0 C5 0 0 10 20 20 C32 20 37 16 40 10 Z" fill="url(#flameGradient)" />
-              </svg>
-
+        <!-- Flight Range Instrument -->
+        <div class="instrument" id="flightRangeControl">
+          <div class="bezel" id="flightRangeBezel">
+            <div class="bezel-pointer" id="flightRangePointer"></div>
+            <div class="instrument-display">
+              <div class="instrument-label">Flight Range</div>
+              <!-- Самолёт и пламя турбины для индикации дальности -->
+              <div id="flightRangeIndicator" class="instrument-visual">
+                <div class="jet">
+                  <div class="wing-trail top"></div>
+                  <div class="wing-trail bottom"></div>
+                  <svg class="jet-plane" viewBox="0 0 38 20">
+                    <polygon points="38,10 8,20 8,15 0,10 8,5 8,0" />
+                  </svg>
+                  <svg id="flame" class="jet-flame" viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+                    <defs>
+                      <radialGradient id="flameGradient" cx="100%" cy="50%" r="60%">
+                        <stop offset="0%" stop-color="#ffea00" />
+                        <stop offset="100%" stop-color="#ff4500" />
+                      </radialGradient>
+                    </defs>
+                    <path d="M40 10 C37 4 32 0 20 0 C5 0 0 10 20 20 C32 20 37 16 40 10 Z" fill="url(#flameGradient)" />
+                  </svg>
+                </div>
+              </div>
+              <div class="instrument-value" id="flightRangeDisplay">15</div>
             </div>
-          </div>
-          <div class="control-value"><span id="flightRangeDisplay">15 cells</span></div>
-          <div class="control-buttons">
-            <button id="flightRangeMinus" class="control-btn">−</button>
-            <button id="flightRangePlus" class="control-btn">+</button>
           </div>
         </div>
 
-        <!-- Aiming Amplitude Control -->
-        <div class="control-box">
-          <div class="control-label">Aiming Amplitude</div>
-          <div id="amplitudeIndicator" class="control-visual">
-            <div class="line3"></div>
-          </div>
-          <div class="control-value"><span id="amplitudeAngleDisplay">20°</span></div>
-          <div class="control-buttons">
-            <button id="amplitudeMinus" class="control-btn">−</button>
-            <button id="amplitudePlus" class="control-btn">+</button>
+        <!-- Aiming Amplitude Instrument -->
+        <div class="instrument" id="amplitudeControl">
+          <div class="bezel" id="amplitudeBezel">
+            <div class="bezel-pointer" id="amplitudePointer"></div>
+            <div class="instrument-display">
+              <div class="instrument-label">Aiming Amplitude</div>
+              <div id="amplitudeIndicator" class="instrument-visual">
+                <div class="line3"></div>
+              </div>
+              <div class="instrument-value" id="amplitudeAngleDisplay">20°</div>
+            </div>
           </div>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -186,6 +186,97 @@ body {
   box-sizing: border-box;
 }
 
+#modeMenu .control-pair-row .instrument {
+  flex: 1 1 0;
+  display: flex;
+  justify-content: center;
+}
+
+.instrument {
+  position: relative;
+  width: 140px;
+  height: 140px;
+}
+
+.instrument .bezel {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: #222;
+  position: relative;
+}
+
+.instrument .bezel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: repeating-conic-gradient(#666 0deg, #666 2deg, transparent 2deg, transparent 18deg);
+  mask: radial-gradient(farthest-side, transparent calc(50% - 8px), #000 calc(50% - 8px));
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(50% - 8px), #000 calc(50% - 8px));
+  pointer-events: none;
+}
+
+.instrument .instrument-display {
+  position: absolute;
+  inset: 12px;
+  border-radius: 50%;
+  background: #111;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #0f0;
+  text-align: center;
+}
+
+.instrument .instrument-label {
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
+.instrument .instrument-visual {
+  width: 60%;
+  height: 40%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.instrument .instrument-value {
+  font-family: 'Patrick Hand', cursive;
+  font-size: 18px;
+  margin-top: 4px;
+}
+
+.bezel-pointer {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 4px;
+  height: 45%;
+  background: #0f0;
+  transform-origin: 50% 100%;
+  transform: translate(-50%, -100%) rotate(0deg);
+  border-radius: 2px;
+  pointer-events: none;
+}
+
+.bezel.disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.instrument #flightRangeIndicator {
+  transform: scale(0.6);
+  transform-origin: center;
+}
+
+.instrument #amplitudeIndicator {
+  transform: scale(0.8);
+  transform-origin: center;
+}
+
 #modeMenu #mapControl {
   grid-template-rows: auto auto auto;
 }
@@ -277,33 +368,6 @@ body {
   height: 2px;
   background: linear-gradient(to left, rgba(230,230,230,0.8), rgba(230,230,230,0));
   opacity: 0.8;
-
-  border-radius: 1px;
-  transform-origin: right center;
-  transform: translateY(-50%);
-  filter: blur(0.5px);
-  animation: trail-wisp 3s infinite ease-in-out;
-}
-#flightRangeIndicator .wing-trail.top { top: 2px; }
-#flightRangeIndicator .wing-trail.bottom { bottom: 2px; }
-
-
-
-
-  right: 100%;
-  width: 35px;
-  height: 2px;
-  background: linear-gradient(to left, rgba(200,200,200,0.6), rgba(200,200,200,0));
-  opacity: 0.7;
-
-
-  right: calc(100% + 2px);
-  width: 35px;
-  height: 2px;
-  background: linear-gradient(to left, rgba(160,160,160,0.5), rgba(160,160,160,0));
-  opacity: 0.5;
-
-
 
   border-radius: 1px;
   transform-origin: right center;


### PR DESCRIPTION
## Summary
- replace flight range and aiming amplitude controls with circular instruments and bezel rotation
- implement rotary control logic and pointer indicators
- style instruments with ticked bezels and scaled visuals
- remove stray CSS that hid instrument controls

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bde6f540832d8f75c26ddab87659