### PR TITLE
feat: show scaling arrow for aiming

### DIFF
--- a/script.js
+++ b/script.js
@@ -15,7 +15,6 @@ const gameCanvas  = document.getElementById("gameCanvas");
 const gameCtx     = gameCanvas.getContext("2d");
 
 const aimCanvas   = document.getElementById("aimCanvas");
-const aimCtx      = aimCanvas.getContext("2d");
 
 const modeMenuDiv = document.getElementById("modeMenu");
 const hotSeatBtn  = document.getElementById("hotSeatBtn");
@@ -54,17 +53,17 @@ arrowSprite.src = "sprite_ copy.png";
 const ARROW_Y = 358;   // vertical offset of arrow graphic
 const PART_H  = 254;   // height of arrow graphic
 
-// Horizontal slices for tail, shaft, and head within the sprite
-const TAIL_X  = 35;
-const TAIL_W  = 364;
+// Horizontal slices for head, shaft, and tail within the sprite
+const HEAD_X  = 35;
+const HEAD_W  = 364;
 const SHAFT_X = 422;
 const SHAFT_W = 576;
-const HEAD_X  = 1034;
-const HEAD_W  = 336;
+const TAIL_X  = 1034;
+const TAIL_W  = 336;
 
 
-// Scale factor to draw a small arrow around the plane
-const ARROW_SCALE = 0.03;
+// Scale factor so the arrow is about half the plane's size
+const ARROW_SCALE = 0.08;
 const ARROW_DEST_H = PART_H * ARROW_SCALE;
 const TAIL_DEST_W  = TAIL_W * ARROW_SCALE;
 const HEAD_DEST_W  = HEAD_W * ARROW_SCALE;
