### PR TITLE
Fix arrow sprite path

### DIFF
--- a/script.js
+++ b/script.js
@@ -47,7 +47,8 @@ brickFrameImg.src = "brick frame 2.png";
 
 // Sprite used for the aiming arrow
 const arrowSprite = new Image();
-arrowSprite.src = "sprite_arrow.png";
+// Use the PNG sprite that contains the arrow graphics
+arrowSprite.src = "sprite_ copy.png";
 
 // Dimensions of arrow parts inside the sprite
 const HEAD_W = 95;


### PR DESCRIPTION
## Summary
- Use the correct PNG file for the aiming arrow sprite so the arrow renders instead of a black line

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b560ecd148832db6269e8dac61a940