### PR TITLE
Fix brick frame initialization and add Additional Settings container

### DIFF
--- a/script.js
+++ b/script.js
@@ -40,6 +40,7 @@ const greenPlaneImg = new Image();
 greenPlaneImg.src = "green plane 2.png";
 const fieldImg = new Image();
 fieldImg.src = "field 5.png";
+const FIELD_BORDER_THICKNESS = 10; // px, width of brick frame edges
 
 const brickFrameImg = new Image();
 brickFrameImg.src = "brick frame.png";
@@ -97,7 +98,6 @@ const HANDLE_SIZE          = 10;     // px
 const BOUNCE_FRAMES        = 68;
 const MAX_DRAG_DISTANCE    = 100;    // px
 const ATTACK_RANGE_PX      = 300;    // px
-const FIELD_BORDER_THICKNESS = 10;    // px, ширина кирпичной рамки по краям
 let FIELD_BORDER_OFFSET = FIELD_BORDER_THICKNESS; // внутренняя граница для отражения
 // Используем бесконечное количество сегментов,
 // чтобы следы самолётов сохранялись до конца раунда.

--- a/settings.html
+++ b/settings.html
@@ -65,15 +65,20 @@
         <div id="mapNameDisplay" class="control-value">
           <span id="mapNameValue">wall</span>
         </div>
+        <div class="control-buttons">
+          <button id="mapMinus" class="control-btn">−</button>
+          <button id="mapPlus" class="control-btn">+</button>
+        </div>
+      </div>
+
+      <!-- Additional Settings -->
+      <div class="control-box" id="additionalSettings">
+        <div class="control-label">Additional Settings</div>
         <div class="aa-toggle">
           <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
         </div>
         <div class="aa-toggle">
           <label><input type="checkbox" id="sharpEdgesToggle" /> Sharp Edges</label>
-        </div>
-        <div class="control-buttons">
-          <button id="mapMinus" class="control-btn">−</button>
-          <button id="mapPlus" class="control-btn">+</button>
         </div>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -223,7 +223,15 @@ body {
 }
 
 #modeMenu #mapControl {
-  grid-template-rows: auto auto auto auto auto;
+  grid-template-rows: auto auto auto;
+}
+
+#modeMenu #additionalSettings {
+  grid-template-rows: auto auto auto;
+}
+
+#modeMenu #additionalSettings .aa-toggle {
+  margin: 5px 0;
 }
 
 #modeMenu .control-box > .control-label {


### PR DESCRIPTION
## Summary
- Define FIELD_BORDER_THICKNESS before initializing the brick frame image
- Move anti-aircraft and sharp edge toggles into a dedicated Additional Settings container

## Testing
- `node --check script.js`
- `node --check settings.js`


------
https://chatgpt.com/codex/tasks/task_e_68aec371ec7c832d86c5535073a79ec1