### PR TITLE
fix: prevent horizontal scroll on first screen

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,10 @@ body, button {
   -webkit-tap-highlight-color: transparent;
 }
 
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 /* Базовый шрифт/раскладка */
 body {
   position: relative;


### PR DESCRIPTION
## Summary
- ensure all elements use border-box sizing so UI fits within viewport without horizontal scroll

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b156488b28832db07b21f37f2bab77