### PR TITLE
feat: use paper background for field

### DIFF
--- a/script.js
+++ b/script.js
@@ -47,8 +47,8 @@ bluePlaneImg.src = "blue plane 23.5.png";
 const greenPlaneImg = new Image();
 
 greenPlaneImg.src = "green plane 2.png";
-const fieldImg = new Image();
-fieldImg.src = "field 5.png";
+const backgroundImg = new Image();
+backgroundImg.src = "background paper 1.png";
 const FIELD_BORDER_THICKNESS = 10; // px, width of brick frame edges
 
 const brickFrameImg = new Image();
@@ -1726,12 +1726,8 @@ function handleAAForPlane(p, fp){
 
 /* ======= RENDER ======= */
 function drawFieldBackground(ctx2d, w, h){
-  ctx2d.fillStyle = "#fffbea";
-  ctx2d.fillRect(0,0,w,h);
-  if(fieldImg.complete){
-    ctx2d.drawImage(fieldImg, FIELD_LEFT, 0, FIELD_WIDTH, h);
-  } else {
-    ctx2d.fillRect(FIELD_LEFT, 0, FIELD_WIDTH, h);
+  if(backgroundImg.complete){
+    ctx2d.drawImage(backgroundImg, 0, 0, w, h);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -42,7 +42,7 @@ body {
   margin: 5px auto;
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
   border-radius: 12px;
-  background-color: #fffbea;
+  background-color: transparent;
   width: 360px;
   height: 640px;
   display: block;


### PR DESCRIPTION
## Summary
- replace grid and paper with `background paper 1.png`
- clean canvas background color

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/p-p-online/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68bff6b1923c832d91c741e086562ad0