### PR TITLE
feat: show flight range value beside plane

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -32,8 +32,8 @@
                 <path d="M40 10 C38 2 30 0 22 0 C14 0 6 8 8 14 C10 18 18 20 26 18 C34 16 38 14 40 10 Z" fill="url(#menuFlameGradient)" />
               </svg>
             </div>
+            <div id="flightRangeDisplay" class="range-display">15</div>
           </div>
-          <div class="control-value"><span id="flightRangeDisplay">15 cells</span></div>
           <div class="control-buttons">
             <button id="flightRangeMinus" class="control-btn">−</button>
             <button id="flightRangePlus" class="control-btn">+</button>

--- a/settings.js
+++ b/settings.js
@@ -31,7 +31,7 @@ const backBtn = document.getElementById('backBtn');
 
 function updateFlightRangeDisplay(){
   const el = document.getElementById('flightRangeDisplay');
-  if(el) el.textContent = `${flightRangeCells} cells`;
+  if(el) el.textContent = `${flightRangeCells}`;
 }
 
 function updateFlightRangeFlame(){

--- a/styles.css
+++ b/styles.css
@@ -283,19 +283,19 @@ body {
 /* Индикатор дальности — самолёт с огнём */
 #flightRangeIndicator {
   position: relative;
-  width: 100px;
+  width: 120px;
   height: 24px;
   margin: auto;
   max-width: 100%;
   max-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  column-gap: 8px;
 }
 
 #flightRangeIndicator .jet {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-
+  position: relative;
   width: 40px;
   height: 20px;
 }
@@ -328,6 +328,13 @@ body {
 
   animation: flame-flicker 0.8s infinite;
 
+}
+
+/* Numeric display next to the plane */
+#flightRangeIndicator .range-display {
+  font-size: 20px;
+  color: #ee0000;
+  font-family: 'Patrick Hand', cursive;
 }
 
 #menuFlameGradient stop:first-child {


### PR DESCRIPTION
## Summary
- display flight range digits next to the jet indicator
- adjust styling and scripting to update the new readout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c8aacaac832d845e4a4d0618f8b4