### PR TITLE
Highlight settings button when custom config exists

### DIFF
--- a/script.js
+++ b/script.js
@@ -163,6 +163,19 @@ let settings = {
   addAA: localStorage.getItem('settings.addAA') === 'true'
 };
 
+// Highlight advanced settings button if custom settings are stored
+const hasCustomSettings = [
+  'settings.flightRangeCells',
+  'settings.aimingAmplitude',
+  'settings.mapIndex',
+  'settings.addAA'
+].some(key => localStorage.getItem(key) !== null);
+
+if(hasCustomSettings && classicRulesBtn && advancedSettingsBtn){
+  classicRulesBtn.classList.remove('selected');
+  advancedSettingsBtn.classList.add('selected');
+}
+
 
 let greenVictories = 0;
 let blueVictories  = 0;
@@ -290,11 +303,17 @@ if(classicRulesBtn){
     localStorage.removeItem('settings.mapIndex');
     localStorage.removeItem('settings.addAA');
     applyCurrentMap();
+    advancedSettingsBtn?.classList.remove('selected');
     classicRulesBtn.classList.add('selected');
   });
 }
 if(advancedSettingsBtn){
   advancedSettingsBtn.addEventListener('click', () => {
+    classicRulesBtn?.classList.remove('selected');
+    advancedSettingsBtn.classList.add('selected');
+    applyCurrentMap();
+  });
+  advancedSettingsBtn.addEventListener('dblclick', () => {
     window.location.href = 'settings.html';
   });
 }


### PR DESCRIPTION
## Summary
- Highlight Advanced Settings button when custom settings are stored
- Single click selects Advanced Settings, double click opens settings page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68accbd53a00832d814bd0e77a8049e8