### PR TITLE
Render plane explosions above other elements

### DIFF
--- a/script.js
+++ b/script.js
@@ -1610,6 +1610,7 @@ function isExplosionFinished(p){
   }
 
 function drawPlanesAndTrajectories(){
+  const burningPlanes = [];
   for(const p of points){
     if(!p.isAlive && !p.burning) continue;
     for(const seg of p.segments){
@@ -1624,13 +1625,19 @@ function drawPlanesAndTrajectories(){
     if(p.burning){
       const cx = p.collisionX ?? p.x;
       const cy = p.collisionY ?? p.y;
-      if(!isExplosionFinished(p)){
+      burningPlanes.push({plane: p, cx, cy});
+    }
+  }
 
-        gameCtx.drawImage(explosionImg, cx - EXPLOSION_SIZE/2, cy - EXPLOSION_SIZE/2, EXPLOSION_SIZE, EXPLOSION_SIZE);
-
-      } else {
-        drawRedCross(gameCtx, cx, cy, 16);
-      }
+  for(const {plane: p, cx, cy} of burningPlanes){
+    if(!isExplosionFinished(p)){
+      gameCtx.save();
+      gameCtx.globalAlpha = 1;
+      gameCtx.globalCompositeOperation = "source-over";
+      gameCtx.drawImage(explosionImg, cx - EXPLOSION_SIZE/2, cy - EXPLOSION_SIZE/2, EXPLOSION_SIZE, EXPLOSION_SIZE);
+      gameCtx.restore();
+    } else {
+      drawRedCross(gameCtx, cx, cy, 16);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Collect burning planes before rendering explosions
- Draw explosion imagery after other elements with explicit compositing

## Testing
- `node --check script.js`
- `python -m http.server` (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68ad5e206b68832da114ef6334662890