### PR TITLE
Fix amplitude indicator to swing from fixed anchor

### DIFF
--- a/script.js
+++ b/script.js
@@ -1910,7 +1910,7 @@ function updateAmplitudeIndicator(){
   if(!sight) return;
 
   const angleDeg = aimingAmplitude * Math.sin(oscillationPhase);
-  sight.style.transform = `translateX(-50%) rotate(${angleDeg}deg)`;
+  sight.style.transform = `rotate(${angleDeg}deg)`;
 
   const disp = document.getElementById("amplitudeAngleDisplay");
   if(disp){

--- a/styles.css
+++ b/styles.css
@@ -368,14 +368,14 @@ body {
 }
 #amplitudeIndicator .crosshair {
   position: absolute;
-  top: 35px;
+  top: 40px;
   left: 50%;
   width: 30px;
   height: 30px;
+  margin-left: -15px;
   border: 3px solid #6c757d;
   border-radius: 50%;
-  transform-origin: 50% 0;
-  transform: translateX(-50%);
+  transform-origin: 50% -40px;
 }
 #amplitudeIndicator .crosshair::before {
   content: "";


### PR DESCRIPTION
## Summary
- anchor aiming amplitude indicator's rope to a static top point
- rotate crosshair around the anchor so it swings like a pendulum

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e6effdd0832db7f1dfea86814439