### PR TITLE
Center field with new frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <canvas id="scoreCanvas" width="300" height="60" style="display:none;"></canvas>
 
   <!-- Game Field (Initially Hidden) -->
-  <canvas id="gameCanvas" width="300" height="400" style="display:none;"></canvas>
+  <canvas id="gameCanvas" width="383" height="400" style="display:none;"></canvas>
 
   <!-- Bottom Scoreboard (Initially Hidden) -->
   <canvas id="scoreCanvasBottom" width="300" height="60" style="display:none;"></canvas>

--- a/script.js
+++ b/script.js
@@ -52,7 +52,10 @@ fieldImg.src = "field 5.png";
 const FIELD_BORDER_THICKNESS = 10; // px, width of brick frame edges
 
 const brickFrameImg = new Image();
-brickFrameImg.src = "brick frame 2.png";
+brickFrameImg.src = "brick frame 3.png";
+
+let FIELD_LEFT = 0;
+let FIELD_WIDTH = 0;
 
 // Sprite used for the aiming arrow
 const arrowSprite = new Image();
@@ -113,7 +116,8 @@ brickFrameImg.onload = () => {
     }
   }
   brickFrameBorderPx = top;
-  updateFieldBorderOffset();
+  updateFieldDimensions();
+  if(points.length) initPoints();
 };
 
 
@@ -172,10 +176,22 @@ function updateFieldBorderOffset(){
   if(settings.sharpEdges){
     FIELD_BORDER_OFFSET = 0;
   } else if(brickFrameImg.naturalWidth){
-    FIELD_BORDER_OFFSET = brickFrameBorderPx * (gameCanvas.width / brickFrameImg.naturalWidth);
+    FIELD_BORDER_OFFSET = brickFrameBorderPx * (FIELD_WIDTH / brickFrameImg.naturalWidth);
   } else {
     FIELD_BORDER_OFFSET = FIELD_BORDER_THICKNESS;
   }
+}
+
+function updateFieldDimensions(){
+  if(brickFrameImg.naturalWidth && brickFrameImg.naturalHeight){
+    const aspect = brickFrameImg.naturalWidth / brickFrameImg.naturalHeight;
+    FIELD_WIDTH = gameCanvas.height * aspect;
+    FIELD_LEFT = (gameCanvas.width - FIELD_WIDTH) / 2;
+  } else {
+    FIELD_LEFT = 0;
+    FIELD_WIDTH = gameCanvas.width;
+  }
+  updateFieldBorderOffset();
 }
 
 
