### PR TITLE
Add dedicated advanced settings page and simplify main menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,78 +32,11 @@
 
     <button id="playBtn" class="disabled" disabled>Play</button>
 
-    <div class="control-group-row">
-      <div class="control-pair-row">
-        <!-- Flight Range Control -->
-        <div class="control-box">
-          <div class="control-label">Flight Range</div>
-          <!-- Самолёт и пламя турбины для индикации дальности -->
-            <div id="flightRangeIndicator" class="control-visual">
-            <div class="jet">
-              <div class="wing-trail top"></div>
-              <div class="wing-trail bottom"></div>
-              <svg class="jet-plane" viewBox="0 0 38 20">
-                <polygon points="38,10 8,20 8,15 0,10 8,5 8,0" />
-              </svg>
-
-              <svg id="menuFlame" class="jet-flame" viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
-                <defs>
-
-                  <radialGradient id="menuFlameGradient" cx="100%" cy="50%" r="60%">
-                    <!-- Inner glow shifted toward orange to restore red-orange flame -->
-                    <stop offset="0%" stop-color="#ff8c00" />
-                    <stop offset="100%" stop-color="#ff0000" />
-
-                  </radialGradient>
-                </defs>
-                <path d="M40 10 C38 2 30 0 22 0 C14 0 6 8 8 14 C10 18 18 20 26 18 C34 16 38 14 40 10 Z" fill="url(#menuFlameGradient)" />
-              </svg>
-
-            </div>
-          </div>
-          <div class="control-value"><span id="flightRangeDisplay">15 cells</span></div>
-          <div class="control-buttons">
-            <button id="flightRangeMinus" class="control-btn">−</button>
-            <button id="flightRangePlus" class="control-btn">+</button>
-          </div>
-        </div>
-
-        <!-- Aiming Amplitude Control -->
-        <div class="control-box">
-          <div class="control-label">Aiming Amplitude</div>
-          <div id="amplitudeIndicator" class="control-visual">
-            <div class="crosshair">
-              <div class="inner-circle"></div>
-              <div class="center-dot"></div>
-              <div class="horizontal"></div>
-              <div class="vertical"></div>
-            </div>
-          </div>
-          <div class="control-value"><span id="amplitudeAngleDisplay">20°</span></div>
-          <div class="control-buttons">
-            <button id="amplitudeMinus" class="control-btn">−</button>
-            <button id="amplitudePlus" class="control-btn">+</button>
-          </div>
-        </div>
-      </div>
-
-
-        <!-- Map Control -->
-        <div class="control-box" id="mapControl">
-          <div class="control-label">Map</div>
-          <div id="mapNameDisplay" class="control-value">
-            <span id="mapNameValue">wall</span>
-          </div>
-          <div class="aa-toggle">
-            <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
-          </div>
-          <div class="control-buttons">
-            <button id="mapMinus" class="control-btn">−</button>
-            <button id="mapPlus" class="control-btn">+</button>
-          </div>
-        </div>
-      </div> <!-- /control-group-row -->
-    </div> <!-- /modeMenu -->
+    <div class="rules-options">
+      <button id="classicRulesBtn" class="rules-btn selected">Classic Rules</button>
+      <button id="advancedSettingsBtn" class="rules-btn">Advanced Settings</button>
+    </div>
+  </div> <!-- /modeMenu -->
 
 
   <!-- End Game Window -->

--- a/script.js
+++ b/script.js
@@ -31,6 +31,8 @@ const mapPlusBtn    = document.getElementById("mapPlus");
 const amplitudeMinusBtn   = document.getElementById("amplitudeMinus");
 const amplitudePlusBtn    = document.getElementById("amplitudePlus");
 const addAAToggle         = document.getElementById("addAAToggle");
+const classicRulesBtn     = document.getElementById("classicRulesBtn");
+const advancedSettingsBtn = document.getElementById("advancedSettingsBtn");
 
 const endGameDiv  = document.getElementById("endGameButtons");
 const yesBtn      = document.getElementById("yesButton");