@@ -1311,8 +1310,6 @@ function handleAAForPlane(p, fp){
   gameCtx.clearRect(0,0, gameCanvas.width, gameCanvas.height);
   drawFieldBackground(gameCtx, gameCanvas.width, gameCanvas.height);
 
-  aimCtx.clearRect(0,0, aimCanvas.width, aimCanvas.height);
-
   // Планирование хода ИИ
   if (!isGameOver
       && gameMode === "computer"
@@ -1484,200 +1481,25 @@ function handleAAForPlane(p, fp){
 
     // вращаем самолёт по направлению предполагаемого полёта
     plane.angle = Math.atan2(-vdy, -vdx) + Math.PI/2;
-
-    const rect = gameCanvas.getBoundingClientRect();
-    const scaleX = rect.width / gameCanvas.width;
-    const scaleY = rect.height / gameCanvas.height;
-    const startX = rect.left + plane.x * scaleX;
-    const startY = rect.top  + plane.y * scaleY;
-
-    // Angles for ticks and overlays
-    const dragAngle = Math.atan2(vdy, vdx);
-    const tickAngle = dragAngle + Math.PI/2;
-    const numTicks = Math.min(5, Math.floor(vdist / CELL_SIZE));
-    const thirdDist = 3 * CELL_SIZE;
-    const fourthDist = 4 * CELL_SIZE;
-
-    // Predicted flight distance in cells based on current pull
-    const travelCells = (vdist / MAX_DRAG_DISTANCE) * flightRangeCells;
-    const labelSX = startX + CELL_SIZE * scaleX;
-    const labelSY = startY;
-
-    const travelPx = travelCells * CELL_SIZE;
-    const travelEndGX = plane.x - travelPx * Math.cos(dragAngle);
-    const travelEndGY = plane.y - travelPx * Math.sin(dragAngle);
-    const travelEndSX = rect.left + travelEndGX * scaleX;
-    const travelEndSY = rect.top  + travelEndGY * scaleY;
-
-
-    // Forward shadow aiming line (90% transparent)
-    const forwardEndX = rect.left + (plane.x - vdx) * scaleX;
-    const forwardEndY = rect.top  + (plane.y - vdy) * scaleY;
-
-    aimCtx.save();
-    aimCtx.globalAlpha = 0.1;
-
-    aimCtx.beginPath();
-    aimCtx.strokeStyle = "black";
-    aimCtx.lineWidth = 2;
-    aimCtx.moveTo(startX, startY);
-    aimCtx.lineTo(forwardEndX, forwardEndY);
-    aimCtx.stroke();
-
-    // Tick marks on the shadow line
-    for(let i=1; i<=numTicks; i++){
-      const d = i*CELL_SIZE;
-      if(d > vdist) break;
-      const posX = plane.x - d*Math.cos(dragAngle);
-      const posY = plane.y - d*Math.sin(dragAngle);
-      const halfTick = (CELL_SIZE/2)/2;
-      const startGX = posX - halfTick*Math.cos(tickAngle);
-      const startGY = posY - halfTick*Math.sin(tickAngle);
-      const endGX   = posX + halfTick*Math.cos(tickAngle);
-      const endGY   = posY + halfTick*Math.sin(tickAngle);
-
-      const startSX = rect.left + startGX * scaleX;
-      const startSY = rect.top  + startGY * scaleY;
-      const endSX   = rect.left + endGX   * scaleX;
-      const endSY   = rect.top  + endGY   * scaleY;
-
-      aimCtx.beginPath();
-      aimCtx.strokeStyle="black";
-      aimCtx.lineWidth=2;
-      aimCtx.moveTo(startSX, startSY);
-      aimCtx.lineTo(endSX, endSY);
-      aimCtx.stroke();
+    // Offset arrow so the drag point grabs the middle of the tail
+    const halfTail = TAIL_DEST_W / 2;
+    let baseDx = vdx;
+    let baseDy = vdy;
+    if (vdist > 0) {
+      const ux = vdx / vdist;
+      const uy = vdy / vdist;
+      const baseDist = Math.max(vdist - halfTail, 0);
+      baseDx = ux * baseDist;
+      baseDy = uy * baseDist;
     }
 
-    // Red overlay on the shadow line
-    if(vdist > thirdDist){
-      const start3GX = plane.x - thirdDist*Math.cos(dragAngle);
-      const start3GY = plane.y - thirdDist*Math.sin(dragAngle);
-      const start3SX = rect.left + start3GX * scaleX;
-      const start3SY = rect.top  + start3GY * scaleY;
-
-      const seg1EndDist = Math.min(vdist, fourthDist);
-      const seg1EndGX = plane.x - seg1EndDist*Math.cos(dragAngle);
-      const seg1EndGY = plane.y - seg1EndDist*Math.sin(dragAngle);
-      const seg1EndSX = rect.left + seg1EndGX * scaleX;
-      const seg1EndSY = rect.top  + seg1EndGY * scaleY;
-
-      aimCtx.beginPath();
-      aimCtx.strokeStyle = "black";
-      aimCtx.lineWidth = 1;
-      aimCtx.moveTo(start3SX, start3SY);
-      aimCtx.lineTo(seg1EndSX, seg1EndSY);
-      aimCtx.stroke();
-
-      if(vdist > fourthDist){
-        const seg2EndGX = plane.x - vdist*Math.cos(dragAngle);
-        const seg2EndGY = plane.y - vdist*Math.sin(dragAngle);
-        const seg2EndSX = rect.left + seg2EndGX * scaleX;
-        const seg2EndSY = rect.top  + seg2EndGY * scaleY;
-
-        aimCtx.beginPath();
-        aimCtx.strokeStyle = "black";
-        aimCtx.lineWidth = 2;
-        aimCtx.moveTo(seg1EndSX, seg1EndSY);
-        aimCtx.lineTo(seg2EndSX, seg2EndSY);
-        aimCtx.stroke();
-      }
-    }
-
-    aimCtx.restore();
-
-    // Tick marks and overlay on the aiming line (50% transparent)
-    aimCtx.save();
-    aimCtx.globalAlpha = 0.5;
-
-    for(let i=1; i<=numTicks; i++){
-      const d = i*CELL_SIZE;
-      if(d > vdist) break;
-      const posX = plane.x + d*Math.cos(dragAngle);
-      const posY = plane.y + d*Math.sin(dragAngle);
-      const halfTick = (CELL_SIZE/2)/2;
-      const startGX = posX - halfTick*Math.cos(tickAngle);
-      const startGY = posY - halfTick*Math.sin(tickAngle);
-      const endGX   = posX + halfTick*Math.cos(tickAngle);
-      const endGY   = posY + halfTick*Math.sin(tickAngle);
-
-      const startSX = rect.left + startGX * scaleX;
-      const startSY = rect.top  + startGY * scaleY;
-      const endSX   = rect.left + endGX   * scaleX;
-      const endSY   = rect.top  + endGY   * scaleY;
-
-      aimCtx.beginPath();
-      aimCtx.strokeStyle="black";
-      aimCtx.lineWidth=2;
-      aimCtx.moveTo(startSX, startSY);
-      aimCtx.lineTo(endSX, endSY);
-      aimCtx.stroke();
-    }
-
-    // Overlay after the third tick mark
-    if(vdist > thirdDist){
-      const start3GX = plane.x + thirdDist*Math.cos(dragAngle);
-      const start3GY = plane.y + thirdDist*Math.sin(dragAngle);
-      const start3SX = rect.left + start3GX * scaleX;
-      const start3SY = rect.top  + start3GY * scaleY;
-
-      const seg1EndDist = Math.min(vdist, fourthDist);
-      const seg1EndGX = plane.x + seg1EndDist*Math.cos(dragAngle);
-      const seg1EndGY = plane.y + seg1EndDist*Math.sin(dragAngle);
-      const seg1EndSX = rect.left + seg1EndGX * scaleX;
-      const seg1EndSY = rect.top  + seg1EndGY * scaleY;
-
-      aimCtx.beginPath();
-      aimCtx.strokeStyle = "black";
-      aimCtx.lineWidth = 1;
-      aimCtx.moveTo(start3SX, start3SY);
-      aimCtx.lineTo(seg1EndSX, seg1EndSY);
-      aimCtx.stroke();
-
-      if(vdist > fourthDist){
-        const seg2EndGX = plane.x + vdist*Math.cos(dragAngle);
-        const seg2EndGY = plane.y + vdist*Math.sin(dragAngle);
-        const seg2EndSX = rect.left + seg2EndGX * scaleX;
-        const seg2EndSY = rect.top  + seg2EndGY * scaleY;
-
-        aimCtx.beginPath();
-        aimCtx.strokeStyle = "black";
-        aimCtx.lineWidth = 2;
-        aimCtx.moveTo(seg1EndSX, seg1EndSY);
-        aimCtx.lineTo(seg2EndSX, seg2EndSY);
-        aimCtx.stroke();
-      }
-    }
-
-    aimCtx.restore();
-
-    // Draw arrow sprite under the plane
+    // Draw arrow sprite under the plane with opacity based on pull distance
+    const arrowAlpha = 0.5 * (vdist / MAX_DRAG_DISTANCE);
     gameCtx.save();
-    gameCtx.globalAlpha = 0.8;
-
-    drawArrow(gameCtx, plane.x, plane.y, vdx, vdy);
-
+    gameCtx.globalAlpha = arrowAlpha;
+    drawArrow(gameCtx, plane.x, plane.y, baseDx, baseDy);
     gameCtx.restore();
 
-
-    // Predicted distance text with 40% transparency
-    aimCtx.save();
-    aimCtx.globalAlpha = 0.6;
-
-
-    aimCtx.font = "18px 'Patrick Hand', cursive";
-    aimCtx.fillStyle = plane.color;
-    aimCtx.textAlign = "left";
-    aimCtx.textBaseline = "middle";
-    aimCtx.fillText(travelCells.toFixed(1), labelSX, labelSY);
-
-
-    aimCtx.font = "14px 'Patrick Hand', cursive";
-    aimCtx.textBaseline = "top";
-    aimCtx.fillText("cells", labelSX + 1, labelSY + 9);
-
-
-    aimCtx.restore();
 
   }
 
@@ -2205,46 +2027,47 @@ function drawBrickWall(ctx, width, height){
 function drawArrow(ctx, cx, cy, dx, dy) {
   if (!arrowSprite.complete) return;
 
-  // Total arrow length with the plane in the middle
-  const len = 2 * Math.hypot(dx, dy);
-  const ang = Math.atan2(dy, dx);
-
-  // Length of the stretchable shaft section
-  const shaftLen = Math.max(0, len - HEAD_DEST_W - TAIL_DEST_W);
+  // Shaft length doubles the pull distance so the plane sits in the middle
+  const shaftLen = 2 * Math.hypot(dx, dy);
+  const ang = Math.atan2(-dy, -dx); // head points toward flight direction
 
   ctx.save();
   ctx.translate(cx, cy);
   ctx.rotate(ang);
 
-  // Tail (fixed size)
+  // Tail (fixed size, anchored at the drag point, rotated 180°)
+  const tailCenterX = -shaftLen / 2 - TAIL_DEST_W / 2;
+  ctx.save();
+  ctx.translate(tailCenterX, 0);
+  ctx.rotate(Math.PI);
   ctx.drawImage(
     arrowSprite,
     TAIL_X, ARROW_Y, TAIL_W, PART_H,
-
-    -(shaftLen / 2 + TAIL_DEST_W), -ARROW_DEST_H / 2,
+    -TAIL_DEST_W / 2, -ARROW_DEST_H / 2,
     TAIL_DEST_W, ARROW_DEST_H
-
   );
+  ctx.restore();
 
   // Shaft (stretched to match distance)
   ctx.drawImage(
     arrowSprite,
     SHAFT_X, ARROW_Y, SHAFT_W, PART_H,
-
     -shaftLen / 2, -ARROW_DEST_H / 2,
     shaftLen, ARROW_DEST_H
-
   );
 
-  // Head (fixed size)
+  // Head (fixed size, rotated 180°)
+  const headCenterX = shaftLen / 2 + HEAD_DEST_W / 2;
+  ctx.save();
+  ctx.translate(headCenterX, 0);
+  ctx.rotate(Math.PI);
   ctx.drawImage(
     arrowSprite,
     HEAD_X, ARROW_Y, HEAD_W, PART_H,
-
-    shaftLen / 2, -ARROW_DEST_H / 2,
+    -HEAD_DEST_W / 2, -ARROW_DEST_H / 2,
     HEAD_DEST_W, ARROW_DEST_H
-
   );
+  ctx.restore();
 
   ctx.restore();
 }
@@ -2610,7 +2433,6 @@ function startNewRound(){
   scoreCanvas.style.display = "block";
   gameCanvas.style.display = "block";
   scoreCanvasBottom.style.display = "block";
-  aimCanvas.style.display = "block";
 
   initPoints(); // ориентации на базе
   blueFlagCarrier = null;


### PR DESCRIPTION
## Summary
- remove old line-based aiming overlays and tick marks
- keep only the scaled arrow under the plane for aiming
- center the tail sprite on the drag point for more natural grip
- fade in arrow opacity from transparent to 50% as the pull distance increases

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6a84823b0832d91fe1130399ad094