### PR TITLE
Center field with new frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <canvas id="scoreCanvas" width="300" height="60" style="display:none;"></canvas>
 
   <!-- Game Field (Initially Hidden) -->
-  <canvas id="gameCanvas" width="300" height="400" style="display:none;"></canvas>
+  <canvas id="gameCanvas" width="383" height="400" style="display:none;"></canvas>
 
   <!-- Bottom Scoreboard (Initially Hidden) -->
   <canvas id="scoreCanvasBottom" width="300" height="60" style="display:none;"></canvas>


### PR DESCRIPTION
## Summary
- Centered the play field within the canvas using the new `brick frame 3.png` and computed horizontal offsets.
- Repositioned planes and map obstacles based on the new field width and adjusted collision handling.
- Calculated brick-frame side borders and used them so planes bounce off the brick walls rather than the canvas edges.

## Testing
- `node --check script.js`
- `npm test` *(fails: no such file or directory 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b871c02314832d98565b82dee07280