### PR TITLE
Use green plane sprite and restore menu flame animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -37,9 +37,12 @@ const yesBtn      = document.getElementById("yesButton");
 const noBtn       = document.getElementById("noButton");
 const menuFlame   = document.getElementById("menuFlame");
 
-// Image for blue plane (updated PNG asset)
+// Images for planes
 const bluePlaneImg = new Image();
 bluePlaneImg.src = "blue plane 23.3.png";
+
+const greenPlaneImg = new Image();
+greenPlaneImg.src = "green plane.png";
 
 
 
@@ -1405,9 +1408,10 @@ function drawFieldEdges(ctx2d, w, h){
 
 function drawJetFlame(ctx2d, widthScale){
   if(widthScale <= 0) return;
+  const BASE_SCALE = 1.5;
   ctx2d.save();
   ctx2d.translate(0, 15);
-  ctx2d.scale(widthScale, 1);
+  ctx2d.scale(widthScale * BASE_SCALE, BASE_SCALE);
   ctx2d.translate(0, -15);
 
   const shimmer = (Math.sin(globalFrame * 0.02) + 1) / 2;
@@ -1458,6 +1462,20 @@ function drawWingTrails(ctx2d){
   ctx2d.stroke();
 }
 
+function drawPlaneOutline(ctx2d, color){
+  ctx2d.strokeStyle = color;
+  ctx2d.lineWidth = 2;
+  ctx2d.beginPath();
+  ctx2d.moveTo(0, -20);
+  ctx2d.lineTo(10, 10);
+  ctx2d.lineTo(5, 10);
+  ctx2d.lineTo(0, 18);
+  ctx2d.lineTo(-5, 10);
+  ctx2d.lineTo(-10, 10);
+  ctx2d.closePath();
+  ctx2d.stroke();
+}
+
 function drawThinPlane(ctx2d, plane){
   const {x: cx, y: cy, color, angle} = plane;
   ctx2d.save();
@@ -1479,30 +1497,16 @@ function drawThinPlane(ctx2d, plane){
     if(bluePlaneImg.complete){
       ctx2d.drawImage(bluePlaneImg, -20, -20, 40, 40);
     } else {
-      ctx2d.strokeStyle = color;
-      ctx2d.lineWidth = 2;
-      ctx2d.beginPath();
-      ctx2d.moveTo(0, -20);
-      ctx2d.lineTo(10, 10);
-      ctx2d.lineTo(5, 10);
-      ctx2d.lineTo(0, 18);
-      ctx2d.lineTo(-5, 10);
-      ctx2d.lineTo(-10, 10);
-      ctx2d.closePath();
-      ctx2d.stroke();
+      drawPlaneOutline(ctx2d, color);
+    }
+  } else if(color === "green"){
+    if(greenPlaneImg.complete){
+      ctx2d.drawImage(greenPlaneImg, -20, -20, 40, 40);
+    } else {
+      drawPlaneOutline(ctx2d, color);
     }
   } else {
-    ctx2d.strokeStyle = color;
-    ctx2d.lineWidth = 2;
-    ctx2d.beginPath();
-    ctx2d.moveTo(0, -20);
-    ctx2d.lineTo(10, 10);
-    ctx2d.lineTo(5, 10);
-    ctx2d.lineTo(0, 18);
-    ctx2d.lineTo(-5, 10);
-    ctx2d.lineTo(-10, 10);
-    ctx2d.closePath();
-    ctx2d.stroke();
+    drawPlaneOutline(ctx2d, color);
   }
   ctx2d.restore();
 }
@@ -2075,8 +2079,8 @@ function updateFlightRangeDisplay(){
 }
 function updateFlightRangeFlame(){
   const trails = document.querySelectorAll("#flightRangeIndicator .wing-trail");
-  const minScale = 0.3;
-  const maxScale = 1.2;
+  const minScale = 0.8;
+  const maxScale = 1.6;
   const t = (flightRangeCells - MIN_FLIGHT_RANGE_CELLS) /
             (MAX_FLIGHT_RANGE_CELLS - MIN_FLIGHT_RANGE_CELLS);
   const ratio = minScale + t * (maxScale - minScale);
@@ -2084,8 +2088,8 @@ function updateFlightRangeFlame(){
 
 
   if(menuFlame){
-    const baseWidth = 20;  // matches CSS default
-    const baseHeight = 6; // matches CSS default
+    const baseWidth = 40;  // matches CSS default
+    const baseHeight = 12; // matches CSS default
     menuFlame.style.width = `${baseWidth * ratio}px`;
     menuFlame.style.height = `${baseHeight * (0.9 + 0.1 * ratio)}px`;
 

--- a/styles.css
+++ b/styles.css
@@ -270,13 +270,13 @@ body {
 
 }
 
-#flameGradient stop:first-child {
-  stop-color: #80d8ff;
+#menuFlameGradient stop:first-child {
+  stop-color: #ff8c00;
 
   animation: flame-color-inner 2s infinite alternate;
 }
-#flameGradient stop:last-child {
-  stop-color: #0066ff;
+#menuFlameGradient stop:last-child {
+  stop-color: #ff0000;
   animation: flame-color-outer 2s infinite alternate;
 
 }
@@ -319,13 +319,13 @@ body {
 }
 
 @keyframes flame-color-inner {
-  from { stop-color: #80d8ff; }
-  to   { stop-color: #ffffff; }
+  from { stop-color: #ff8c00; }
+  to   { stop-color: #ffff66; }
 }
 
 @keyframes flame-color-outer {
-  from { stop-color: #0066ff; }
-  to   { stop-color: #80d8ff; }
+  from { stop-color: #ff0000; }
+  to   { stop-color: #ff8c00; }
 }
 
 /* Цифровой индикатор */


### PR DESCRIPTION
## Summary
- draw green planes using green plane.png
- refactor plane drawing to reuse outline helper
- enlarge resting blue flame by 1.5x
- restore animated red-orange flame on flight range menu indicator

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa00bc2ae8832da728bf28ac279ec7