### PR TITLE
Add dedicated advanced settings page and simplify main menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,78 +32,11 @@
 
     <button id="playBtn" class="disabled" disabled>Play</button>
 
-    <div class="control-group-row">
-      <div class="control-pair-row">
-        <!-- Flight Range Control -->
-        <div class="control-box">
-          <div class="control-label">Flight Range</div>
-          <!-- Самолёт и пламя турбины для индикации дальности -->
-            <div id="flightRangeIndicator" class="control-visual">
-            <div class="jet">
-              <div class="wing-trail top"></div>
-              <div class="wing-trail bottom"></div>
-              <svg class="jet-plane" viewBox="0 0 38 20">
-                <polygon points="38,10 8,20 8,15 0,10 8,5 8,0" />
-              </svg>
-
-              <svg id="menuFlame" class="jet-flame" viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
-                <defs>
-
-                  <radialGradient id="menuFlameGradient" cx="100%" cy="50%" r="60%">
-                    <!-- Inner glow shifted toward orange to restore red-orange flame -->
-                    <stop offset="0%" stop-color="#ff8c00" />
-                    <stop offset="100%" stop-color="#ff0000" />
-
-                  </radialGradient>
-                </defs>
-                <path d="M40 10 C38 2 30 0 22 0 C14 0 6 8 8 14 C10 18 18 20 26 18 C34 16 38 14 40 10 Z" fill="url(#menuFlameGradient)" />
-              </svg>
-
-            </div>
-          </div>
-          <div class="control-value"><span id="flightRangeDisplay">15 cells</span></div>
-          <div class="control-buttons">
-            <button id="flightRangeMinus" class="control-btn">−</button>
-            <button id="flightRangePlus" class="control-btn">+</button>
-          </div>
-        </div>
-
-        <!-- Aiming Amplitude Control -->
-        <div class="control-box">
-          <div class="control-label">Aiming Amplitude</div>
-          <div id="amplitudeIndicator" class="control-visual">
-            <div class="crosshair">
-              <div class="inner-circle"></div>
-              <div class="center-dot"></div>
-              <div class="horizontal"></div>
-              <div class="vertical"></div>
-            </div>
-          </div>
-          <div class="control-value"><span id="amplitudeAngleDisplay">20°</span></div>
-          <div class="control-buttons">
-            <button id="amplitudeMinus" class="control-btn">−</button>
-            <button id="amplitudePlus" class="control-btn">+</button>
-          </div>
-        </div>
-      </div>
-
-
-        <!-- Map Control -->
-        <div class="control-box" id="mapControl">
-          <div class="control-label">Map</div>
-          <div id="mapNameDisplay" class="control-value">
-            <span id="mapNameValue">wall</span>
-          </div>
-          <div class="aa-toggle">
-            <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
-          </div>
-          <div class="control-buttons">
-            <button id="mapMinus" class="control-btn">−</button>
-            <button id="mapPlus" class="control-btn">+</button>
-          </div>
-        </div>
-      </div> <!-- /control-group-row -->
-    </div> <!-- /modeMenu -->
+    <div class="rules-options">
+      <button id="classicRulesBtn" class="rules-btn selected">Classic Rules</button>
+      <button id="advancedSettingsBtn" class="rules-btn">Advanced Settings</button>
+    </div>
+  </div> <!-- /modeMenu -->
 
 
   <!-- End Game Window -->

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>Advanced Settings - Paper Wings!</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Patrick+Hand&family=Roboto&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div id="modeMenu">
+    <h1 class="game-title">Advanced Settings</h1>
+    <div class="control-group-row">
+      <div class="control-pair-row">
+        <!-- Flight Range Control -->
+        <div class="control-box">
+          <div class="control-label">Flight Range</div>
+          <div id="flightRangeIndicator" class="control-visual">
+            <div class="jet">
+              <div class="wing-trail top"></div>
+              <div class="wing-trail bottom"></div>
+              <svg class="jet-plane" viewBox="0 0 38 20">
+                <polygon points="38,10 8,20 8,15 0,10 8,5 8,0" />
+              </svg>
+              <svg id="menuFlame" class="jet-flame" viewBox="0 0 40 20" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+                <defs>
+                  <radialGradient id="menuFlameGradient" cx="100%" cy="50%" r="60%">
+                    <stop offset="0%" stop-color="#ff8c00" />
+                    <stop offset="100%" stop-color="#ff0000" />
+                  </radialGradient>
+                </defs>
+                <path d="M40 10 C38 2 30 0 22 0 C14 0 6 8 8 14 C10 18 18 20 26 18 C34 16 38 14 40 10 Z" fill="url(#menuFlameGradient)" />
+              </svg>
+            </div>
+          </div>
+          <div class="control-value"><span id="flightRangeDisplay">15 cells</span></div>
+          <div class="control-buttons">
+            <button id="flightRangeMinus" class="control-btn">−</button>
+            <button id="flightRangePlus" class="control-btn">+</button>
+          </div>
+        </div>
+
+        <!-- Aiming Amplitude Control -->
+        <div class="control-box">
+          <div class="control-label">Aiming Amplitude</div>
+          <div id="amplitudeIndicator" class="control-visual">
+            <div class="crosshair">
+              <div class="inner-circle"></div>
+              <div class="center-dot"></div>
+              <div class="horizontal"></div>
+              <div class="vertical"></div>
+            </div>
+          </div>
+          <div class="control-value"><span id="amplitudeAngleDisplay">20°</span></div>
+          <div class="control-buttons">
+            <button id="amplitudeMinus" class="control-btn">−</button>
+            <button id="amplitudePlus" class="control-btn">+</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Map Control -->
+      <div class="control-box" id="mapControl">
+        <div class="control-label">Map</div>
+        <div id="mapNameDisplay" class="control-value">
+          <span id="mapNameValue">wall</span>
+        </div>
+        <div class="aa-toggle">
+          <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
+        </div>
+        <div class="control-buttons">
+          <button id="mapMinus" class="control-btn">−</button>
+          <button id="mapPlus" class="control-btn">+</button>
+        </div>
+      </div>
+    </div>
+    <button id="backBtn" class="mode-btn" style="margin-top:15px;">Back</button>
+  </div>
+  <script src="settings.js"></script>
+</body>
+</html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,158 @@
+const MIN_FLIGHT_RANGE_CELLS = 5;
+const MAX_FLIGHT_RANGE_CELLS = 30;
+const MIN_AMPLITUDE = 0;
+const MAX_AMPLITUDE = 30;
+const MAPS = ["clear sky", "wall", "two walls", "sharp edges"];
+
+let flightRangeCells = parseInt(localStorage.getItem('settings.flightRangeCells')) || 15;
+let aimingAmplitude  = parseInt(localStorage.getItem('settings.aimingAmplitude')) || 10;
+let mapIndex = parseInt(localStorage.getItem('settings.mapIndex')) || 1;
+let addAA = localStorage.getItem('settings.addAA') === 'true';
+
+const flightRangeMinusBtn = document.getElementById('flightRangeMinus');
+const flightRangePlusBtn  = document.getElementById('flightRangePlus');
+const amplitudeMinusBtn   = document.getElementById('amplitudeMinus');
+const amplitudePlusBtn    = document.getElementById('amplitudePlus');
+const mapMinusBtn = document.getElementById('mapMinus');
+const mapPlusBtn  = document.getElementById('mapPlus');
+const addAAToggle = document.getElementById('addAAToggle');
+const backBtn = document.getElementById('backBtn');
+
+function updateFlightRangeDisplay(){
+  const el = document.getElementById('flightRangeDisplay');
+  if(el) el.textContent = `${flightRangeCells} cells`;
+}
+
+function updateFlightRangeFlame(){
+  const trails = document.querySelectorAll('#flightRangeIndicator .wing-trail');
+  const menuFlame = document.getElementById('menuFlame');
+  const minScale = 0.8;
+  const maxScale = 1.6;
+  const t = (flightRangeCells - MIN_FLIGHT_RANGE_CELLS) /
+            (MAX_FLIGHT_RANGE_CELLS - MIN_FLIGHT_RANGE_CELLS);
+  const ratio = minScale + t * (maxScale - minScale);
+  if(menuFlame){
+    const baseWidth = 32;
+    const baseHeight = 10;
+    menuFlame.style.width = `${baseWidth * ratio}px`;
+    menuFlame.style.height = `${baseHeight * (0.9 + 0.1 * ratio)}px`;
+  }
+  if(trails.length){
+    const baseTrailWidth = 35;
+    const baseTrailHeight = 2;
+    trails.forEach(trail => {
+      trail.style.width = `${baseTrailWidth * ratio}px`;
+      trail.style.height = `${baseTrailHeight}px`;
+    });
+  }
+}
+
+function updateAmplitudeDisplay(){
+  const disp = document.getElementById('amplitudeAngleDisplay');
+  if(disp){
+    const maxAngle = aimingAmplitude * 2;
+    disp.textContent = `${maxAngle.toFixed(0)}°`;
+  }
+}
+
+function updateAmplitudeIndicator(){
+  const el = document.getElementById('amplitudeIndicator');
+  if(!el) return;
+  el.style.setProperty('--amp', `${aimingAmplitude}deg`);
+}
+
+function updateMapDisplay(){
+  const el = document.getElementById('mapNameValue');
+  if(el) el.textContent = MAPS[mapIndex];
+}
+
+function saveSettings(){
+  localStorage.setItem('settings.flightRangeCells', flightRangeCells);
+  localStorage.setItem('settings.aimingAmplitude', aimingAmplitude);
+  localStorage.setItem('settings.mapIndex', mapIndex);
+  localStorage.setItem('settings.addAA', addAA);
+}
+
+function setupRepeatButton(btn, cb){
+  if(!btn) return;
+  let timeoutId = null;
+  let intervalId = null;
+  const start = () => {
+    cb();
+    timeoutId = setTimeout(() => {
+      intervalId = setInterval(cb, 150);
+    }, 400);
+  };
+  const stop = () => {
+    clearTimeout(timeoutId);
+    clearInterval(intervalId);
+  };
+  btn.addEventListener('mousedown', start);
+  btn.addEventListener('mouseup', stop);
+  btn.addEventListener('mouseleave', stop);
+  btn.addEventListener('touchstart', start);
+  btn.addEventListener('touchend', stop);
+}
+
+if(addAAToggle){
+  addAAToggle.checked = addAA;
+  addAAToggle.addEventListener('change', e => {
+    addAA = e.target.checked;
+    saveSettings();
+  });
+}
+
+setupRepeatButton(flightRangeMinusBtn, () => {
+  if(flightRangeCells > MIN_FLIGHT_RANGE_CELLS){
+    flightRangeCells--;
+    updateFlightRangeFlame();
+    updateFlightRangeDisplay();
+    saveSettings();
+  }
+});
+setupRepeatButton(flightRangePlusBtn, () => {
+  if(flightRangeCells < MAX_FLIGHT_RANGE_CELLS){
+    flightRangeCells++;
+    updateFlightRangeFlame();
+    updateFlightRangeDisplay();
+    saveSettings();
+  }
+});
+setupRepeatButton(amplitudeMinusBtn, () => {
+  if(aimingAmplitude > MIN_AMPLITUDE){
+    aimingAmplitude--;
+    updateAmplitudeDisplay();
+    updateAmplitudeIndicator();
+    saveSettings();
+  }
+});
+setupRepeatButton(amplitudePlusBtn, () => {
+  if(aimingAmplitude < MAX_AMPLITUDE){
+    aimingAmplitude++;
+    updateAmplitudeDisplay();
+    updateAmplitudeIndicator();
+    saveSettings();
+  }
+});
+setupRepeatButton(mapMinusBtn, () => {
+  mapIndex = (mapIndex - 1 + MAPS.length) % MAPS.length;
+  updateMapDisplay();
+  saveSettings();
+});
+setupRepeatButton(mapPlusBtn, () => {
+  mapIndex = (mapIndex + 1) % MAPS.length;
+  updateMapDisplay();
+  saveSettings();
+});
+
+if(backBtn){
+  backBtn.addEventListener('click', () => {
+    window.location.href = 'index.html';
+  });
+}
+
+updateFlightRangeDisplay();
+updateFlightRangeFlame();
+updateAmplitudeDisplay();
+updateAmplitudeIndicator();
+updateMapDisplay();