@@ -326,12 +342,12 @@ let aiMoveScheduled = false;
 /* ======= INIT ======= */
 function initPoints(){
   points = [];
-  const spacing = gameCanvas.width / (PLANES_PER_SIDE + 1);
+  const spacing = FIELD_WIDTH / (PLANES_PER_SIDE + 1);
   const middleOffset = MIDDLE_GAP_EXTRA_PX / 2;
 
   // Green (низ поля) — смотрят ВВЕРХ (к сопернику)
   for(let i = 1; i <= PLANES_PER_SIDE; i++){
-    let x = spacing * i;
+    let x = FIELD_LEFT + spacing * i;
     if(i === Math.ceil(PLANES_PER_SIDE / 2)) x -= middleOffset;
     if(i === Math.ceil(PLANES_PER_SIDE / 2) + 1) x += middleOffset;
     points.push(makePlane(x, gameCanvas.height - 40, "green", 0)); // 0 рад — нос вверх
@@ -339,7 +355,7 @@ function initPoints(){
 
   // Blue (верх поля) — смотрят ВНИЗ
   for(let i = 1; i <= PLANES_PER_SIDE; i++){
-    let x = spacing * i;
+    let x = FIELD_LEFT + spacing * i;
     if(i === Math.ceil(PLANES_PER_SIDE / 2)) x -= middleOffset;
     if(i === Math.ceil(PLANES_PER_SIDE / 2) + 1) x += middleOffset;
     points.push(makePlane(x, 40, "blue", Math.PI)); // π рад — нос вниз
@@ -650,6 +666,11 @@ function isValidAAPlacement(x,y){
     return false;
   }
 
+  if (x < FIELD_LEFT + FIELD_BORDER_OFFSET ||
+      x > FIELD_LEFT + FIELD_WIDTH - FIELD_BORDER_OFFSET) {
+    return false;
+  }
+
   // Prevent placing the AA center inside any building
   for(const b of buildings){
     const left = b.x - b.width/2;
@@ -689,9 +710,9 @@ function drawAAPlacementZone(){
   gameCtx.save();
   gameCtx.fillStyle = colorWithAlpha(currentPlacer, 0.05);
   if(currentPlacer === 'green'){
-    gameCtx.fillRect(0, half, gameCanvas.width, half);
+    gameCtx.fillRect(FIELD_LEFT, half, FIELD_WIDTH, half);
   } else {
-    gameCtx.fillRect(0, 0, gameCanvas.width, half);
+    gameCtx.fillRect(FIELD_LEFT, 0, FIELD_WIDTH, half);
   }
   gameCtx.restore();
 }
@@ -868,7 +889,7 @@ function doComputerMove(){
   const enemies  = points.filter(p=> p.color==="green" && p.isAlive && !p.burning);
   if(!aiPlanes.length || !enemies.length) return;
 
-  const centerX = gameCanvas.width/2;
+  const centerX = FIELD_LEFT + FIELD_WIDTH/2;
   const topY    = 40;
   const bottomY = gameCanvas.height - 40;
 
@@ -1373,16 +1394,16 @@ function handleAAForPlane(p, fp){
       p.y += fp.vy * deltaSec;
 
         // field borders
-        if (p.x < FIELD_BORDER_OFFSET) {
-          p.x = FIELD_BORDER_OFFSET;
+        if (p.x < FIELD_LEFT + FIELD_BORDER_OFFSET) {
+          p.x = FIELD_LEFT + FIELD_BORDER_OFFSET;
           if (settings.sharpEdges) {
             destroyPlane(fp);
             continue;
           }
           fp.vx = -fp.vx;
         }
-        else if (p.x > gameCanvas.width - FIELD_BORDER_OFFSET) {
-          p.x = gameCanvas.width - FIELD_BORDER_OFFSET;
+        else if (p.x > FIELD_LEFT + FIELD_WIDTH - FIELD_BORDER_OFFSET) {
+          p.x = FIELD_LEFT + FIELD_WIDTH - FIELD_BORDER_OFFSET;
           if (settings.sharpEdges) {
             destroyPlane(fp);
             continue;
@@ -1586,11 +1607,12 @@ function handleAAForPlane(p, fp){
 
 /* ======= RENDER ======= */
 function drawFieldBackground(ctx2d, w, h){
+  ctx2d.fillStyle = "#fffbea";
+  ctx2d.fillRect(0,0,w,h);
   if(fieldImg.complete){
-    ctx2d.drawImage(fieldImg, 0, 0, w, h);
+    ctx2d.drawImage(fieldImg, FIELD_LEFT, 0, FIELD_WIDTH, h);
   } else {
-    ctx2d.fillStyle = "#fffbea";
-    ctx2d.fillRect(0,0,w,h);
+    ctx2d.fillRect(FIELD_LEFT, 0, FIELD_WIDTH, h);
   }
 }
 
@@ -1656,35 +1678,34 @@ function drawNailEdges(ctx2d, w, h){
 
 function drawBrickEdges(ctx2d, w, h){
   if(brickFrameImg.complete){
-    ctx2d.drawImage(brickFrameImg, 0, 0, w, h);
+    ctx2d.drawImage(brickFrameImg, FIELD_LEFT, 0, FIELD_WIDTH, h);
   } else {
     const brickHeight = FIELD_BORDER_THICKNESS;
-    // draw all walls fully inside the canvas
-
-    // top border
     ctx2d.save();
-    ctx2d.translate(w / 2, brickHeight / 2);
-    drawBrickWall(ctx2d, w, brickHeight);
+    ctx2d.translate(FIELD_LEFT, 0);
+
+    ctx2d.save();
+    ctx2d.translate(FIELD_WIDTH / 2, brickHeight / 2);
+    drawBrickWall(ctx2d, FIELD_WIDTH, brickHeight);
     ctx2d.restore();
 
-    // bottom border
     ctx2d.save();
-    ctx2d.translate(w / 2, h - brickHeight / 2);
-    drawBrickWall(ctx2d, w, brickHeight);
+    ctx2d.translate(FIELD_WIDTH / 2, h - brickHeight / 2);
+    drawBrickWall(ctx2d, FIELD_WIDTH, brickHeight);
     ctx2d.restore();
 
-    // left border
     ctx2d.save();
     ctx2d.translate(brickHeight / 2, h / 2);
     ctx2d.rotate(Math.PI / 2);
     drawBrickWall(ctx2d, h, brickHeight);
     ctx2d.restore();
 
-    // right border
     ctx2d.save();
-    ctx2d.translate(w - brickHeight / 2, h / 2);
+    ctx2d.translate(FIELD_WIDTH - brickHeight / 2, h / 2);
     ctx2d.rotate(Math.PI / 2);
     drawBrickWall(ctx2d, h, brickHeight);
+    ctx2d.restore();
+
     ctx2d.restore();
   }
 }
@@ -2016,7 +2037,7 @@ function drawFlag(ctx2d, x, y, color){
 }
 
 function drawFlags(){
-  const centerX = gameCanvas.width / 2;
+  const centerX = FIELD_LEFT + FIELD_WIDTH / 2;
   if(!blueFlagCarrier){
     drawFlag(gameCtx, centerX, 40, "blue");
   }
@@ -2306,7 +2327,7 @@ function distanceToFlag(px, py, baseX, baseY){
 }
 
 function handleFlagInteractions(plane){
-  const centerX = gameCanvas.width / 2;
+  const centerX = FIELD_LEFT + FIELD_WIDTH / 2;
   const topY = 40;
   const bottomY = gameCanvas.height - 40;
   const flagRadius = POINT_RADIUS;
@@ -2462,10 +2483,10 @@ function generateRandomBuildingAligned(){
     const width = buildingSize[type].width;
     const height= buildingSize[type].height;
 
-    const x = getRandomGridAlignedCoordinate(gameCanvas.width,  width/2);
+    const x = FIELD_LEFT + getRandomGridAlignedCoordinate(FIELD_WIDTH,  width/2);
     const minY = 80; // избегаем зон самолётов
-  const maxY = gameCanvas.height - 80;
-  const y = minY + Math.random() * (maxY - minY - height);
+    const maxY = gameCanvas.height - 80;
+    const y = minY + Math.random() * (maxY - minY - height);
     if(x===null || y===null){ attempt++; continue; }
 
     const b = { type, x, y, color, width, height };
@@ -2566,7 +2587,7 @@ function startNewRound(){
 /* ======= Map helpers ======= */
 function applyCurrentMap(){
   buildings = [];
-  updateFieldBorderOffset();
+  updateFieldDimensions();
   if(MAPS[mapIndex] === "clear sky"){
     // no buildings to add
   } else if (MAPS[mapIndex] === "wall") {
@@ -2574,19 +2595,19 @@ function applyCurrentMap(){
     const wallHeight = CELL_SIZE;
     buildings.push({
       type: "wall",
-      x: gameCanvas.width / 2,
+      x: FIELD_LEFT + FIELD_WIDTH / 2,
       y: gameCanvas.height / 2,
       width: wallWidth,
       height: wallHeight,
       color: "darkred"
     });
   } else if (MAPS[mapIndex] === "two walls") {
-    const wallWidth = gameCanvas.width / 2;
+    const wallWidth = FIELD_WIDTH / 2;
     const wallHeight = CELL_SIZE;
     const offset = CELL_SIZE * 2;
     buildings.push({
       type: "wall",
-      x: wallWidth / 2,
+      x: FIELD_LEFT + wallWidth / 2,
       y: gameCanvas.height / 2 + offset,
       width: wallWidth,
       height: wallHeight,
@@ -2594,7 +2615,7 @@ function applyCurrentMap(){
     });
     buildings.push({
       type: "wall",
-      x: gameCanvas.width - wallWidth / 2,
+      x: FIELD_LEFT + FIELD_WIDTH - wallWidth / 2,
       y: gameCanvas.height / 2 - offset,
       width: wallWidth,
       height: wallHeight,


### PR DESCRIPTION
## Summary
- Centered the play field within the canvas using the new `brick frame 3.png` and computed horizontal offsets.
- Repositioned planes and map obstacles based on the new field width and adjusted collision handling.

## Testing
- `node --check script.js`
- `npm test` *(fails: no such file or directory 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b871c02314832d98565b82dee07280