### PR TITLE
Open advanced settings after second click when selected

### DIFF
--- a/script.js
+++ b/script.js
@@ -309,12 +309,13 @@ if(classicRulesBtn){
 }
 if(advancedSettingsBtn){
   advancedSettingsBtn.addEventListener('click', () => {
-    classicRulesBtn?.classList.remove('selected');
-    advancedSettingsBtn.classList.add('selected');
-    applyCurrentMap();
-  });
-  advancedSettingsBtn.addEventListener('dblclick', () => {
-    window.location.href = 'settings.html';
+    if(advancedSettingsBtn.classList.contains('selected')){
+      window.location.href = 'settings.html';
+    } else {
+      classicRulesBtn?.classList.remove('selected');
+      advancedSettingsBtn.classList.add('selected');
+      applyCurrentMap();
+    }
   });
 }
 function updateModeSelection(){


### PR DESCRIPTION
## Summary
- allow opening advanced settings with a second click when the button is already highlighted

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68accdfe53b8832d8b27d4d78d77ba01