@@ -109,13 +111,13 @@ const AA_TRAIL_MS = 5000; // radar sweep afterglow duration
 
 
 const MAPS = ["clear sky", "wall", "two walls", "sharp edges"];
-let mapIndex = 1;
+let mapIndex = parseInt(localStorage.getItem('settings.mapIndex')) || 1;
 
-let flightRangeCells = 15;     // значение «в клетках» для меню/физики
+let flightRangeCells = parseInt(localStorage.getItem('settings.flightRangeCells')) || 15;     // значение «в клетках» для меню/физики
 let buildingsCount   = 0;
 
 
-let aimingAmplitude  = 10;     // 0..30 (UI показывает *2)
+let aimingAmplitude  = parseInt(localStorage.getItem('settings.aimingAmplitude')) || 10;     // 0..30 (UI показывает *2)
 
 let isGameOver   = false;
 let winnerColor  = null;
@@ -206,7 +208,6 @@ function resetGame(){
   globalFrame=0;
   flyingPoints= [];
   buildings = [];
-  mapIndex = 1;
   applyCurrentMap();
 
   aaUnits = [];
@@ -252,12 +253,12 @@ function resetGame(){
   renderScoreboard();
 }
 function setControlsEnabled(enabled){
-  flightRangeMinusBtn.disabled = !enabled;
-  flightRangePlusBtn.disabled  = !enabled;
-  mapMinusBtn.disabled   = !enabled;
-  mapPlusBtn.disabled    = !enabled;
-  amplitudeMinusBtn.disabled   = !enabled;
-  amplitudePlusBtn.disabled    = !enabled;
+  if(flightRangeMinusBtn) flightRangeMinusBtn.disabled = !enabled;
+  if(flightRangePlusBtn)  flightRangePlusBtn.disabled  = !enabled;
+  if(mapMinusBtn)   mapMinusBtn.disabled   = !enabled;
+  if(mapPlusBtn)    mapPlusBtn.disabled    = !enabled;
+  if(amplitudeMinusBtn)   amplitudeMinusBtn.disabled   = !enabled;
+  if(amplitudePlusBtn)    amplitudePlusBtn.disabled    = !enabled;
 }
 
 function stopGameLoop(){
@@ -285,6 +286,25 @@ onlineBtn.addEventListener("click",()=>{
   selectedMode = (selectedMode==="online" ? null : "online");
   updateModeSelection();
 });
+if(classicRulesBtn){
+  classicRulesBtn.addEventListener('click', () => {
+    flightRangeCells = 15;
+    aimingAmplitude = 10;
+    mapIndex = 1;
+    settings.addAA = false;
+    localStorage.removeItem('settings.flightRangeCells');
+    localStorage.removeItem('settings.aimingAmplitude');
+    localStorage.removeItem('settings.mapIndex');
+    localStorage.removeItem('settings.addAA');
+    applyCurrentMap();
+    classicRulesBtn.classList.add('selected');
+  });
+}
+if(advancedSettingsBtn){
+  advancedSettingsBtn.addEventListener('click', () => {
+    window.location.href = 'settings.html';
+  });
+}
 function updateModeSelection(){
   hotSeatBtn.classList.toggle("selected", selectedMode==="hotSeat");
   computerBtn.classList.toggle("selected", selectedMode==="computer");
@@ -1875,14 +1895,14 @@ if (addAAToggle) {
 }
 
 /* Flight Range */
-setupRepeatButton(flightRangeMinusBtn, ()=>{
+if(flightRangeMinusBtn) setupRepeatButton(flightRangeMinusBtn, ()=>{
   if(flightRangeCells > MIN_FLIGHT_RANGE_CELLS){
     flightRangeCells--;
     updateFlightRangeFlame();
     updateFlightRangeDisplay();
   }
 });
-setupRepeatButton(flightRangePlusBtn, ()=>{
+if(flightRangePlusBtn) setupRepeatButton(flightRangePlusBtn, ()=>{
   if(flightRangeCells < MAX_FLIGHT_RANGE_CELLS){
     flightRangeCells++;
     updateFlightRangeFlame();
@@ -1891,23 +1911,23 @@ setupRepeatButton(flightRangePlusBtn, ()=>{
 });
 
 /* Map */
-setupRepeatButton(mapMinusBtn, ()=>{
+if(mapMinusBtn) setupRepeatButton(mapMinusBtn, ()=>{
   mapIndex = (mapIndex - 1 + MAPS.length) % MAPS.length;
   applyCurrentMap();
 });
-setupRepeatButton(mapPlusBtn, ()=>{
+if(mapPlusBtn) setupRepeatButton(mapPlusBtn, ()=>{
   mapIndex = (mapIndex + 1) % MAPS.length;
   applyCurrentMap();
 });
 
 /* Aiming amplitude */
-setupRepeatButton(amplitudeMinusBtn, ()=>{
+if(amplitudeMinusBtn) setupRepeatButton(amplitudeMinusBtn, ()=>{
   if(aimingAmplitude > MIN_AMPLITUDE){
     aimingAmplitude--;
     updateAmplitudeDisplay();
   }
 });
-setupRepeatButton(amplitudePlusBtn, ()=>{
+if(amplitudePlusBtn) setupRepeatButton(amplitudePlusBtn, ()=>{
   if(aimingAmplitude < MAX_AMPLITUDE){
     aimingAmplitude++;
     updateAmplitudeDisplay();

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>Advanced Settings - Paper Wings!</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Patrick+Hand&family=Roboto&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div id="modeMenu">
+    <h1 class="game-title">Advanced Settings</h1>
+    <div class="control-group-row">
+      <div class="control-pair-row">
+        <!-- Flight Range Control -->
+        <div class="control-box">
+          <div class="control-label">Flight Range</div>
+          <div id="flightRangeIndicator" class="control-visual">
+            <div class="jet">
+              <div class="wing-trail top"></div>
+              <div class="wing-trail bottom"></div>
+              <svg class="jet-plane" viewBox="0 0 38 20">
+                <polygon points="38,10 8,20 8,15 0,10 8,5 8,0" />
+              </svg>
+              <svg id="menuFlame" class="jet-flame" viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+                <defs>
+                  <radialGradient id="menuFlameGradient" cx="100%" cy="50%" r="60%">
+                    <stop offset="0%" stop-color="#ff8c00" />
+                    <stop offset="100%" stop-color="#ff0000" />
+                  </radialGradient>
+                </defs>
+                <path d="M40 10 C38 2 30 0 22 0 C14 0 6 8 8 14 C10 18 18 20 26 18 C34 16 38 14 40 10 Z" fill="url(#menuFlameGradient)" />
+              </svg>
+            </div>
+          </div>
+          <div class="control-value"><span id="flightRangeDisplay">15 cells</span></div>
+          <div class="control-buttons">
+            <button id="flightRangeMinus" class="control-btn">−</button>
+            <button id="flightRangePlus" class="control-btn">+</button>
+          </div>
+        </div>
+
+        <!-- Aiming Amplitude Control -->
+        <div class="control-box">
+          <div class="control-label">Aiming Amplitude</div>
+          <div id="amplitudeIndicator" class="control-visual">
+            <div class="crosshair">
+              <div class="inner-circle"></div>
+              <div class="center-dot"></div>
+              <div class="horizontal"></div>
+              <div class="vertical"></div>
+            </div>
+          </div>
+          <div class="control-value"><span id="amplitudeAngleDisplay">20°</span></div>
+          <div class="control-buttons">
+            <button id="amplitudeMinus" class="control-btn">−</button>
+            <button id="amplitudePlus" class="control-btn">+</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Map Control -->
+      <div class="control-box" id="mapControl">
+        <div class="control-label">Map</div>
+        <div id="mapNameDisplay" class="control-value">
+          <span id="mapNameValue">wall</span>
+        </div>
+        <div class="aa-toggle">
+          <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
+        </div>
+        <div class="control-buttons">
+          <button id="mapMinus" class="control-btn">−</button>
+          <button id="mapPlus" class="control-btn">+</button>
+        </div>
+      </div>
+    </div>
+    <button id="backBtn" class="mode-btn" style="margin-top:15px;">Back</button>
+  </div>
+  <script src="settings.js"></script>
+</body>
+</html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,161 @@
+const MIN_FLIGHT_RANGE_CELLS = 5;
+const MAX_FLIGHT_RANGE_CELLS = 30;
+const MIN_AMPLITUDE = 0;
+const MAX_AMPLITUDE = 30;
+const MAPS = ["clear sky", "wall", "two walls", "sharp edges"];
+
+let flightRangeCells = parseInt(localStorage.getItem('settings.flightRangeCells')) || 15;
+let aimingAmplitude  = parseInt(localStorage.getItem('settings.aimingAmplitude')) || 10;
+let mapIndex = parseInt(localStorage.getItem('settings.mapIndex')) || 1;
+let addAA = localStorage.getItem('settings.addAA') === 'true';
+
+const flightRangeMinusBtn = document.getElementById('flightRangeMinus');
+const flightRangePlusBtn  = document.getElementById('flightRangePlus');
+const amplitudeMinusBtn   = document.getElementById('amplitudeMinus');
+const amplitudePlusBtn    = document.getElementById('amplitudePlus');
+const mapMinusBtn = document.getElementById('mapMinus');
+const mapPlusBtn  = document.getElementById('mapPlus');
+const addAAToggle = document.getElementById('addAAToggle');
+const backBtn = document.getElementById('backBtn');
+
+function updateFlightRangeDisplay(){
+  const el = document.getElementById('flightRangeDisplay');
+  if(el) el.textContent = `${flightRangeCells} cells`;
+}
+
+function updateFlightRangeFlame(){
+  const trails = document.querySelectorAll('#flightRangeIndicator .wing-trail');
+  const menuFlame = document.getElementById('menuFlame');
+  const minScale = 0.8;
+  const maxScale = 1.6;
+  const t = (flightRangeCells - MIN_FLIGHT_RANGE_CELLS) /
+            (MAX_FLIGHT_RANGE_CELLS - MIN_FLIGHT_RANGE_CELLS);
+  const ratio = minScale + t * (maxScale - minScale);
+  if(menuFlame){
+    const baseWidth = 32;
+    const baseHeight = 10;
+    menuFlame.style.width = `${baseWidth * ratio}px`;
+    menuFlame.style.height = `${baseHeight * (0.9 + 0.1 * ratio)}px`;
+  }
+  if(trails.length){
+    const baseTrailWidth = 35;
+    const baseTrailHeight = 2;
+    trails.forEach(trail => {
+      trail.style.width = `${baseTrailWidth * ratio}px`;
+      trail.style.height = `${baseTrailHeight}px`;
+    });
+  }
+}
+
+function updateAmplitudeDisplay(){
+  const disp = document.getElementById('amplitudeAngleDisplay');
+  if(disp){
+    const maxAngle = aimingAmplitude * 2;
+    disp.textContent = `${maxAngle.toFixed(0)}°`;
+  }
+}
+
+function updateAmplitudeIndicator(){
+  const el = document.getElementById('amplitudeIndicator');
+  if(!el) return;
+  const sight = el.querySelector('.crosshair');
+  if(!sight) return;
+  const angleDeg = aimingAmplitude;
+  sight.style.transform = `rotate(${angleDeg}deg)`;
+}
+
+function updateMapDisplay(){
+  const el = document.getElementById('mapNameValue');
+  if(el) el.textContent = MAPS[mapIndex];
+}
+
+function saveSettings(){
+  localStorage.setItem('settings.flightRangeCells', flightRangeCells);
+  localStorage.setItem('settings.aimingAmplitude', aimingAmplitude);
+  localStorage.setItem('settings.mapIndex', mapIndex);
+  localStorage.setItem('settings.addAA', addAA);
+}
+
+function setupRepeatButton(btn, cb){
+  if(!btn) return;
+  let timeoutId = null;
+  let intervalId = null;
+  const start = () => {
+    cb();
+    timeoutId = setTimeout(() => {
+      intervalId = setInterval(cb, 150);
+    }, 400);
+  };
+  const stop = () => {
+    clearTimeout(timeoutId);
+    clearInterval(intervalId);
+  };
+  btn.addEventListener('mousedown', start);
+  btn.addEventListener('mouseup', stop);
+  btn.addEventListener('mouseleave', stop);
+  btn.addEventListener('touchstart', start);
+  btn.addEventListener('touchend', stop);
+}
+
+if(addAAToggle){
+  addAAToggle.checked = addAA;
+  addAAToggle.addEventListener('change', e => {
+    addAA = e.target.checked;
+    saveSettings();
+  });
+}
+
+setupRepeatButton(flightRangeMinusBtn, () => {
+  if(flightRangeCells > MIN_FLIGHT_RANGE_CELLS){
+    flightRangeCells--;
+    updateFlightRangeFlame();
+    updateFlightRangeDisplay();
+    saveSettings();
+  }
+});
+setupRepeatButton(flightRangePlusBtn, () => {
+  if(flightRangeCells < MAX_FLIGHT_RANGE_CELLS){
+    flightRangeCells++;
+    updateFlightRangeFlame();
+    updateFlightRangeDisplay();
+    saveSettings();
+  }
+});
+setupRepeatButton(amplitudeMinusBtn, () => {
+  if(aimingAmplitude > MIN_AMPLITUDE){
+    aimingAmplitude--;
+    updateAmplitudeDisplay();
+    updateAmplitudeIndicator();
+    saveSettings();
+  }
+});
+setupRepeatButton(amplitudePlusBtn, () => {
+  if(aimingAmplitude < MAX_AMPLITUDE){
+    aimingAmplitude++;
+    updateAmplitudeDisplay();
+    updateAmplitudeIndicator();
+    saveSettings();
+  }
+});
+setupRepeatButton(mapMinusBtn, () => {
+  mapIndex = (mapIndex - 1 + MAPS.length) % MAPS.length;
+  updateMapDisplay();
+  saveSettings();
+});
+setupRepeatButton(mapPlusBtn, () => {
+  mapIndex = (mapIndex + 1) % MAPS.length;
+  updateMapDisplay();
+  saveSettings();
+});
+
+if(backBtn){
+  backBtn.addEventListener('click', () => {
+    window.location.href = 'index.html';
+  });
+}
+
+updateFlightRangeDisplay();
+updateFlightRangeFlame();
+updateAmplitudeDisplay();
+updateAmplitudeIndicator();
+updateMapDisplay();

--- a/styles.css
+++ b/styles.css
@@ -119,6 +119,31 @@ body {
   transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
 }
 
+/* Rules buttons */
+#modeMenu .rules-options {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 15px;
+}
+
+#modeMenu .rules-options .rules-btn {
+  padding: 10px 15px;
+  font-size: 16px;
+  font-weight: bold;
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  background: linear-gradient(145deg, #6c757d, #5a6268);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+}
+
+#modeMenu .rules-options .rules-btn.selected {
+  background: linear-gradient(145deg, #28a745, #218838);
+}
+
 #modeMenu #playBtn {
   width: 100%;
   padding: 12px;


### PR DESCRIPTION
## Summary
- Replace inline flight range, amplitude, map, and AA controls with Classic Rules and Advanced Settings buttons on the main menu
- Introduce a new advanced settings page housing the removed controls and a back button
- Load user settings from localStorage and add navigation helpers for switching between rules modes

## Testing
- `node --check script.js`
- `node --check settings.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1ffb49ec832db390e91bd670e64b