### PR TITLE
Add parachute animation for blue turns

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,9 @@
   <!-- Overlay canvas for aiming line -->
   <canvas id="aimCanvas" style="display:none;"></canvas>
 
+  <!-- Parachute animation -->
+  <img id="parachute" src="parachute.gif" alt="parachute" />
+
   <!-- Game Mode Selection Menu -->
   <div id="modeMenu">
     <h1 class="game-title">Paper Wings!</h1>

--- a/script.js
+++ b/script.js
@@ -36,6 +36,7 @@ const endGameDiv  = document.getElementById("endGameButtons");
 const yesBtn      = document.getElementById("yesButton");
 const noBtn       = document.getElementById("noButton");
 const flame       = document.getElementById("flame");
+const parachuteImg = document.getElementById("parachute");
 
 
 /* Disable pinch and double-tap zoom on mobile */
@@ -263,6 +264,42 @@ function startGameLoop(){
   }
 }
 
+/* ======= PARACHUTE ======= */
+function startParachuteAnimation(){
+  const img = parachuteImg;
+  if(!img) return;
+  const rect = gameCanvas.getBoundingClientRect();
+  img.style.display = "block";
+  const imgW = img.naturalWidth;
+  const imgH = img.naturalHeight;
+  img.style.left = (rect.left + rect.width/2 - imgW/2) + "px";
+  img.style.top = (rect.top - imgH) + "px";
+  img.style.opacity = "1";
+
+  const targetY = rect.top + rect.height/2 - imgH/2;
+  function step(){
+    const currentY = parseFloat(img.style.top);
+    if(currentY < targetY){
+      img.style.top = Math.min(currentY + 2, targetY) + "px";
+      requestAnimationFrame(step);
+    } else {
+      img.style.transition = "opacity 0.5s";
+      img.style.opacity = "0";
+      setTimeout(()=>{
+        img.style.display = "none";
+        img.style.transition = "";
+      }, 500);
+    }
+  }
+  requestAnimationFrame(step);
+}
+
+function maybeStartParachute(){
+  if(turnColors[turnIndex] === "blue"){
+    startParachuteAnimation();
+  }
+}
+
 /* ======= MENU ======= */
 hotSeatBtn.addEventListener("click",()=>{
   selectedMode = (selectedMode==="hotSeat" ? null : "hotSeat");
@@ -308,6 +345,9 @@ playBtn.addEventListener("click",()=>{
     phase = 'TURN';
   }
   startGameLoop();
+  if(phase === 'TURN'){
+    maybeStartParachute();
+  }
 });
 
 /* Меню: анимация индикатора амплитуды */
@@ -404,6 +444,7 @@ function handleAAPlacement(x, y){
     currentPlacer = 'blue';
   } else {
     phase = 'TURN';
+    maybeStartParachute();
   }
 }
 
@@ -980,6 +1021,7 @@ function destroyPlane(fp){
     if(gameMode === "computer" && turnColors[turnIndex] === "blue"){
       aiMoveScheduled = false;
     }
+    maybeStartParachute();
   }
 }
 
@@ -1027,6 +1069,7 @@ function handleAAForPlane(p, fp){
                 if(gameMode==="computer" && turnColors[turnIndex]==="blue"){
                   aiMoveScheduled = false;
                 }
+                maybeStartParachute();
               }
               return true;
             }
@@ -1148,6 +1191,7 @@ function handleAAForPlane(p, fp){
           if(gameMode==="computer" && turnColors[turnIndex]==="blue"){
             aiMoveScheduled = false; // разрешаем планирование следующего хода ИИ
           }
+          maybeStartParachute();
         }
       }
     }
@@ -1903,6 +1947,9 @@ function startNewRound(){
     phase = 'TURN';
   }
   if(animationFrameId===null) startGameLoop();
+  if(phase === 'TURN'){
+    maybeStartParachute();
+  }
 }
 
 /* ======= UI Helpers (амплитуда) ======= */

--- a/styles.css
+++ b/styles.css
@@ -69,6 +69,13 @@ body {
   z-index: 10;
 }
 
+#parachute {
+  position: absolute;
+  display: none;
+  pointer-events: none;
+  z-index: 20;
+}
+
 /* Меню выбора режима */
 #modeMenu {
   position: fixed;


### PR DESCRIPTION
## Summary
- Display a parachute gif that drops into the field at the start of each blue turn
- Style and animate the parachute so it falls to mid-field then fades out

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a808d9d0d4832dbdc9c2bcef70e4a6