### PR TITLE
Expand plane selection hit area and remove plane halo

### DIFF
--- a/script.js
+++ b/script.js
@@ -174,6 +174,8 @@ document.addEventListener('dblclick', (e) => {
 const PLANE_SCALE          = 0.9;    // 10% smaller planes
 const CELL_SIZE            = 20;     // px
 const POINT_RADIUS         = 15 * PLANE_SCALE;     // px (увеличено для мобильных)
+// Larger hit area for selecting planes with touch/mouse
+const PLANE_TOUCH_RADIUS   = 20;                   // px
 const AA_HIT_RADIUS        = POINT_RADIUS + 5; // slightly larger zone to hit Anti-Aircraft center
 const BOUNCE_FRAMES        = 68;
 // Duration of a full-speed flight in seconds (previously measured in frames)
@@ -621,7 +623,7 @@ function handleStart(e) {
   let found= points.find(pt=>
     pt.color=== currentColor &&
     pt.isAlive && !pt.burning &&
-    Math.hypot(pt.x - mx, pt.y - my) <= POINT_RADIUS
+    Math.hypot(pt.x - mx, pt.y - my) <= PLANE_TOUCH_RADIUS
   );
   if(!found) return;
 
@@ -1918,13 +1920,14 @@ function drawWingTrails(ctx2d){
 }
 
 function addPlaneShading(ctx2d){
-  const grad = ctx2d.createRadialGradient(0, 0, 10, 0, 0, 20);
-  grad.addColorStop(0, "rgba(255,255,255,0.2)");
-  grad.addColorStop(1, "rgba(0,0,0,0)");
+  const grad = ctx2d.createRadialGradient(0, 0, 8, 0, 0, 18);
+  grad.addColorStop(0, "rgba(255,255,255,0.15)");
+  grad.addColorStop(1, "rgba(0,0,0,0.25)");
+  ctx2d.save();
+  ctx2d.globalCompositeOperation = "source-atop";
   ctx2d.fillStyle = grad;
-  ctx2d.beginPath();
-  ctx2d.arc(0, 0, 20, 0, Math.PI * 2);
-  ctx2d.fill();
+  ctx2d.fillRect(-20, -20, 40, 40);
+  ctx2d.restore();
 }
 
 function drawPlaneOutline(ctx2d, color){


### PR DESCRIPTION
## Summary
- Add configurable radius for selecting planes and set to 20px
- Use the new radius when detecting player touches on planes
- Clip plane shading to plane body so no glow appears

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c063017604832db57f842dfbf18e08