### PR TITLE
Add visual wind and clouds

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,12 +90,12 @@
           <div class="control-label">Map</div>
           <div id="mapNameDisplay" class="control-value">
             <span id="mapNameValue">wall</span>
-            <div class="aa-toggle">
-              <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
-            </div>
-            <div class="aa-toggle">
-              <label><input type="checkbox" id="weatherToggle" /> Weather</label>
-            </div>
+          </div>
+          <div class="aa-toggle">
+            <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
+          </div>
+          <div class="aa-toggle">
+            <label><input type="checkbox" id="weatherToggle" /> Weather</label>
           </div>
           <div class="control-buttons">
             <button id="mapMinus" class="control-btn">−</button>

--- a/index.html
+++ b/index.html
@@ -93,6 +93,9 @@
             <div class="aa-toggle">
               <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
             </div>
+            <div class="aa-toggle">
+              <label><input type="checkbox" id="weatherToggle" /> Weather</label>
+            </div>
           </div>
           <div class="control-buttons">
             <button id="mapMinus" class="control-btn">−</button>

--- a/script.js
+++ b/script.js
@@ -31,6 +31,7 @@ const mapPlusBtn    = document.getElementById("mapPlus");
 const amplitudeMinusBtn   = document.getElementById("amplitudeMinus");
 const amplitudePlusBtn    = document.getElementById("amplitudePlus");
 const addAAToggle         = document.getElementById("addAAToggle");
+const weatherToggle       = document.getElementById("weatherToggle");
 
 const endGameDiv  = document.getElementById("endGameButtons");
 const yesBtn      = document.getElementById("yesButton");
@@ -128,6 +129,11 @@ let aaUnits     = [];
 let aaPlacementPreview = null;
 let aaPreviewTrail = [];
 
+// Weather visuals
+let windSystems = [];
+let windParticles = [];
+let clouds = [];
+
 
 let aaPointerDown = false;
 
@@ -141,7 +147,8 @@ let phase = "MENU"; // MENU | AA_PLACEMENT (Anti-Aircraft placement) | ROUND_STA
 let currentPlacer = null; // 'green' | 'blue'
 
 let settings = {
-  addAA: localStorage.getItem('settings.addAA') === 'true'
+  addAA: localStorage.getItem('settings.addAA') === 'true',
+  weather: localStorage.getItem('settings.weather') !== 'false'
 };
 
 
@@ -186,6 +193,31 @@ function makePlane(x,y,color,angle){
   };
 }
 
