### PR TITLE
Group extra options under Additional Settings container

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -70,18 +70,19 @@
           <button id="mapPlus" class="control-btn">+</button>
         </div>
       </div>
+    </div>
 
-      <!-- Additional Settings -->
-      <div class="control-box" id="additionalSettings">
-        <div class="control-label">Additional Settings</div>
-        <div class="aa-toggle">
-          <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
-        </div>
-        <div class="aa-toggle">
-          <label><input type="checkbox" id="sharpEdgesToggle" /> Sharp Edges</label>
-        </div>
+    <!-- Additional Settings -->
+    <div class="control-box" id="additionalSettings">
+      <div class="control-label">Additional Settings</div>
+      <div class="aa-toggle">
+        <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
+      </div>
+      <div class="aa-toggle">
+        <label><input type="checkbox" id="sharpEdgesToggle" /> Sharp Edges</label>
       </div>
     </div>
+
     <button id="backBtn" class="mode-btn">Back</button>
   </div>
   <script src="settings.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -228,6 +228,7 @@ body {
 
 #modeMenu #additionalSettings {
   grid-template-rows: auto auto auto;
+  margin-top: 10px;
 }
 
 #modeMenu #additionalSettings .aa-toggle {


### PR DESCRIPTION
## Summary
- Move anti-aircraft and sharp-edge toggles into a separate "Additional Settings" box on the settings page
- Add spacing style for the new Additional Settings section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af530031c0832d96d80fe2d4d517e6