### PR TITLE
Fix explosion animation by rendering GIF as hidden DOM element

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,11 +46,6 @@
     <button id="noButton" class="end-btn">No</button>
   </div>
 
-  <!-- Hidden explosion GIF used for canvas animation -->
-  <img id="explosionGif" src="explosion 4.gif"
-       style="position:absolute; left:-1000px; top:-1000px;"
-       alt="" />
-
-  <script src="script.js"></script>
-</body>
+    <script src="script.js"></script>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -43,8 +43,12 @@ fieldImg.src = "field 5.png";
 
 
 function createExplosionImage(){
-  const img = new Image();
+  const img = document.createElement("img");
   img.src = `explosion 4.gif?${Date.now()}`;
+  img.style.position = "absolute";
+  img.style.left = "-1000px";
+  img.style.top = "-1000px";
+  document.body.appendChild(img);
   return img;
 }
 
@@ -1009,12 +1013,12 @@ function destroyPlane(fp){
   img.onload = () => {
     p.explosionStart = performance.now();
     setTimeout(() => {
-      if (p.explosionImg === img) p.explosionImg = null;
+      if (p.explosionImg === img) {
+        img.remove();
+        p.explosionImg = null;
+      }
     }, EXPLOSION_DURATION_MS);
   };
-  img.addEventListener('ended', () => {
-    if (p.explosionImg === img) p.explosionImg = null;
-  });
   p.collisionX = p.x;
   p.collisionY = p.y;
   flyingPoints = flyingPoints.filter(x=>x!==fp);
@@ -1067,12 +1071,12 @@ function handleAAForPlane(p, fp){
               img.onload = () => {
                 p.explosionStart = performance.now();
                 setTimeout(() => {
-                  if (p.explosionImg === img) p.explosionImg = null;
+                  if (p.explosionImg === img) {
+                    img.remove();
+                    p.explosionImg = null;
+                  }
                 }, EXPLOSION_DURATION_MS);
               };
-              img.addEventListener('ended', () => {
-                if (p.explosionImg === img) p.explosionImg = null;
-              });
               p.collisionX=p.x; p.collisionY=p.y;
               if(fp) {
                 flyingPoints = flyingPoints.filter(x=>x!==fp);
@@ -1808,12 +1812,12 @@ function checkPlaneHits(plane, fp){
       img.onload = () => {
         p.explosionStart = performance.now();
         setTimeout(() => {
-          if (p.explosionImg === img) p.explosionImg = null;
+          if (p.explosionImg === img) {
+            img.remove();
+            p.explosionImg = null;
+          }
         }, EXPLOSION_DURATION_MS);
       };
-      img.addEventListener('ended', () => {
-        if (p.explosionImg === img) p.explosionImg = null;
-      });
       const cx = d === 0 ? plane.x : plane.x + dx / d * POINT_RADIUS;
       const cy = d === 0 ? plane.y : plane.y + dy / d * POINT_RADIUS;
       p.collisionX = cx;


### PR DESCRIPTION
## Summary
- Render explosion GIFs as offscreen `<img>` elements so they animate while drawn on the canvas
- Clean up temporary explosion elements after `EXPLOSION_DURATION_MS`
- Remove unused hidden GIF from HTML

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad85e5fdf0832da9a95da9fe2741f4