### PR TITLE
Fix duplicate button declarations in script.js

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,12 +27,6 @@ const playBtn     = document.getElementById("playBtn");
 const classicRulesBtn     = document.getElementById("classicRulesBtn");
 const advancedSettingsBtn = document.getElementById("advancedSettingsBtn");
 
-
-
-
-const classicRulesBtn     = document.getElementById("classicRulesBtn");
-const advancedSettingsBtn = document.getElementById("advancedSettingsBtn");
-
 const endGameDiv  = document.getElementById("endGameButtons");
 const yesBtn      = document.getElementById("yesButton");
 const noBtn       = document.getElementById("noButton");


### PR DESCRIPTION
## Summary
- Remove accidental duplicate DOM element declarations for `classicRulesBtn` and `advancedSettingsBtn` that caused a SyntaxError and prevented the game script from running.

## Testing
- `node --check script.js && echo 'Syntax OK'`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9dee1650832d80c60c0bf9872dcb