### PR TITLE
fix: set game canvas to 360x640

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,13 +9,13 @@
 </head>
 <body>
   <!-- Top Scoreboard (Initially Hidden) -->
-  <canvas id="scoreCanvas" width="300" height="60" style="display:none;"></canvas>
+  <canvas id="scoreCanvas" width="360" height="60" style="display:none;"></canvas>
 
   <!-- Game Field (Initially Hidden) -->
-  <canvas id="gameCanvas" width="383" height="400" style="display:none;"></canvas>
+  <canvas id="gameCanvas" width="360" height="640" style="display:none;"></canvas>
 
   <!-- Bottom Scoreboard (Initially Hidden) -->
-  <canvas id="scoreCanvasBottom" width="300" height="60" style="display:none;"></canvas>
+  <canvas id="scoreCanvasBottom" width="360" height="60" style="display:none;"></canvas>
 
   <!-- Overlay canvas for aiming line -->
   <canvas id="aimCanvas" style="display:none;"></canvas>

--- a/script.js
+++ b/script.js
@@ -2767,31 +2767,25 @@ function resizeCanvas() {
   }
 
   const canvas = gameCanvas;
-  const container = document.body;
+  const width = 360;
+  const height = 640;
 
-  // Максимальный размер с учётом табло
-  const maxWidth = Math.min(window.innerWidth * 0.95, 383);
-  const maxHeight = Math.min(window.innerHeight - 120, window.innerHeight * 0.7);
-
-  canvas.style.width = maxWidth + 'px';
-  canvas.style.height = maxHeight + 'px';
-
-  // Масштабируем canvas пропорционально
-  const scale = Math.min(maxWidth / 300, maxHeight / 400);
-  canvas.width = 300 * scale;
-  canvas.height = 400 * scale;
+  canvas.style.width = width + 'px';
+  canvas.style.height = height + 'px';
+  canvas.width = width;
+  canvas.height = height;
 
   updateFieldDimensions();
 
-  aimCanvas.style.width = window.innerWidth + 'px';
-  aimCanvas.style.height = window.innerHeight + 'px';
-  aimCanvas.width = window.innerWidth;
-  aimCanvas.height = window.innerHeight;
+  aimCanvas.style.width = width + 'px';
+  aimCanvas.style.height = height + 'px';
+  aimCanvas.width = width;
+  aimCanvas.height = height;
 
-  planeCanvas.style.width = window.innerWidth + 'px';
-  planeCanvas.style.height = window.innerHeight + 'px';
-  planeCanvas.width = window.innerWidth;
-  planeCanvas.height = window.innerHeight;
+  planeCanvas.style.width = width + 'px';
+  planeCanvas.style.height = height + 'px';
+  planeCanvas.width = width;
+  planeCanvas.height = height;
 
 
   // Переинициализируем самолёты

--- a/styles.css
+++ b/styles.css
@@ -30,8 +30,8 @@ body {
   margin: 5px auto;
   background-color: rgba(255, 255, 255, 0.9);
   border-radius: 8px;
-  width: 95vw;
-  max-width: 350px;
+  width: 360px;
+  max-width: 360px;
   height: 60px;
   display: block;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
@@ -43,10 +43,8 @@ body {
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
   border-radius: 12px;
   background-color: #fffbea;
-  width: 95vw;
-  max-width: 350px;
-  height: calc(100dvh - 140px);
-  max-height: calc(100dvh - 140px);
+  width: 360px;
+  height: 640px;
   display: block;
   position: relative;
   z-index: 11;
@@ -57,8 +55,8 @@ body {
   margin: 5px auto;
   background-color: rgba(255, 255, 255, 0.9);
   border-radius: 8px;
-  width: 95vw;
-  max-width: 350px;
+  width: 360px;
+  max-width: 360px;
   height: 60px;
   display: block;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
@@ -69,8 +67,8 @@ body {
   position: fixed;
   top: 0;
   left: 0;
-  width: 100vw;
-  height: 100dvh;
+  width: 360px;
+  height: 640px;
   pointer-events: none;
   /* Ensure the arrow renders above the game field */
   z-index: 20;
@@ -82,8 +80,8 @@ body {
   position: fixed;
   top: 0;
   left: 0;
-  width: 100vw;
-  height: 100dvh;
+  width: 360px;
+  height: 640px;
   pointer-events: none;
   /* Highest layer so planes appear above the aiming arrow */
   z-index: 30;


### PR DESCRIPTION
## Summary
- fix game canvas and related overlays to a fixed 360x640 size
- align scoreboards to 360px width for consistent layout

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be7feb84bc832d9e1919b77e27d548