+function initWeather(){
+  windSystems = [
+    { x: gameCanvas.width * 0.3, y: gameCanvas.height * 0.3, strength: 4000, dir: 1 },
+    { x: gameCanvas.width * 0.7, y: gameCanvas.height * 0.6, strength: 4000, dir: -1 }
+  ];
+
+  windParticles = [];
+  for (let i = 0; i < 40; i++) {
+    windParticles.push({
+      x: Math.random() * gameCanvas.width,
+      y: Math.random() * gameCanvas.height
+    });
+  }
+
+  clouds = [];
+  for (let i = 0; i < 5; i++) {
+    clouds.push({
+      x: Math.random() * gameCanvas.width,
+      y: Math.random() * gameCanvas.height * 0.5,
+      size: 30 + Math.random() * 40,
+      speed: 0.1 + Math.random() * 0.3
+    });
+  }
+}
+
 function resetGame(){
   isGameOver= false;
   winnerColor= null;
@@ -199,6 +231,13 @@ function resetGame(){
   buildings = [];
   mapIndex = 1;
   applyCurrentMap();
+  if (settings.weather) {
+    initWeather();
+  } else {
+    windSystems = [];
+    windParticles = [];
+    clouds = [];
+  }
   aaUnits = [];
 
   hasShotThisRound = false;
@@ -494,6 +533,51 @@ function placeAA({owner,x,y}){
     dwellTimeMs: AA_DEFAULTS.dwellTimeMs,
     trail: []
   });
+}
+
+function drawClouds(){
+  gameCtx.save();
+  gameCtx.fillStyle = 'rgba(255,255,255,0.8)';
+  for(const c of clouds){
+    c.x += c.speed;
+    if(c.x - c.size > gameCanvas.width){
+      c.x = -c.size;
+      c.y = Math.random() * gameCanvas.height * 0.5;
+    }
+    gameCtx.beginPath();
+    gameCtx.ellipse(c.x, c.y, c.size, c.size * 0.6, 0, 0, Math.PI * 2);
+    gameCtx.fill();
+  }
+  gameCtx.restore();
+}
+
+function drawWind(){
+  gameCtx.save();
+  gameCtx.strokeStyle = 'rgba(150,150,255,0.7)';
+  gameCtx.lineWidth = 1;
+  for(const p of windParticles){
+    let vx = 0, vy = 0;
+    for(const sys of windSystems){
+      const dx = p.x - sys.x;
+      const dy = p.y - sys.y;
+      const distSq = dx * dx + dy * dy + 1;
+      const factor = sys.strength / distSq;
+      vx += -dy * sys.dir * factor;
+      vy += dx * sys.dir * factor;
+    }
+    p.x += vx;
+    p.y += vy;
+    if(p.x < 0) p.x = gameCanvas.width;
+    if(p.x > gameCanvas.width) p.x = 0;
+    if(p.y < 0) p.y = gameCanvas.height;
+    if(p.y > gameCanvas.height) p.y = 0;
+
+    gameCtx.beginPath();
+    gameCtx.moveTo(p.x, p.y);
+    gameCtx.lineTo(p.x - vx * 2, p.y - vy * 2);
+    gameCtx.stroke();
+  }
+  gameCtx.restore();
 }
 
 function drawAAPlacementZone(){
@@ -1048,6 +1132,10 @@ function handleAAForPlane(p, fp){
   // фон
   gameCtx.clearRect(0,0, gameCanvas.width, gameCanvas.height);
   drawNotebookBackground(gameCtx, gameCanvas.width, gameCanvas.height);
+  if (settings.weather) {
+    drawClouds();
+    drawWind();
+  }
   aimCtx.clearRect(0,0, aimCanvas.width, aimCanvas.height);
 
   // Планирование хода ИИ
@@ -1746,6 +1834,21 @@ if (addAAToggle) {
   });
 }
 
+if (weatherToggle) {
+  weatherToggle.checked = settings.weather;
+  weatherToggle.addEventListener('change', (e)=>{
+    settings.weather = e.target.checked;
+    localStorage.setItem('settings.weather', settings.weather);
+    if (settings.weather) {
+      initWeather();
+    } else {
+      windSystems = [];
+      windParticles = [];
+      clouds = [];
+    }
+  });
+}
+
 /* Flight Range */
 setupRepeatButton(flightRangeMinusBtn, ()=>{
   if(flightRangeCells > MIN_FLIGHT_RANGE_CELLS){
@@ -2028,6 +2131,14 @@ function resizeCanvas() {
   aimCanvas.style.height = window.innerHeight + 'px';
   aimCanvas.width = window.innerWidth;
   aimCanvas.height = window.innerHeight;
+
+  if (settings.weather) {
+    initWeather();
+  } else {
+    windSystems = [];
+    windParticles = [];
+    clouds = [];
+  }
 
   // Переинициализируем самолёты
   if(points.length === 0) {

--- a/styles.css
+++ b/styles.css
@@ -187,7 +187,7 @@ body {
 }
 
 #modeMenu #mapControl {
-  grid-template-rows: auto auto auto;
+  grid-template-rows: auto auto auto auto auto;
 }
 
 #modeMenu .control-box > .control-label {


### PR DESCRIPTION
## Summary
- Introduce weather visuals: drifting clouds and particle-based wind driven by cyclones and anticyclones
- Render weather each frame and reinitialize on canvas resize
- Add menu toggle to enable or disable weather effects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60c9fea64832db735761680f1428a