### PR TITLE
Remove wind and render clouds above gameplay

### DIFF
--- a/script.js
+++ b/script.js
@@ -194,24 +194,14 @@ function makePlane(x,y,color,angle){
 }
 
 function initWeather(){
-  windSystems = [
-    { x: gameCanvas.width * 0.3, y: gameCanvas.height * 0.3, strength: 4000, dir: 1 },
-    { x: gameCanvas.width * 0.7, y: gameCanvas.height * 0.6, strength: 4000, dir: -1 }
-  ];
-
+  windSystems = [];
   windParticles = [];
-  for (let i = 0; i < 40; i++) {
-    windParticles.push({
-      x: Math.random() * gameCanvas.width,
-      y: Math.random() * gameCanvas.height
-    });
-  }
 
   clouds = [];
   for (let i = 0; i < 5; i++) {
     clouds.push({
       x: Math.random() * gameCanvas.width,
-      y: Math.random() * gameCanvas.height * 0.5,
+      y: Math.random() * gameCanvas.height,
       size: 30 + Math.random() * 40,
       speed: 0.1 + Math.random() * 0.3
     });
@@ -544,40 +534,11 @@ function drawClouds(){
     c.x += c.speed;
     if(c.x - c.size > gameCanvas.width){
       c.x = -c.size;
-      c.y = Math.random() * gameCanvas.height * 0.5;
+      c.y = Math.random() * gameCanvas.height;
     }
     gameCtx.beginPath();
     gameCtx.ellipse(c.x, c.y, c.size, c.size * 0.6, 0, 0, Math.PI * 2);
     gameCtx.fill();
-  }
-  gameCtx.restore();
-}
-
-function drawWind(){
-  gameCtx.save();
-  gameCtx.strokeStyle = 'rgba(150,150,255,0.7)';
-  gameCtx.lineWidth = 1;
-  for(const p of windParticles){
-    let vx = 0, vy = 0;
-    for(const sys of windSystems){
-      const dx = p.x - sys.x;
-      const dy = p.y - sys.y;
-      const distSq = dx * dx + dy * dy + 1;
-      const factor = sys.strength / distSq;
-      vx += -dy * sys.dir * factor;
-      vy += dx * sys.dir * factor;
-    }
-    p.x += vx;
-    p.y += vy;
-    if(p.x < 0) p.x = gameCanvas.width;
-    if(p.x > gameCanvas.width) p.x = 0;
-    if(p.y < 0) p.y = gameCanvas.height;
-    if(p.y > gameCanvas.height) p.y = 0;
-
-    gameCtx.beginPath();
-    gameCtx.moveTo(p.x, p.y);
-    gameCtx.lineTo(p.x - vx * 2, p.y - vy * 2);
-    gameCtx.stroke();
   }
   gameCtx.restore();
 }
@@ -1135,11 +1096,6 @@ function handleAAForPlane(p, fp){
   gameCtx.clearRect(0,0, gameCanvas.width, gameCanvas.height);
   drawNotebookBackground(gameCtx, gameCanvas.width, gameCanvas.height);
 
-  if (settings.weather) {
-    drawClouds();
-    drawWind();
-  }
-
   aimCtx.clearRect(0,0, aimCanvas.width, aimCanvas.height);
 
   // Планирование хода ИИ
@@ -1361,6 +1317,10 @@ function handleAAForPlane(p, fp){
     gameCtx.fillText(text, (gameCanvas.width - w)/2, gameCanvas.height/2 - 80);
 
     endGameDiv.style.display="block";
+  }
+
+  if (settings.weather) {
+    drawClouds();
   }
 
   animationFrameId = requestAnimationFrame(gameDraw);


### PR DESCRIPTION
## Summary
- drop wind systems and particles
- allow clouds across entire field and render them above gameplay

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a612c7cd90832d911eba0d7b8016fc