### PR TITLE
Fix amplitude crosshair rotation pivot

### DIFF
--- a/script.js
+++ b/script.js
@@ -1910,7 +1910,7 @@ function updateAmplitudeIndicator(){
   if(!sight) return;
 
   const angleDeg = aimingAmplitude * Math.sin(oscillationPhase);
-  sight.style.transform = `translateX(-50%) rotate(${angleDeg}deg)`;
+  sight.style.transform = `rotate(${angleDeg}deg) translateX(-50%)`;
 
   const disp = document.getElementById("amplitudeAngleDisplay");
   if(disp){


### PR DESCRIPTION
## Summary
- Rotate amplitude indicator crosshair around the rope's top to simulate weight

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dfdf41dc832db35bd8feac68efad