### PR TITLE
Expand plane selection hit area

### DIFF
--- a/script.js
+++ b/script.js
@@ -174,6 +174,8 @@ document.addEventListener('dblclick', (e) => {
 const PLANE_SCALE          = 0.9;    // 10% smaller planes
 const CELL_SIZE            = 20;     // px
 const POINT_RADIUS         = 15 * PLANE_SCALE;     // px (увеличено для мобильных)
+// Larger hit area for selecting planes with touch/mouse
+const PLANE_TOUCH_RADIUS   = 20;                   // px
 const AA_HIT_RADIUS        = POINT_RADIUS + 5; // slightly larger zone to hit Anti-Aircraft center
 const BOUNCE_FRAMES        = 68;
 // Duration of a full-speed flight in seconds (previously measured in frames)
@@ -621,7 +623,7 @@ function handleStart(e) {
   let found= points.find(pt=>
     pt.color=== currentColor &&
     pt.isAlive && !pt.burning &&
-    Math.hypot(pt.x - mx, pt.y - my) <= POINT_RADIUS
+    Math.hypot(pt.x - mx, pt.y - my) <= PLANE_TOUCH_RADIUS
   );
   if(!found) return;
 


### PR DESCRIPTION
## Summary
- Add configurable radius for selecting planes and set to 20px
- Use the new radius when detecting player touches on planes

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c063017604832db57f842dfbf18e08