### PR TITLE
feat: style instruments like analog displays

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -202,8 +202,10 @@ body {
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  background: #222;
+  background: linear-gradient(145deg, #d9d9d9, #7a7a7a);
   position: relative;
+  box-shadow: inset 0 2px 2px rgba(255, 255, 255, 0.7),
+              inset 0 -2px 2px rgba(0, 0, 0, 0.4);
 }
 
 .instrument .bezel::before {
@@ -211,7 +213,7 @@ body {
   position: absolute;
   inset: 0;
   border-radius: 50%;
-  background: repeating-conic-gradient(#666 0deg, #666 2deg, transparent 2deg, transparent 18deg);
+  background: repeating-conic-gradient(#b3b3b3 0deg, #b3b3b3 2deg, transparent 2deg, transparent 18deg);
   mask: radial-gradient(farthest-side, transparent calc(50% - 8px), #000 calc(50% - 8px));
   -webkit-mask: radial-gradient(farthest-side, transparent calc(50% - 8px), #000 calc(50% - 8px));
   pointer-events: none;
@@ -221,13 +223,24 @@ body {
   position: absolute;
   inset: 12px;
   border-radius: 50%;
-  background: #111;
+  background: linear-gradient(#d0d0d0, #b4b4b4);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  color: #0f0;
+  color: #111;
   text-align: center;
+  box-shadow: inset 0 0 4px rgba(0,0,0,0.3),
+              inset 0 0 2px rgba(255,255,255,0.4);
+}
+
+.instrument .instrument-display::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.4), rgba(255,255,255,0.1) 40%, transparent 60%);
+  pointer-events: none;
 }
 
 .instrument .instrument-label {
@@ -255,7 +268,7 @@ body {
   left: 50%;
   width: 4px;
   height: 45%;
-  background: #0f0;
+  background: #111;
   transform-origin: 50% 100%;
   transform: translate(-50%, -100%) rotate(0deg);
   border-radius: 2px;


### PR DESCRIPTION
## Summary
- Render instrument bezels with a metallic gradient
- Give instrument displays a gray glass look with dark text
- Darken gauge pointer for analog appearance

## Testing
- `npm test` (fails: Could not read package.json)
- `npx --yes prettier --check styles.css` (fails: Code style issues found in the above file. Run Prettier with --write to fix.)

------
https://chatgpt.com/codex/tasks/task_e_68a4c4d38a4c832d9b5bb9b9e1ac1d8c