### PR TITLE
Fix AI wall awareness and preserve advanced settings

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -4,9 +4,14 @@ const MIN_AMPLITUDE = 0;
 const MAX_AMPLITUDE = 30;
 const MAPS = ["clear sky", "wall", "two walls", "sharp edges"];
 
-let flightRangeCells = parseInt(localStorage.getItem('settings.flightRangeCells')) || 15;
-let aimingAmplitude  = parseInt(localStorage.getItem('settings.aimingAmplitude')) || 10;
-let mapIndex = parseInt(localStorage.getItem('settings.mapIndex')) || 1;
+function getIntSetting(key, defaultValue){
+  const value = parseInt(localStorage.getItem(key));
+  return Number.isNaN(value) ? defaultValue : value;
+}
+
+let flightRangeCells = getIntSetting('settings.flightRangeCells', 15);
+let aimingAmplitude  = getIntSetting('settings.aimingAmplitude', 10);
+let mapIndex = getIntSetting('settings.mapIndex', 1);
 let addAA = localStorage.getItem('settings.addAA') === 'true';
 
 const flightRangeMinusBtn = document.getElementById('flightRangeMinus');

--- a/styles.css
+++ b/styles.css
@@ -72,9 +72,9 @@ body {
 /* Меню выбора режима */
 #modeMenu {
   position: fixed;
-  top: 50%;
+  top: 0;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   background: linear-gradient(135deg, #fffbe6, #ffe0b3);
   border: 2px solid #ffd699;
   border-radius: 15px;
@@ -84,9 +84,12 @@ body {
   box-shadow: 0 8px 16px rgba(0,0,0,0.2);
   width: 95vw;
   max-width: 350px;
-  min-height: 400px;
-  max-height: 95vh;
+  height: 100dvh;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 /* Заголовок */


### PR DESCRIPTION
## Summary
- ensure AI considers plane radius when checking clear paths
- expand building edges in mirror-shot logic to avoid wall collisions
- keep user-tuned advanced settings when switching back from classic rules
- load settings using NaN checks to preserve zero values
- align menu and settings screens with game viewport height

## Testing
- `node --check script.js`
- `node --check settings.js`


------
https://chatgpt.com/codex/tasks/task_e_68acd43a8a1c832d83f9443bcc156f40