### PR TITLE
Fix diesel smoke direction and position

### DIFF
--- a/script.js
+++ b/script.js
@@ -1448,7 +1448,7 @@ function drawDieselSmoke(ctx2d, scale){
 
   const baseRadius = 5 * scale;
   ctx2d.save();
-  ctx2d.translate(0, 15);
+  ctx2d.translate(0, 19);
   ctx2d.scale(0.5, 1); // make smoke column narrower
   ctx2d.globalAlpha = 1; // stronger contrast
 
@@ -1457,7 +1457,7 @@ function drawDieselSmoke(ctx2d, scale){
     const flicker = 0.8 + 0.2 * Math.sin(phase);
     const radius  = baseRadius * (0.7 + 0.3 * Math.sin(phase * 0.7)) * flicker;
     const offsetX = Math.sin(phase) * baseRadius * 0.3;
-    const offsetY = -i * baseRadius * 0.9;
+    const offsetY =  i * baseRadius * 0.9;
     ctx2d.beginPath();
     ctx2d.arc(offsetX, offsetY, radius, 0, Math.PI * 2);
     ctx2d.fillStyle = "#000";


### PR DESCRIPTION
## Summary
- Correct diesel smoke offset so exhaust trails behind plane
- Shift stationary smoke four pixels aft of the tail

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aac1cdaf94832d9749915cddbcafea