### PR TITLE
Use new clear sky map image

### DIFF
--- a/script.js
+++ b/script.js
@@ -2708,7 +2708,9 @@ function startNewRound(){
 function applyCurrentMap(){
   buildings = [];
   // load appropriate brick layout for current map
-  if (MAPS[mapIndex] === "7 bricks") {
+  if (MAPS[mapIndex] === "clear sky") {
+    brickFrameImg.src = "map 1_ clear sky.png";
+  } else if (MAPS[mapIndex] === "7 bricks") {
     brickFrameImg.src = "7 bricks.png";
   } else if (MAPS[mapIndex] === "15 diagonals") {
     brickFrameImg.src = "15 diagonals.png";


### PR DESCRIPTION
## Summary
- Switch clear sky map to use `map 1_ clear sky.png` with integrated brick border.

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68be84727a7c832db99b286b96213ce8