### PR TITLE
Smooth rotated planes and arrows

### DIFF
--- a/script.js
+++ b/script.js
@@ -20,6 +20,12 @@ const aimCtx      = aimCanvas.getContext("2d");
 const planeCanvas = document.getElementById("planeCanvas");
 const planeCtx    = planeCanvas.getContext("2d");
 
+// Enable smoothing so rotated images (planes, arrows) don't appear jagged
+[gameCtx, aimCtx, planeCtx].forEach(ctx => {
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = "high";
+});
+
 const modeMenuDiv = document.getElementById("modeMenu");
 const hotSeatBtn  = document.getElementById("hotSeatBtn");
 const computerBtn = document.getElementById("computerBtn");
@@ -72,6 +78,23 @@ const ARROW_SCALE = 0.08;
 const ARROW_DEST_H = PART_H * ARROW_SCALE;
 const TAIL_DEST_W  = TAIL_W * ARROW_SCALE;
 const HEAD_DEST_W  = HEAD_W * ARROW_SCALE;
+
+const PLAYER_COLORS = {
+  green: '#7f8e40',
+  blue: '#013c83'
+};
+
+function colorFor(color){
+  return PLAYER_COLORS[color] || color;
+}
+
+function colorWithAlpha(color, alpha){
+  const hex = colorFor(color).slice(1);
+  const r = parseInt(hex.slice(0,2),16);
+  const g = parseInt(hex.slice(2,4),16);
+  const b = parseInt(hex.slice(4,6),16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}
 
 let brickFrameBorderPx = FIELD_BORDER_THICKNESS;
 brickFrameImg.onload = () => {
@@ -661,11 +684,7 @@ function drawAAPlacementZone(){
 
   const half = gameCanvas.height / 2;
   gameCtx.save();
-  const color = currentPlacer === 'green'
-    ? 'rgba(0,255,0,0.05)'
-    : 'rgba(0,0,255,0.05)';
-
-  gameCtx.fillStyle = color;
+  gameCtx.fillStyle = colorWithAlpha(currentPlacer, 0.05);
   if(currentPlacer === 'green'){
     gameCtx.fillRect(0, half, gameCanvas.width, half);
   } else {
@@ -681,7 +700,7 @@ function drawAAPreview(){
 
   gameCtx.save();
   gameCtx.globalAlpha = 0.3;
-  gameCtx.strokeStyle = currentPlacer;
+  gameCtx.strokeStyle = colorFor(currentPlacer);
   gameCtx.beginPath();
   gameCtx.arc(x, y, AA_DEFAULTS.radius, 0, Math.PI*2);
   gameCtx.stroke();
@@ -698,7 +717,7 @@ function drawAAPreview(){
     const alpha = (1 - age/AA_TRAIL_MS) * 0.3;
 
     gameCtx.globalAlpha = alpha;
-    gameCtx.strokeStyle = currentPlacer;
+    gameCtx.strokeStyle = colorFor(currentPlacer);
     gameCtx.lineWidth = 2;
     gameCtx.lineCap = "round";
     const trailAng = seg.angleDeg * Math.PI/180;
@@ -717,7 +736,7 @@ function drawAAPreview(){
   const endY = y + Math.sin(ang) * AA_DEFAULTS.radius;
 
   gameCtx.globalAlpha = 0.6;
-  gameCtx.strokeStyle = currentPlacer;
+  gameCtx.strokeStyle = colorFor(currentPlacer);
   gameCtx.lineWidth = 2;
   gameCtx.lineCap = "round";
   gameCtx.beginPath();
@@ -736,7 +755,7 @@ function drawAAPreview(){
   gameCtx.stroke();
 
   gameCtx.globalAlpha = 0.4;
-  gameCtx.fillStyle = currentPlacer;
+  gameCtx.fillStyle = colorFor(currentPlacer);
   gameCtx.beginPath();
   gameCtx.arc(x, y, 6, 0, Math.PI*2);
   gameCtx.fill();
@@ -750,7 +769,7 @@ function drawAAPreview(){
 
   // colored center dot matching player color
   gameCtx.globalAlpha = 1;
-  gameCtx.fillStyle = currentPlacer;
+  gameCtx.fillStyle = colorFor(currentPlacer);
   gameCtx.beginPath();
   gameCtx.arc(x, y, 1.5, 0, Math.PI*2);
   gameCtx.fill();
@@ -1540,7 +1559,7 @@ function handleAAForPlane(p, fp){
 
   if(isGameOver && winnerColor){
     gameCtx.font="48px 'Patrick Hand', cursive";
-    gameCtx.fillStyle= winnerColor;
+    gameCtx.fillStyle= colorFor(winnerColor);
     const text= `${winnerColor.charAt(0).toUpperCase() + winnerColor.slice(1)} wins!`;
     const w= gameCtx.measureText(text).width;
     gameCtx.fillText(text, (gameCanvas.width - w)/2, gameCanvas.height/2 - 80);
@@ -1760,7 +1779,7 @@ function drawWingTrails(ctx2d){
 }
 
 function drawPlaneOutline(ctx2d, color){
-  ctx2d.strokeStyle = color;
+  ctx2d.strokeStyle = colorFor(color);
   ctx2d.lineWidth = 2;
   ctx2d.beginPath();
   ctx2d.moveTo(0, -20);
@@ -1778,6 +1797,7 @@ function drawThinPlane(ctx2d, plane){
   ctx2d.save();
   ctx2d.translate(cx, cy);
   ctx2d.rotate(angle);
+  ctx2d.filter = "blur(0.2px)"; // slight blur to soften rotated edges
   const showEngine = !(plane.burning && isExplosionFinished(plane));
   if(color === "blue"){
     if(showEngine){
@@ -1849,7 +1869,7 @@ function isExplosionFinished(p){
     ctx2d.scale(scale, scale);
     const angle = 0; // ВСЕГДА носом ВВЕРХ на табло
     ctx2d.rotate(angle);
-    ctx2d.strokeStyle = color;
+    ctx2d.strokeStyle = colorFor(color);
     ctx2d.lineWidth = 2/scale;
     ctx2d.beginPath();
     ctx2d.moveTo(0, -8);
@@ -1881,7 +1901,7 @@ function drawPlanesAndTrajectories(){
     if(!p.isAlive && !p.burning) continue;
     for(const seg of p.segments){
       gameCtx.beginPath();
-      gameCtx.strokeStyle = p.color;
+      gameCtx.strokeStyle = colorFor(p.color);
       gameCtx.lineWidth = seg.lineWidth || 3;
       gameCtx.moveTo(seg.x1, seg.y1);
       gameCtx.lineTo(seg.x2, seg.y2);
@@ -1898,12 +1918,12 @@ function drawPlanesAndTrajectories(){
       }
       const cells = Math.round((vdist / MAX_DRAG_DISTANCE) * flightRangeCells);
       const textX = p.x + POINT_RADIUS + 8;
-      rangeTextInfo = { color: p.color, cells, x: textX, y: p.y };
+      rangeTextInfo = { color: colorFor(p.color), cells, x: textX, y: p.y };
     }
 
     if(p.flagColor){
       planeCtx.save();
-      planeCtx.strokeStyle = p.flagColor;
+      planeCtx.strokeStyle = colorFor(p.flagColor);
       planeCtx.lineWidth = 3;
       planeCtx.beginPath();
       planeCtx.arc(p.x, p.y, POINT_RADIUS + 5, 0, Math.PI*2);
@@ -1964,7 +1984,7 @@ function drawFlag(ctx2d, x, y, color){
   ctx2d.lineTo(x, y - FLAG_POLE_HEIGHT);
   ctx2d.stroke();
 
-  ctx2d.fillStyle = color;
+  ctx2d.fillStyle = colorFor(color);
   ctx2d.beginPath();
   ctx2d.moveTo(x, y - FLAG_POLE_HEIGHT);
   ctx2d.lineTo(x + FLAG_WIDTH, y - FLAG_POLE_HEIGHT + FLAG_HEIGHT / 2);
@@ -2005,7 +2025,7 @@ function drawAAUnits(){
       const width = 8;
       const grad = gameCtx.createLinearGradient(0, -width/2, 0, width/2);
       grad.addColorStop(0, "rgba(0,0,0,0)");
-      grad.addColorStop(0.5, aa.owner);
+      grad.addColorStop(0.5, colorFor(aa.owner));
       grad.addColorStop(1, "rgba(0,0,0,0)");
 
       gameCtx.globalAlpha = alpha;
@@ -2024,7 +2044,7 @@ function drawAAUnits(){
     const ang = aa.sweepAngleDeg * Math.PI/180;
     const endX = aa.x + Math.cos(ang) * aa.radius;
     const endY = aa.y + Math.sin(ang) * aa.radius;
-    gameCtx.strokeStyle = aa.owner;
+    gameCtx.strokeStyle = colorFor(aa.owner);
     gameCtx.lineWidth = 2;
     gameCtx.lineCap = "round";
     gameCtx.beginPath();
@@ -2046,7 +2066,7 @@ function drawAAUnits(){
 
     // Anti-Aircraft center ring
     gameCtx.beginPath();
-    gameCtx.fillStyle = aa.owner;
+    gameCtx.fillStyle = colorFor(aa.owner);
     gameCtx.arc(aa.x, aa.y, 6, 0, Math.PI*2);
     gameCtx.fill();
 
@@ -2100,6 +2120,7 @@ function drawArrow(ctx, cx, cy, dx, dy) {
   ctx.save();
   ctx.translate(cx, cy);
   ctx.rotate(ang);
+  ctx.filter = "blur(0.2px)"; // soften jagged arrow when rotated
 
   // Tail (fixed size, anchored at the drag point, rotated 180°)
   const tailCenterX = -shaftLen / 2 - TAIL_DEST_W / 2;
@@ -2375,14 +2396,14 @@ function drawPlayerPanel(ctx, color, score, isTurn){
   if (phase === 'AA_PLACEMENT') {
     if (currentPlacer === color) {
       statusText = 'You are placing Anti-Aircraft';
-      ctx.fillStyle = color;
+      ctx.fillStyle = colorFor(color);
     } else {
       statusText = 'Enemy is placing Anti-Aircraft';
       ctx.fillStyle = '#888';
     }
   } else if (isTurn) {
     statusText = "Your Turn";
-    ctx.fillStyle = color;
+    ctx.fillStyle = colorFor(color);
   } else {
     statusText = "Enemy Pilot's Turn";
     ctx.fillStyle = "#888";
@@ -2390,7 +2411,7 @@ function drawPlayerPanel(ctx, color, score, isTurn){
   ctx.fillText(statusText, sectionW*1.5, canvas.height/2);
 
   // score
-  ctx.fillStyle = color;
+  ctx.fillStyle = colorFor(color);
   ctx.fillText(String(score), sectionW*2.5, canvas.height/2);
 }
 


### PR DESCRIPTION
## Summary
- enable high-quality image smoothing on game, aim and plane canvases
- apply slight blur filter when drawing rotated planes and aiming arrow to reduce jagged edges
- map player colors to plane-specific hex codes and use them across trails, flags and UI

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7309db50c832d9aeed79e8303a1ac