### PR TITLE
Fix duplicate flag score declarations causing syntax error

### DIFF
--- a/script.js
+++ b/script.js
@@ -251,28 +251,6 @@ function addScore(color, delta){
   }
 }
 
-let blueFlagCarrier = null;
-let greenFlagCarrier = null;
-let blueFlagStolenBy = null;
-let greenFlagStolenBy = null;
-
-function addScore(color, delta){
-  if(color === "blue"){
-    blueScore = Math.max(0, blueScore + delta);
-  } else if(color === "green"){
-    greenScore = Math.max(0, greenScore + delta);
-  }
-  if(!isGameOver){
-    if(blueScore >= POINTS_TO_WIN){
-      isGameOver = true;
-      winnerColor = "blue";
-    } else if(greenScore >= POINTS_TO_WIN){
-      isGameOver = true;
-      winnerColor = "green";
-    }
-  }
-}
-
 let animationFrameId = null;
 
 /* Планирование хода ИИ */


### PR DESCRIPTION
## Summary
- remove duplicated flag carrier variables and score function

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68b0c2999c0c832db815f3e7e30b6c16