### PR TITLE
Replace amplitude indicator with oscillating crosshair

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,10 @@
         <div class="control-box">
           <div class="control-label">Aiming Amplitude</div>
           <div id="amplitudeIndicator" class="control-visual">
-            <div class="line3"></div>
+            <div class="crosshair">
+              <div class="horizontal"></div>
+              <div class="vertical"></div>
+            </div>
           </div>
           <div class="control-value"><span id="amplitudeAngleDisplay">20°</span></div>
           <div class="control-buttons">

--- a/script.js
+++ b/script.js
@@ -1906,15 +1906,17 @@ function startNewRound(){
 function updateAmplitudeIndicator(){
   const el = document.getElementById("amplitudeIndicator");
   if(!el) return;
-  const line = el.querySelector(".line3");
-  if(!line) return;
+  const sight = el.querySelector(".crosshair");
+  if(!sight) return;
 
-  const maxAngleDeg = aimingAmplitude * 2; // отображаемое в UI
-  const oscDeg = maxAngleDeg * Math.sin(oscillationPhase);
-  line.style.transform = `rotate(${oscDeg}deg) translateZ(0)`;
+  const maxOffsetPx = 35;
+  const ratio = aimingAmplitude / MAX_AMPLITUDE;
+  const oscPx = maxOffsetPx * ratio * Math.sin(oscillationPhase);
+  sight.style.transform = `translate(-50%, -50%) translateX(${oscPx}px)`;
 
   const disp = document.getElementById("amplitudeAngleDisplay");
   if(disp){
+    const maxAngleDeg = aimingAmplitude * 2;
     disp.textContent = `${maxAngleDeg.toFixed(0)}°`;
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -366,15 +366,32 @@ body {
   max-width: 100%;
   max-height: 100%;
 }
-#amplitudeIndicator .line3 {
+#amplitudeIndicator .crosshair {
   position: absolute;
-  width: 80px;
-  height: 3px;
-  background-color: #6c757d;
   top: 50%;
-  left: 10px;
-  transform-origin: 0 50%;
-  border-radius: 2px;
+  left: 50%;
+  width: 30px;
+  height: 30px;
+  transform: translate(-50%, -50%);
+}
+#amplitudeIndicator .crosshair .horizontal,
+#amplitudeIndicator .crosshair .vertical {
+  position: absolute;
+  background-color: #6c757d;
+}
+#amplitudeIndicator .crosshair .horizontal {
+  top: 50%;
+  left: 0;
+  width: 30px;
+  height: 3px;
+  transform: translateY(-50%);
+}
+#amplitudeIndicator .crosshair .vertical {
+  left: 50%;
+  top: 0;
+  width: 3px;
+  height: 30px;
+  transform: translateX(-50%);
 }
 #amplitudeAngleDisplay {
   font-size: 22px;


### PR DESCRIPTION
## Summary
- Replace amplitude indicator line with a crosshair in the settings UI
- Animate crosshair to sway horizontally based on aiming amplitude
- Style new crosshair indicator and remove old line styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cd2995ac832d9d8f5bb8f7a45fc6