### PR TITLE
Align menu screens with game dimensions

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -72,9 +72,9 @@ body {
 /* Меню выбора режима */
 #modeMenu {
   position: fixed;
-  top: 0;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   background: linear-gradient(135deg, #fffbe6, #ffe0b3);
   border: 2px solid #ffd699;
   border-radius: 15px;
@@ -84,7 +84,8 @@ body {
   box-shadow: 0 8px 16px rgba(0,0,0,0.2);
   width: 95vw;
   max-width: 350px;
-  height: 100dvh;
+  height: calc(100dvh - 20px);
+  max-height: calc(100dvh - 20px);
   overflow-y: auto;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Align start and settings screens with fixed game-area dimensions
- Center menus and cap their size to prevent browser stretching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6d681b64832da2f809ce4567a6a1