### PR TITLE
Style aiming amplitude as swinging crosshair

### DIFF
--- a/script.js
+++ b/script.js
@@ -1909,10 +1909,8 @@ function updateAmplitudeIndicator(){
   const sight = el.querySelector(".crosshair");
   if(!sight) return;
 
-  const maxOffsetPx = 35;
-  const ratio = aimingAmplitude / MAX_AMPLITUDE;
-  const oscPx = maxOffsetPx * ratio * Math.sin(oscillationPhase);
-  sight.style.transform = `translate(-50%, -50%) translateX(${oscPx}px)`;
+  const angleDeg = aimingAmplitude * Math.sin(oscillationPhase);
+  sight.style.transform = `translateX(-50%) rotate(${angleDeg}deg)`;
 
   const disp = document.getElementById("amplitudeAngleDisplay");
   if(disp){

--- a/styles.css
+++ b/styles.css
@@ -368,11 +368,24 @@ body {
 }
 #amplitudeIndicator .crosshair {
   position: absolute;
-  top: 50%;
+  top: 20px;
   left: 50%;
-  width: 30px;
-  height: 30px;
-  transform: translate(-50%, -50%);
+  width: 60px;
+  height: 60px;
+  border: 3px solid #6c757d;
+  border-radius: 50%;
+  transform-origin: 50% 0;
+  transform: translateX(-50%);
+}
+#amplitudeIndicator .crosshair::before {
+  content: "";
+  position: absolute;
+  top: -20px;
+  left: 50%;
+  width: 2px;
+  height: 20px;
+  background-color: #6c757d;
+  transform: translateX(-50%);
 }
 #amplitudeIndicator .crosshair .horizontal,
 #amplitudeIndicator .crosshair .vertical {
@@ -382,7 +395,7 @@ body {
 #amplitudeIndicator .crosshair .horizontal {
   top: 50%;
   left: 0;
-  width: 30px;
+  width: 100%;
   height: 3px;
   transform: translateY(-50%);
 }
@@ -390,7 +403,7 @@ body {
   left: 50%;
   top: 0;
   width: 3px;
-  height: 30px;
+  height: 100%;
   transform: translateX(-50%);
 }
 #amplitudeAngleDisplay {


### PR DESCRIPTION
## Summary
- Style aiming amplitude indicator as a pendulum-like crosshair hanging on a rope.
- Animate crosshair swing using rotation based on amplitude.

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4d0c89bcc832d82b6355307fde365