### PR TITLE
Stabilize aiming amplitude behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 - Each side controls a group of paper planes (green vs. blue).
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
-- Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls"), enable sharp edges, and adjust aiming amplitude.
+- Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls"), enable sharp edges, and adjust aiming amplitude. The chosen amplitude is a fixed value in degrees and no longer scales with drag distance.
 - With **Sharp Edges** enabled, hitting the border destroys the plane instead of bouncing it back.
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - Rounds advance automatically; at the end of a match you can choose to play again or return to the menu.

--- a/script.js
+++ b/script.js
@@ -1455,12 +1455,11 @@ function handleAAForPlane(p, fp){
     let dy = handleCircle.baseY - plane.y;
     let distPx = Math.hypot(dx, dy);
 
-    // амплитуда зависит от расстояния натяжения
+    // clamp drag distance but keep a fixed wobble amplitude in degrees
     const clampedDist = Math.min(distPx, MAX_DRAG_DISTANCE);
 
-    // scale wobble smoothly with drag distance
-    const distRatio = clampedDist / MAX_DRAG_DISTANCE;
-    const maxAngleDeg = aimingAmplitude * 4 * distRatio * distRatio;
+    // use a constant aiming amplitude (in degrees) independent of drag distance
+    const maxAngleDeg = aimingAmplitude * 4;
     const maxAngleRad = maxAngleDeg * Math.PI / 180;
 
     // обновляем текущий угол раскачивания


### PR DESCRIPTION
## Summary
- Make aiming arrow wobble use a fixed amplitude in degrees instead of scaling with drag distance
- Document the stable degree-based aiming amplitude in README

## Testing
- `node --check script.js`
- `node --check settings.js`
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b70f2f6c90832d8f60193dc25e89b2