### PR TITLE
Enhance amplitude indicator crosshair

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,8 @@
           <div class="control-label">Aiming Amplitude</div>
           <div id="amplitudeIndicator" class="control-visual">
             <div class="crosshair">
+              <div class="inner-circle"></div>
+              <div class="center-dot"></div>
               <div class="horizontal"></div>
               <div class="vertical"></div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -387,23 +387,45 @@ body {
   background-color: #6c757d;
   transform: translateX(-50%);
 }
+#amplitudeIndicator .crosshair .inner-circle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 12px;
+  height: 12px;
+  border: 2px solid #6c757d;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+#amplitudeIndicator .crosshair .center-dot {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 4px;
+  height: 4px;
+  background-color: #ee0000;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+}
 #amplitudeIndicator .crosshair .horizontal,
 #amplitudeIndicator .crosshair .vertical {
   position: absolute;
   background-color: #6c757d;
+  z-index: 1;
 }
 #amplitudeIndicator .crosshair .horizontal {
   top: 50%;
-  left: 0;
-  width: 100%;
+  left: -6px;
+  width: calc(100% + 12px);
   height: 3px;
   transform: translateY(-50%);
 }
 #amplitudeIndicator .crosshair .vertical {
   left: 50%;
-  top: 0;
+  top: -6px;
   width: 3px;
-  height: 100%;
+  height: calc(100% + 12px);
   transform: translateX(-50%);
 }
 #amplitudeAngleDisplay {


### PR DESCRIPTION
## Summary
- Add inner ring and central red dot to amplitude indicator crosshair
- Extend crosshair lines slightly beyond the outer ring for clearer aiming

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a57a7553c8832dbfddbfc07144b6a5