### PR TITLE
Set classic rules aiming amplitude to 10 degrees

### DIFF
--- a/script.js
+++ b/script.js
@@ -230,8 +230,8 @@ let settings = { addAA: false, sharpEdges: false };
 function loadSettings(){
   const fr = parseInt(localStorage.getItem('settings.flightRangeCells'));
   flightRangeCells = Number.isNaN(fr) ? 15 : fr;
-  const amp = parseInt(localStorage.getItem('settings.aimingAmplitude'));
-  aimingAmplitude = Number.isNaN(amp) ? 10 : amp;
+  const amp = parseFloat(localStorage.getItem('settings.aimingAmplitude'));
+  aimingAmplitude = Number.isNaN(amp) ? 10 / 4 : amp;
   const mi = parseInt(localStorage.getItem('settings.mapIndex'));
   mapIndex = Number.isNaN(mi) ? 1 : mi;
   if(mapIndex < 0 || mapIndex >= MAPS.length){
@@ -435,7 +435,7 @@ onlineBtn.addEventListener("click",()=>{
 if(classicRulesBtn){
   classicRulesBtn.addEventListener('click', () => {
     flightRangeCells = 15;
-    aimingAmplitude = 10;
+    aimingAmplitude = 10 / 4; // 10°
     mapIndex = 1;
     settings.addAA = false;
     settings.sharpEdges = false;

--- a/settings.js
+++ b/settings.js
@@ -10,7 +10,8 @@ function getIntSetting(key, defaultValue){
 }
 
 let flightRangeCells = getIntSetting('settings.flightRangeCells', 15);
-let aimingAmplitude  = getIntSetting('settings.aimingAmplitude', 10);
+let aimingAmplitude  = parseFloat(localStorage.getItem('settings.aimingAmplitude'));
+if(Number.isNaN(aimingAmplitude)) aimingAmplitude = 10 / 4;
 let mapIndex = getIntSetting('settings.mapIndex', 1);
 // Ensure stored index points to an existing map
 if(mapIndex < 0 || mapIndex >= MAPS.length){


### PR DESCRIPTION
## Summary
- default aiming amplitude to 10° for classic rules
- read and store aiming amplitude as fractional units so 10° persists

## Testing
- `node --check script.js`
- `node --check settings.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b71d0fbabc832d8d68c6ff9cec2a40