### PR TITLE
Add deadly center line map

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 - Each side controls a group of paper planes (green vs. blue).
 - Use the mouse to drag a plane, aim and release to launch it. Releasing before the first tick mark cancels the move.
-- Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls", "7 bricks", "15 diagonals"), enable sharp edges, and adjust aiming amplitude. The chosen amplitude is a fixed value in degrees and no longer scales with drag distance.
+- Controls let you tune the flight range, choose the map ("clear sky", "wall", "two walls", "7 bricks", "15 diagonals", "deadly center line"), enable sharp edges, and adjust aiming amplitude. The chosen amplitude is a fixed value in degrees and no longer scales with drag distance.
 - With **Sharp Edges** enabled, hitting the border destroys the plane instead of bouncing it back.
 - Hitting an enemy plane destroys it. When one colour has no planes left, the other wins the round.
 - Rounds advance automatically; at the end of a match you can choose to play again or return to the menu.

--- a/script.js
+++ b/script.js
@@ -265,7 +265,7 @@ const AA_TRAIL_MS = 5000; // radar sweep afterglow duration
 
 
 
-const MAPS = ["clear sky", "wall", "two walls", "7 bricks", "15 diagonals"];
+const MAPS = ["clear sky", "wall", "two walls", "7 bricks", "15 diagonals", "deadly center line"];
 
 let mapIndex;
 let flightRangeCells; // cells for menu and physics
@@ -1440,8 +1440,18 @@ function handleAAForPlane(p, fp){
 
         if(isBrickPixel(p.x, p.y)){
           const sample = (sx, sy) => isBrickPixel(sx, sy) ? 1 : 0;
-          let nx = sample(p.x - 1, p.y) - sample(p.x + 1, p.y);
-          let ny = sample(p.x, p.y - 1) - sample(p.x, p.y + 1);
+          // Estimate surface normal using a Sobel-like 3×3 kernel so
+          // reflections work correctly for diagonal walls as well.
+          let nx = (
+            sample(prevX - 1, prevY - 1) + 2*sample(prevX - 1, prevY) + sample(prevX - 1, prevY + 1)
+          ) - (
+            sample(prevX + 1, prevY - 1) + 2*sample(prevX + 1, prevY) + sample(prevX + 1, prevY + 1)
+          );
+          let ny = (
+            sample(prevX - 1, prevY - 1) + 2*sample(prevX, prevY - 1) + sample(prevX + 1, prevY - 1)
+          ) - (
+            sample(prevX - 1, prevY + 1) + 2*sample(prevX, prevY + 1) + sample(prevX + 1, prevY + 1)
+          );
           const len = Math.hypot(nx, ny);
           if(len > 0){
             nx /= len;
@@ -2676,6 +2686,8 @@ function applyCurrentMap(){
     brickFrameImg.src = "7 bricks.png";
   } else if (MAPS[mapIndex] === "15 diagonals") {
     brickFrameImg.src = "15 diagonals.png";
+  } else if (MAPS[mapIndex] === "deadly center line") {
+    brickFrameImg.src = "map deadly center line.png";
   } else {
     brickFrameImg.src = "brick frame 3.png";
   }

--- a/settings.js
+++ b/settings.js
@@ -2,7 +2,7 @@ const MIN_FLIGHT_RANGE_CELLS = 5;
 const MAX_FLIGHT_RANGE_CELLS = 30;
 const MIN_AMPLITUDE = 0;
 const MAX_AMPLITUDE = 30;
-const MAPS = ["clear sky", "wall", "two walls", "7 bricks", "15 diagonals"];
+const MAPS = ["clear sky", "wall", "two walls", "7 bricks", "15 diagonals", "deadly center line"];
 
 function getIntSetting(key, defaultValue){
   const value = parseInt(localStorage.getItem(key));


### PR DESCRIPTION
## Summary
- add "deadly center line" to map selection and load its PNG frame
- document new map in readme
- fix diagonal wall reflections by sampling the previous position when estimating surface normals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba992b9b68832d8e86721e4408f975