### PR TITLE
Fix AI wall awareness and preserve advanced settings

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -4,9 +4,14 @@ const MIN_AMPLITUDE = 0;
 const MAX_AMPLITUDE = 30;
 const MAPS = ["clear sky", "wall", "two walls", "sharp edges"];
 
-let flightRangeCells = parseInt(localStorage.getItem('settings.flightRangeCells')) || 15;
-let aimingAmplitude  = parseInt(localStorage.getItem('settings.aimingAmplitude')) || 10;
-let mapIndex = parseInt(localStorage.getItem('settings.mapIndex')) || 1;
+function getIntSetting(key, defaultValue){
+  const value = parseInt(localStorage.getItem(key));
+  return Number.isNaN(value) ? defaultValue : value;
+}
+
+let flightRangeCells = getIntSetting('settings.flightRangeCells', 15);
+let aimingAmplitude  = getIntSetting('settings.aimingAmplitude', 10);
+let mapIndex = getIntSetting('settings.mapIndex', 1);
 let addAA = localStorage.getItem('settings.addAA') === 'true';
 
 const flightRangeMinusBtn = document.getElementById('flightRangeMinus');


### PR DESCRIPTION
## Summary
- ensure AI considers plane radius when checking clear paths
- expand building edges in mirror-shot logic to avoid wall collisions
- keep user-tuned advanced settings when switching back from classic rules
- load settings using NaN checks to preserve zero values

## Testing
- `node --check script.js`
- `node --check settings.js`


------
https://chatgpt.com/codex/tasks/task_e_68acd43a8a1c832d83f9443bcc156f40