### PR TITLE
Use green plane sprite

### DIFF
--- a/script.js
+++ b/script.js
@@ -37,9 +37,12 @@ const yesBtn      = document.getElementById("yesButton");
 const noBtn       = document.getElementById("noButton");
 const menuFlame   = document.getElementById("menuFlame");
 
-// Image for blue plane (updated PNG asset)
+// Images for planes
 const bluePlaneImg = new Image();
 bluePlaneImg.src = "blue plane 23.3.png";
+
+const greenPlaneImg = new Image();
+greenPlaneImg.src = "green plane.png";
 
 
 
@@ -1405,9 +1408,10 @@ function drawFieldEdges(ctx2d, w, h){
 
 function drawJetFlame(ctx2d, widthScale){
   if(widthScale <= 0) return;
+  const BASE_SCALE = 1.5;
   ctx2d.save();
   ctx2d.translate(0, 15);
-  ctx2d.scale(widthScale, 1);
+  ctx2d.scale(widthScale * BASE_SCALE, BASE_SCALE);
   ctx2d.translate(0, -15);
 
   const shimmer = (Math.sin(globalFrame * 0.02) + 1) / 2;
@@ -1458,6 +1462,20 @@ function drawWingTrails(ctx2d){
   ctx2d.stroke();
 }
 
+function drawPlaneOutline(ctx2d, color){
+  ctx2d.strokeStyle = color;
+  ctx2d.lineWidth = 2;
+  ctx2d.beginPath();
+  ctx2d.moveTo(0, -20);
+  ctx2d.lineTo(10, 10);
+  ctx2d.lineTo(5, 10);
+  ctx2d.lineTo(0, 18);
+  ctx2d.lineTo(-5, 10);
+  ctx2d.lineTo(-10, 10);
+  ctx2d.closePath();
+  ctx2d.stroke();
+}
+
 function drawThinPlane(ctx2d, plane){
   const {x: cx, y: cy, color, angle} = plane;
   ctx2d.save();
@@ -1479,30 +1497,16 @@ function drawThinPlane(ctx2d, plane){
     if(bluePlaneImg.complete){
       ctx2d.drawImage(bluePlaneImg, -20, -20, 40, 40);
     } else {
-      ctx2d.strokeStyle = color;
-      ctx2d.lineWidth = 2;
-      ctx2d.beginPath();
-      ctx2d.moveTo(0, -20);
-      ctx2d.lineTo(10, 10);
-      ctx2d.lineTo(5, 10);
-      ctx2d.lineTo(0, 18);
-      ctx2d.lineTo(-5, 10);
-      ctx2d.lineTo(-10, 10);
-      ctx2d.closePath();
-      ctx2d.stroke();
+      drawPlaneOutline(ctx2d, color);
+    }
+  } else if(color === "green"){
+    if(greenPlaneImg.complete){
+      ctx2d.drawImage(greenPlaneImg, -20, -20, 40, 40);
+    } else {
+      drawPlaneOutline(ctx2d, color);
     }
   } else {
-    ctx2d.strokeStyle = color;
-    ctx2d.lineWidth = 2;
-    ctx2d.beginPath();
-    ctx2d.moveTo(0, -20);
-    ctx2d.lineTo(10, 10);
-    ctx2d.lineTo(5, 10);
-    ctx2d.lineTo(0, 18);
-    ctx2d.lineTo(-5, 10);
-    ctx2d.lineTo(-10, 10);
-    ctx2d.closePath();
-    ctx2d.stroke();
+    drawPlaneOutline(ctx2d, color);
   }
   ctx2d.restore();
 }


### PR DESCRIPTION
## Summary
- draw green planes using green plane.png
- refactor plane drawing to reuse outline helper
- enlarge resting blue flame by 1.5x

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa00bc2ae8832da728bf28ac279ec7