### PR TITLE
Shrink flight range and aiming amplitude controls

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -180,7 +180,7 @@ body {
   padding: 10px;
   width: 100%;
   display: grid;
-  grid-template-rows: auto 120px auto auto;
+  grid-template-rows: auto 80px auto auto;
   place-items: center;
   box-shadow: 0 4px 8px rgba(0,0,0,0.1);
   box-sizing: border-box;
@@ -198,7 +198,7 @@ body {
 }
 
 #modeMenu .control-box > .control-visual {
-  height: 120px;
+  height: 80px;
   width: 100%;
   display: flex;
   justify-content: center;
@@ -360,8 +360,8 @@ body {
 
 #amplitudeIndicator {
   position: relative;
-  width: 100px;
-  height: 100px;
+  width: 80px;
+  height: 80px;
   margin: auto;
   max-width: 100%;
   max-height: 100%;


### PR DESCRIPTION
## Summary
- Reduce control box visual height from 120px to 80px for streamlined layout
- Scale aiming amplitude indicator to 80px

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60b5201d4832d8893103ebce3c02b