### PR TITLE
Add configurable sharp edges option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 
 - Each side controls a group of paper planes (green vs. blue).
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
-- Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls", "sharp edges") and adjust aiming amplitude.
-- On the "sharp edges" map, hitting the border destroys the plane instead of bouncing it back.
+- Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls"), enable sharp edges, and adjust aiming amplitude.
+- With **Sharp Edges** enabled, hitting the border destroys the plane instead of bouncing it back.
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - After a round you can choose to play again or return to the menu.
 

--- a/script.js
+++ b/script.js
@@ -118,7 +118,7 @@ const AA_TRAIL_MS = 5000; // radar sweep afterglow duration
 
 
 
-const MAPS = ["clear sky", "wall", "two walls", "sharp edges"];
+const MAPS = ["clear sky", "wall", "two walls"];
 
 let mapIndex;
 let flightRangeCells; // cells for menu and physics
@@ -156,7 +156,7 @@ let phase = "MENU"; // MENU | AA_PLACEMENT (Anti-Aircraft placement) | ROUND_STA
 
 let currentPlacer = null; // 'green' | 'blue'
 
-let settings = { addAA: false };
+let settings = { addAA: false, sharpEdges: false };
 
 function loadSettings(){
   const fr = parseInt(localStorage.getItem('settings.flightRangeCells'));
@@ -166,6 +166,7 @@ function loadSettings(){
   const mi = parseInt(localStorage.getItem('settings.mapIndex'));
   mapIndex = Number.isNaN(mi) ? 1 : mi;
   settings.addAA = localStorage.getItem('settings.addAA') === 'true';
+  settings.sharpEdges = localStorage.getItem('settings.sharpEdges') === 'true';
 }
 
 loadSettings();
@@ -175,7 +176,8 @@ const hasCustomSettings = [
   'settings.flightRangeCells',
   'settings.aimingAmplitude',
   'settings.mapIndex',
-  'settings.addAA'
+  'settings.addAA',
+  'settings.sharpEdges'
 ].some(key => localStorage.getItem(key) !== null);
 
 if(hasCustomSettings && classicRulesBtn && advancedSettingsBtn){
@@ -306,6 +308,7 @@ if(classicRulesBtn){
     aimingAmplitude = 10;
     mapIndex = 1;
     settings.addAA = false;
+    settings.sharpEdges = false;
     applyCurrentMap();
     advancedSettingsBtn?.classList.remove('selected');
     classicRulesBtn.classList.add('selected');
@@ -1143,7 +1146,7 @@ function handleAAForPlane(p, fp){
         // field borders
         if (p.x < FIELD_BORDER_OFFSET) {
           p.x = FIELD_BORDER_OFFSET;
-          if (MAPS[mapIndex] === "sharp edges") {
+          if (settings.sharpEdges) {
             destroyPlane(fp);
             continue;
           }
@@ -1151,7 +1154,7 @@ function handleAAForPlane(p, fp){
         }
         else if (p.x > gameCanvas.width - FIELD_BORDER_OFFSET) {
           p.x = gameCanvas.width - FIELD_BORDER_OFFSET;
-          if (MAPS[mapIndex] === "sharp edges") {
+          if (settings.sharpEdges) {
             destroyPlane(fp);
             continue;
           }
@@ -1159,7 +1162,7 @@ function handleAAForPlane(p, fp){
         }
         if (p.y < FIELD_BORDER_OFFSET) {
           p.y = FIELD_BORDER_OFFSET;
-          if (MAPS[mapIndex] === "sharp edges") {
+          if (settings.sharpEdges) {
             destroyPlane(fp);
             continue;
           }
@@ -1167,7 +1170,7 @@ function handleAAForPlane(p, fp){
         }
         else if (p.y > gameCanvas.height - FIELD_BORDER_OFFSET) {
           p.y = gameCanvas.height - FIELD_BORDER_OFFSET;
-          if (MAPS[mapIndex] === "sharp edges") {
+          if (settings.sharpEdges) {
             destroyPlane(fp);
             continue;
           }
@@ -1437,7 +1440,7 @@ function drawBrickEdges(ctx2d, w, h){
 }
 
 function drawFieldEdges(ctx2d, w, h){
-  if(MAPS[mapIndex] === "sharp edges"){
+  if(settings.sharpEdges){
     drawNailEdges(ctx2d, w, h);
   } else {
     drawBrickEdges(ctx2d, w, h);
@@ -2025,8 +2028,8 @@ function startNewRound(){
 /* ======= Map helpers ======= */
 function applyCurrentMap(){
   buildings = [];
-  FIELD_BORDER_OFFSET = (MAPS[mapIndex] === "sharp edges") ? 0 : FIELD_BORDER_THICKNESS;
-  if(MAPS[mapIndex] === "clear sky" || MAPS[mapIndex] === "sharp edges"){
+  FIELD_BORDER_OFFSET = settings.sharpEdges ? 0 : FIELD_BORDER_THICKNESS;
+  if(MAPS[mapIndex] === "clear sky"){
     // no buildings to add
   } else if (MAPS[mapIndex] === "wall") {
     const wallWidth = CELL_SIZE * 8;

--- a/settings.html
+++ b/settings.html
@@ -68,6 +68,9 @@
         <div class="aa-toggle">
           <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
         </div>
+        <div class="aa-toggle">
+          <label><input type="checkbox" id="sharpEdgesToggle" /> Sharp Edges</label>
+        </div>
         <div class="control-buttons">
           <button id="mapMinus" class="control-btn">−</button>
           <button id="mapPlus" class="control-btn">+</button>

--- a/settings.js
+++ b/settings.js
@@ -2,7 +2,7 @@ const MIN_FLIGHT_RANGE_CELLS = 5;
 const MAX_FLIGHT_RANGE_CELLS = 30;
 const MIN_AMPLITUDE = 0;
 const MAX_AMPLITUDE = 30;
-const MAPS = ["clear sky", "wall", "two walls", "sharp edges"];
+const MAPS = ["clear sky", "wall", "two walls"];
 
 function getIntSetting(key, defaultValue){
   const value = parseInt(localStorage.getItem(key));
@@ -13,6 +13,7 @@ let flightRangeCells = getIntSetting('settings.flightRangeCells', 15);
 let aimingAmplitude  = getIntSetting('settings.aimingAmplitude', 10);
 let mapIndex = getIntSetting('settings.mapIndex', 1);
 let addAA = localStorage.getItem('settings.addAA') === 'true';
+let sharpEdges = localStorage.getItem('settings.sharpEdges') === 'true';
 
 const flightRangeMinusBtn = document.getElementById('flightRangeMinus');
 const flightRangePlusBtn  = document.getElementById('flightRangePlus');
@@ -21,6 +22,7 @@ const amplitudePlusBtn    = document.getElementById('amplitudePlus');
 const mapMinusBtn = document.getElementById('mapMinus');
 const mapPlusBtn  = document.getElementById('mapPlus');
 const addAAToggle = document.getElementById('addAAToggle');
+const sharpEdgesToggle = document.getElementById('sharpEdgesToggle');
 const backBtn = document.getElementById('backBtn');
 
 function updateFlightRangeDisplay(){
@@ -78,6 +80,7 @@ function saveSettings(){
   localStorage.setItem('settings.aimingAmplitude', aimingAmplitude);
   localStorage.setItem('settings.mapIndex', mapIndex);
   localStorage.setItem('settings.addAA', addAA);
+  localStorage.setItem('settings.sharpEdges', sharpEdges);
 }
 
 function setupRepeatButton(btn, cb){
@@ -105,6 +108,14 @@ if(addAAToggle){
   addAAToggle.checked = addAA;
   addAAToggle.addEventListener('change', e => {
     addAA = e.target.checked;
+    saveSettings();
+  });
+}
+
+if(sharpEdgesToggle){
+  sharpEdgesToggle.checked = sharpEdges;
+  sharpEdgesToggle.addEventListener('change', e => {
+    sharpEdges = e.target.checked;
     saveSettings();
   });
 }


### PR DESCRIPTION
## Summary
- Replace dedicated "sharp edges" map with a global Sharp Edges toggle
- Persist Sharp Edges setting and apply it during gameplay
- Document Sharp Edges option and update map list

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check script.js`
- `node --check settings.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad8a2080b0832db9e09610ae077b68