### PR TITLE
Fix explosion animation and enlarge blast

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,9 @@
   </div>
 
   <!-- Hidden explosion GIF used for canvas animation -->
-  <img id="explosionGif" src="explosion 3.gif" style="display:none" alt="" />
+  <img id="explosionGif" src="explosion 3.gif"
+       style="position:absolute; left:-1000px; top:-1000px;"
+       alt="" />
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -45,6 +45,11 @@ fieldImg.src = "field 3.png";
 // Explosion animation (DOM element ensures GIF animates)
 const explosionImg = document.getElementById("explosionGif");
 
+function restartExplosionGif(){
+  const baseSrc = explosionImg.src.split('?')[0];
+  explosionImg.src = `${baseSrc}?t=${Date.now()}`;
+}
+
 
 
 
@@ -79,7 +84,7 @@ const PLANES_PER_SIDE      = 4;      // количество самолётов 
 
 // Explosion effect
 const EXPLOSION_DURATION_MS = 500;   // time before showing cross
-const EXPLOSION_SIZE        = 16;    // px, not bigger than red cross
+const EXPLOSION_SIZE        = 32;    // px, larger for better visibility
 
 
 const MIN_FLIGHT_RANGE_CELLS = 5;
@@ -970,6 +975,7 @@ function destroyPlane(fp){
   p.isAlive = false;
   p.burning = true;
   p.explosionStart = performance.now();
+  restartExplosionGif();
   p.collisionX = p.x;
   p.collisionY = p.y;
   flyingPoints = flyingPoints.filter(x=>x!==fp);
@@ -1017,6 +1023,7 @@ function handleAAForPlane(p, fp){
               aa.lastTriggerAt = now;
               p.isAlive=false; p.burning=true;
               p.explosionStart = performance.now();
+              restartExplosionGif();
               p.collisionX=p.x; p.collisionY=p.y;
               if(fp) {
                 flyingPoints = flyingPoints.filter(x=>x!==fp);
@@ -1739,6 +1746,7 @@ function checkPlaneHits(plane, fp){
       p.isAlive = false;
       p.burning = true;
       p.explosionStart = performance.now();
+      restartExplosionGif();
       p.collisionX = p.x;
       p.collisionY = p.y;
       fp.hit = true;


### PR DESCRIPTION
## Summary
- restart explosion GIF each time a plane is destroyed so animation plays
- keep hidden explosion image animating off-screen and enlarge blast rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acb37e223c832d8fc6600949afa83f