### PR TITLE
Reduce blue plane idle flame size and flicker

### DIFF
--- a/script.js
+++ b/script.js
@@ -1463,7 +1463,7 @@ function drawThinPlane(ctx2d, plane){
   if(color === "blue"){
 
     const flicker = 1 + 0.2 * Math.sin(globalFrame * 0.1);
-    const idleScale = 2 * flicker;
+    const idleScale = flicker;
     drawJetFlame(ctx2d, idleScale);
 
     const fp = flyingPoints.find(fp => fp.plane === plane);


### PR DESCRIPTION
## Summary
- Restore flight range indicator flame dimensions and animation
- Halve stationary blue plane's flame size and flicker amplitude

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e85d9098832d8488cbdf650bc1be