### PR TITLE
Shrink crosshair indicator and extend rope

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -368,10 +368,10 @@ body {
 }
 #amplitudeIndicator .crosshair {
   position: absolute;
-  top: 20px;
+  top: 35px;
   left: 50%;
-  width: 60px;
-  height: 60px;
+  width: 30px;
+  height: 30px;
   border: 3px solid #6c757d;
   border-radius: 50%;
   transform-origin: 50% 0;
@@ -380,10 +380,10 @@ body {
 #amplitudeIndicator .crosshair::before {
   content: "";
   position: absolute;
-  top: -20px;
+  top: -40px;
   left: 50%;
   width: 2px;
-  height: 20px;
+  height: 40px;
   background-color: #6c757d;
   transform: translateX(-50%);
 }


### PR DESCRIPTION
## Summary
- Reduce aiming crosshair size by half and reposition to stay centered
- Extend the crosshair's rope for clearer amplitude indication

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d462c214832d8e90d9e023ad8c6f