### PR TITLE
Restore original flight range flame animation size

### DIFF
--- a/script.js
+++ b/script.js
@@ -2081,8 +2081,8 @@ function updateFlightRangeFlame(){
 
 
   if(flame){
-    const baseWidth = 20;  // matches CSS default
-    const baseHeight = 6; // matches CSS default
+    const baseWidth = 40;  // matches CSS default
+    const baseHeight = 12; // matches CSS default
     flame.style.width = `${baseWidth * ratio}px`;
     flame.style.height = `${baseHeight * (0.9 + 0.1 * ratio)}px`;
   }

--- a/styles.css
+++ b/styles.css
@@ -260,9 +260,9 @@ body {
   right: calc(100% + 2px);
   top: 50%;
 
-  width: 20px;
+  width: 40px;
 
-  height: 6px;
+  height: 12px;
   transform: translateY(-50%);
   transform-origin: right center;
   animation: flame-flicker 0.15s infinite alternate;
@@ -324,10 +324,10 @@ body {
 @keyframes flame-flicker {
   from {
     transform: translateY(-50%) scaleX(1) scaleY(1);
-    opacity: 0.925;
+    opacity: 0.85;
   }
   to {
-    transform: translateY(-50%) scaleX(1.05) scaleY(0.95);
+    transform: translateY(-50%) scaleX(1.1) scaleY(0.9);
     opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary
- Revert flight range indicator flame to its original size
- Restore stronger flicker animation for idle flame

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ee2fe6ac832db5970aeb0deef9dc