### PR TITLE
feat: add 6 bricks map

### DIFF
--- a/script.js
+++ b/script.js
@@ -265,7 +265,7 @@ const AA_TRAIL_MS = 5000; // radar sweep afterglow duration
 
 
 
-const MAPS = ["clear sky", "wall", "two walls"];
+const MAPS = ["clear sky", "wall", "two walls", "6 bricks"];
 
 let mapIndex;
 let flightRangeCells; // cells for menu and physics
@@ -1439,11 +1439,18 @@ function handleAAForPlane(p, fp){
       p.y += fp.vy * deltaSec;
 
         if(isBrickPixel(p.x, p.y)){
-          if(Math.abs(p.x - prevX) > Math.abs(p.y - prevY)){
+          const hitX = isBrickPixel(prevX, p.y);
+          const hitY = isBrickPixel(p.x, prevY);
+          if(!hitX && hitY){
             p.x = prevX;
             fp.vx = -fp.vx;
-          } else {
+          } else if(hitX && !hitY){
             p.y = prevY;
+            fp.vy = -fp.vy;
+          } else {
+            p.x = prevX;
+            p.y = prevY;
+            fp.vx = -fp.vx;
             fp.vy = -fp.vy;
           }
         }
@@ -2647,6 +2654,12 @@ function startNewRound(){
 /* ======= Map helpers ======= */
 function applyCurrentMap(){
   buildings = [];
+  // load appropriate brick layout for current map
+  if(MAPS[mapIndex] === "6 bricks"){
+    brickFrameImg.src = "6 bricks.png";
+  } else {
+    brickFrameImg.src = "brick frame 3.png";
+  }
   updateFieldDimensions();
   if(MAPS[mapIndex] === "clear sky"){
     // no buildings to add

--- a/settings.js
+++ b/settings.js
@@ -2,7 +2,7 @@ const MIN_FLIGHT_RANGE_CELLS = 5;
 const MAX_FLIGHT_RANGE_CELLS = 30;
 const MIN_AMPLITUDE = 0;
 const MAX_AMPLITUDE = 30;
-const MAPS = ["clear sky", "wall", "two walls"];
+const MAPS = ["clear sky", "wall", "two walls", "6 bricks"];
 
 function getIntSetting(key, defaultValue){
   const value = parseInt(localStorage.getItem(key));


### PR DESCRIPTION
## Summary
- improve brick collision handling so planes bounce correctly off field edges
- add optional "6 bricks" map and load its brick layout image

## Testing
- `node --check script.js`
- `node --check settings.js`


------
https://chatgpt.com/codex/tasks/task_e_68b92a57ca30832d980f243294c47393