### PR TITLE
Add new map layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 - Each side controls a group of paper planes (green vs. blue).
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
-- Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls"), enable sharp edges, and adjust aiming amplitude.
+- Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls", "base towers", "cross", "checkerboard"), enable sharp edges, and adjust aiming amplitude.
 - With **Sharp Edges** enabled, hitting the border destroys the plane instead of bouncing it back.
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - Rounds advance automatically; at the end of a match you can choose to play again or return to the menu.

--- a/script.js
+++ b/script.js
@@ -156,7 +156,7 @@ const AA_TRAIL_MS = 5000; // radar sweep afterglow duration
 
 
 
-const MAPS = ["clear sky", "wall", "two walls"];
+const MAPS = ["clear sky", "wall", "two walls", "base towers", "cross", "checkerboard"];
 
 let mapIndex;
 let flightRangeCells; // cells for menu and physics
@@ -2379,6 +2379,68 @@ function applyCurrentMap(){
       height: wallHeight,
       color: "darkred"
     });
+  } else if (MAPS[mapIndex] === "base towers") {
+    const towerWidth = CELL_SIZE * 5;
+    const towerHeight = CELL_SIZE * 6;
+    const offset = CELL_SIZE * 4;
+    buildings.push({
+      type: "wall",
+      x: gameCanvas.width / 2,
+      y: offset + towerHeight / 2,
+      width: towerWidth,
+      height: towerHeight,
+      color: "darkred"
+    });
+    buildings.push({
+      type: "wall",
+      x: gameCanvas.width / 2,
+      y: gameCanvas.height - offset - towerHeight / 2,
+      width: towerWidth,
+      height: towerHeight,
+      color: "darkred"
+    });
+  } else if (MAPS[mapIndex] === "cross") {
+    const thickness = CELL_SIZE;
+    const margin = CELL_SIZE * 2;
+    buildings.push({
+      type: "wall",
+      x: gameCanvas.width / 2,
+      y: gameCanvas.height / 2,
+      width: thickness,
+      height: gameCanvas.height - margin * 2,
+      color: "darkred"
+    });
+    buildings.push({
+      type: "wall",
+      x: gameCanvas.width / 2,
+      y: gameCanvas.height / 2,
+      width: gameCanvas.width - margin * 2,
+      height: thickness,
+      color: "darkred"
+    });
+  } else if (MAPS[mapIndex] === "checkerboard") {
+    const blockSize = CELL_SIZE * 2;
+    const margin = CELL_SIZE;
+    const startX = margin + blockSize / 2;
+    const startY = margin + blockSize / 2;
+    const endX = gameCanvas.width - margin - blockSize / 2;
+    const endY = gameCanvas.height - margin - blockSize / 2;
+    let row = 0;
+    for (let y = startY; y <= endY; y += blockSize, row++) {
+      let col = 0;
+      for (let x = startX; x <= endX; x += blockSize, col++) {
+        if ((row + col) % 2 === 0) {
+          buildings.push({
+            type: "wall",
+            x,
+            y,
+            width: blockSize,
+            height: blockSize,
+            color: "darkred"
+          });
+        }
+      }
+    }
   }
   renderScoreboard();
 }

--- a/settings.js
+++ b/settings.js
@@ -2,7 +2,7 @@ const MIN_FLIGHT_RANGE_CELLS = 5;
 const MAX_FLIGHT_RANGE_CELLS = 30;
 const MIN_AMPLITUDE = 0;
 const MAX_AMPLITUDE = 30;
-const MAPS = ["clear sky", "wall", "two walls"];
+const MAPS = ["clear sky", "wall", "two walls", "base towers", "cross", "checkerboard"];
 
 function getIntSetting(key, defaultValue){
   const value = parseInt(localStorage.getItem(key));


### PR DESCRIPTION
## Summary
- Add "Base Towers", "Cross", and "Checkerboard" maps with brick wall arrangements
- Expose new maps in settings and documentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2085f119c832dae5d8fd7c246c55f