### PR TITLE
Hide round labels after move or delay

### DIFF
--- a/script.js
+++ b/script.js
@@ -486,6 +486,7 @@ function handleStart(e) {
   handleCircle.offsetX=0; handleCircle.offsetY=0;
   handleCircle.active= true;
   handleCircle.pointRef= found;
+  roundTextTimer = 0; // Hide round label when player starts a move
 
   window.addEventListener("mousemove", onHandleMove);
   window.addEventListener("mouseup", onHandleUp);
@@ -862,6 +863,7 @@ function doComputerMove(){
       hasShotThisRound = true;
       renderScoreboard();
     }
+    roundTextTimer = 0; // Hide round label when AI makes a move
   }
 }
 function dist(a,b){ return Math.hypot(a.x-b.x,a.y-b.y); }


### PR DESCRIPTION
## Summary
- Stop showing round indicator once a player begins a move
- Hide round indicator when the AI makes its move so it doesn't linger

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1551021d0832dabf1a6f7c96dd0ed