### PR TITLE
Fix undefined distance label coordinates

### DIFF
--- a/script.js
+++ b/script.js
@@ -1479,6 +1479,11 @@ function handleAAForPlane(p, fp){
 
     // Predicted flight distance in cells based on current pull
     const travelCells = (vdist / MAX_DRAG_DISTANCE) * flightRangeCells;
+    const labelDist = HANDLE_SIZE * 2;
+    const labelGX = plane.x + labelDist * Math.cos(dragAngle);
+    const labelGY = plane.y + labelDist * Math.sin(dragAngle);
+    const labelSX = rect.left + labelGX * scaleX;
+    const labelSY = rect.top  + labelGY * scaleY;
 
     const travelPx = travelCells * CELL_SIZE;
     const travelEndGX = plane.x - travelPx * Math.cos(dragAngle);


### PR DESCRIPTION
## Summary
- Restore calculation of distance label coordinates during aiming to prevent ReferenceError

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3f3c809fc832dbb53e5ba6d41778a