### PR TITLE
Add drag slack before plane rotates

### DIFF
--- a/script.js
+++ b/script.js
@@ -123,6 +123,7 @@ const BOUNCE_FRAMES        = 68;
 // Duration of a full-speed flight in seconds (previously measured in frames)
 const FLIGHT_DURATION_SEC  = BOUNCE_FRAMES / 60;
 const MAX_DRAG_DISTANCE    = 100;    // px
+const DRAG_ROTATION_THRESHOLD = 5;   // px slack before the plane starts to turn
 const ATTACK_RANGE_PX      = 300;    // px
 let FIELD_BORDER_OFFSET = FIELD_BORDER_THICKNESS; // внутренняя граница для отражения
 // Используем бесконечное количество сегментов,
@@ -1486,8 +1487,13 @@ function handleAAForPlane(p, fp){
       vdist = MAX_DRAG_DISTANCE;
     }
 
-    // вращаем самолёт по направлению предполагаемого полёта
-    plane.angle = Math.atan2(-vdy, -vdx) + Math.PI/2;
+    // вращаем самолёт по направлению полёта только после небольшого смещения
+    // чтобы избежать резких рывков при лёгком касании
+    if(vdist > DRAG_ROTATION_THRESHOLD){
+      plane.angle = Math.atan2(-vdy, -vdx) + Math.PI/2;
+    } else {
+      plane.angle = handleCircle.origAngle;
+    }
 
     // Offset arrow so the drag point grabs the middle of the tail
     const halfTail = TAIL_DEST_W / 2;

--- a/styles.css
+++ b/styles.css
@@ -48,6 +48,8 @@ body {
   height: calc(100dvh - 140px);
   max-height: calc(100dvh - 140px);
   display: block;
+  position: relative;
+  z-index: 11;
 }
 
 /* Нижнее табло */


### PR DESCRIPTION
## Summary
- prevent plane from rotating immediately when touched by adding 5px drag threshold
- allow smoother aiming without visual jerk
- render aiming arrow behind plane by layering game canvas above overlay

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d0319b44832da9f6d50475251efc