### PR TITLE
Fix settings back navigation and button styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,12 +27,6 @@ const playBtn     = document.getElementById("playBtn");
 const classicRulesBtn     = document.getElementById("classicRulesBtn");
 const advancedSettingsBtn = document.getElementById("advancedSettingsBtn");
 
-
-
-
-const classicRulesBtn     = document.getElementById("classicRulesBtn");
-const advancedSettingsBtn = document.getElementById("advancedSettingsBtn");
-
 const endGameDiv  = document.getElementById("endGameButtons");
 const yesBtn      = document.getElementById("yesButton");
 const noBtn       = document.getElementById("noButton");

--- a/settings.html
+++ b/settings.html
@@ -74,7 +74,7 @@
         </div>
       </div>
     </div>
-    <button id="backBtn" class="mode-btn" style="margin-top:15px;">Back</button>
+    <button id="backBtn" class="mode-btn">Back</button>
   </div>
   <script src="settings.js"></script>
 </body>

--- a/settings.js
+++ b/settings.js
@@ -64,7 +64,7 @@ function animateAmplitudeIndicator(){
   const angle = Math.sin(ampPhase) * aimingAmplitude * 2;
   crosshair.style.transform = `rotate(${angle}deg)`;
   requestAnimationFrame(animateAmplitudeIndicator);
-
+}
 
 function updateMapDisplay(){
   const el = document.getElementById('mapNameValue');
@@ -161,5 +161,6 @@ if(backBtn){
 updateFlightRangeDisplay();
 updateFlightRangeFlame();
 updateAmplitudeDisplay();
+updateMapDisplay();
 
 animateAmplitudeIndicator();

--- a/styles.css
+++ b/styles.css
@@ -106,7 +106,7 @@ body {
   margin-bottom: 15px;
 }
 
-#modeMenu .mode-options button {
+#modeMenu .mode-btn {
   padding: 12px 8px;
   margin: 0;
   font-size: 16px;
@@ -153,7 +153,13 @@ body {
   background: linear-gradient(145deg, #5bc0de, #31b0d5);
 }
 
-#modeMenu .mode-options button:hover:not(.selected) {
+#modeMenu #backBtn {
+  width: 100%;
+  padding: 12px;
+  margin-top: 15px;
+}
+
+#modeMenu .mode-btn:hover:not(.selected) {
   transform: translateY(-5px);
   box-shadow: 0 8px 16px rgba(0,0,0,0.35);
 }
@@ -168,7 +174,7 @@ body {
 }
 
 /* Disabled */
-#modeMenu .mode-options button:disabled,
+#modeMenu .mode-btn:disabled,
 #modeMenu #playBtn.disabled {
   opacity: 0.6;
   cursor: not-allowed;
@@ -176,7 +182,7 @@ body {
 }
 
 /* Selected */
-#modeMenu .mode-options button.selected {
+#modeMenu .mode-btn.selected {
   background: linear-gradient(145deg, #f80101, #d53131);
   box-shadow: 0 8px 16px rgba(0,0,0,0.35);
 }


### PR DESCRIPTION
## Summary
- Close unclosed function in `settings.js` so the script runs and the back button returns to the main menu
- Style the settings back button consistently with other menu buttons and remove inline styling

## Testing
- `node --check script.js`
- `node --check settings.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9dee1650832d80c60c0bf9872dcb