--- a/styles.css
+++ b/styles.css
@@ -84,6 +84,7 @@ body {
   box-shadow: 0 8px 16px rgba(0,0,0,0.2);
   width: 95vw;
   max-width: 350px;
+  min-height: 400px;
   max-height: 95vh;
   overflow-y: auto;
 }
@@ -117,6 +118,31 @@ body {
   box-shadow: 0 4px 8px rgba(0,0,0,0.2);
   cursor: pointer;
   transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+}
+
+/* Rules buttons */
+#modeMenu .rules-options {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 15px;
+}
+
+#modeMenu .rules-options .rules-btn {
+  padding: 10px 15px;
+  font-size: 16px;
+  font-weight: bold;
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  background: linear-gradient(145deg, #6c757d, #5a6268);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+}
+
+#modeMenu .rules-options .rules-btn.selected {
+  background: linear-gradient(145deg, #28a745, #218838);
 }
 
 #modeMenu #playBtn {
@@ -357,6 +383,7 @@ body {
   margin: auto;
   max-width: 100%;
   max-height: 100%;
+  --amp: 10deg;
 }
 #amplitudeIndicator .crosshair {
   position: absolute;
@@ -368,6 +395,11 @@ body {
   border: 3px solid #6c757d;
   border-radius: 50%;
   transform-origin: 50% -40px;
+  animation: swing 2s ease-in-out infinite alternate;
+}
+@keyframes swing {
+  from { transform: rotate(calc(var(--amp) * -1)); }
+  to   { transform: rotate(var(--amp)); }
 }
 #amplitudeIndicator .crosshair::before {
   content: "";


### PR DESCRIPTION
## Summary
- Remove leftover main-menu control logic so the game and settings pages load without errors
- Keep initial menu size stable while exposing Classic Rules and Advanced Settings buttons
- Swing the aiming amplitude indicator like a pendulum to visualize the chosen angle

## Testing
- `node --check script.js`
- `node --check settings.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1ffb49ec832db390e91bd670e64b