### PR TITLE
Clamp persisted settings to valid ranges

### DIFF
--- a/script.js
+++ b/script.js
@@ -210,6 +210,13 @@ function loadSettings(){
   }
   settings.addAA = localStorage.getItem('settings.addAA') === 'true';
   settings.sharpEdges = localStorage.getItem('settings.sharpEdges') === 'true';
+
+  // Clamp loaded values so corrupted or out-of-range settings
+  // don't break the game on startup
+  flightRangeCells = Math.min(MAX_FLIGHT_RANGE_CELLS,
+                             Math.max(MIN_FLIGHT_RANGE_CELLS, flightRangeCells));
+  aimingAmplitude  = Math.min(MAX_AMPLITUDE,
+                             Math.max(MIN_AMPLITUDE, aimingAmplitude));
 }
 
 loadSettings();


### PR DESCRIPTION
## Summary
- Clamp loaded flight range and aiming amplitude values to their allowed limits so corrupted or out-of-range localStorage settings can't break the game

## Testing
- `node --check script.js`
- `node /tmp/test-run.js`


------
https://chatgpt.com/codex/tasks/task_e_68b413478b00832da7da9f2f1917e34b