### PR TITLE
Add selectable second map with classic randomization

### DIFF
--- a/script.js
+++ b/script.js
@@ -316,9 +316,12 @@ let phase = "MENU"; // MENU | AA_PLACEMENT (Anti-Aircraft placement) | ROUND_STA
 
 
 let currentPlacer = null; // 'green' | 'blue'
+const MAPS = [
+  { name: 'Clear Sky', file: 'map 1_ clear sky 2.png' },
+  { name: '5 Bricks',  file: 'map 2 - 5 bricks.png' }
+];
 
-let settings = { addAA: false, sharpEdges: false };
-// Map selection has been reduced to a single "clear sky" layout.
+let settings = { addAA: false, sharpEdges: false, mapIndex: 0 };
 
 function loadSettings(){
   const fr = parseInt(localStorage.getItem('settings.flightRangeCells'));
@@ -327,6 +330,8 @@ function loadSettings(){
   aimingAmplitude = Number.isNaN(amp) ? 10 / 4 : amp;
   settings.addAA = localStorage.getItem('settings.addAA') === 'true';
   settings.sharpEdges = localStorage.getItem('settings.sharpEdges') === 'true';
+  const mapIdx = parseInt(localStorage.getItem('settings.mapIndex'));
+  settings.mapIndex = Number.isNaN(mapIdx) ? 0 : Math.min(MAPS.length - 1, Math.max(0, mapIdx));
 
   // Clamp loaded values so corrupted or out-of-range settings
   // don't break the game on startup
@@ -343,7 +348,8 @@ const hasCustomSettings = [
   'settings.flightRangeCells',
   'settings.aimingAmplitude',
   'settings.addAA',
-  'settings.sharpEdges'
+  'settings.sharpEdges',
+  'settings.mapIndex'
 ].some(key => localStorage.getItem(key) !== null);
 
 if(hasCustomSettings && classicRulesBtn && advancedSettingsBtn){
@@ -454,6 +460,9 @@ function resetGame(){
   globalFrame=0;
   flyingPoints= [];
   buildings = [];
+  if(!advancedSettingsBtn?.classList.contains('selected')){
+    settings.mapIndex = Math.floor(Math.random() * MAPS.length);
+  }
   applyCurrentMap();
 
   aaUnits = [];
@@ -525,6 +534,7 @@ if(classicRulesBtn){
     aimingAmplitude = 10 / 4; // 10°
     settings.addAA = false;
     settings.sharpEdges = false;
+    settings.mapIndex = Math.floor(Math.random() * MAPS.length);
     applyCurrentMap();
     advancedSettingsBtn?.classList.remove('selected');
     classicRulesBtn.classList.add('selected');
@@ -2642,10 +2652,15 @@ function isOverlappingWithBuildings(b){
 
 /* ======= SCORE / ROUND ======= */
 yesBtn.addEventListener("click", () => {
-  if (blueScore >= POINTS_TO_WIN || greenScore >= POINTS_TO_WIN) {
+  const gameOver = blueScore >= POINTS_TO_WIN || greenScore >= POINTS_TO_WIN;
+  if (gameOver) {
     blueScore = 0;
     greenScore = 0;
     roundNumber = 0;
+    if(!advancedSettingsBtn?.classList.contains('selected')){
+      settings.mapIndex = Math.floor(Math.random() * MAPS.length);
+      applyCurrentMap();
+    }
   }
   startNewRound();
 });
@@ -2697,7 +2712,8 @@ function startNewRound(){
 /* ======= Map helpers ======= */
 function applyCurrentMap(){
   buildings = [];
-  brickFrameImg.src = "map 1_ clear sky 2.png";
+  const map = MAPS[settings.mapIndex] || MAPS[0];
+  brickFrameImg.src = map.file;
   updateFieldDimensions();
   renderScoreboard();
 }

--- a/settings.html
+++ b/settings.html
@@ -61,6 +61,16 @@
 
       </div>
 
+      <!-- Map Selection -->
+    <div class="control-box">
+      <div class="control-label">Map</div>
+      <div class="control-visual"></div>
+      <div class="control-value"></div>
+      <div class="control-buttons">
+        <select id="mapSelect"></select>
+      </div>
+    </div>
+
       <!-- Additional Settings -->
     <div class="control-box" id="additionalSettings">
       <div class="control-label">Additional Settings</div>

--- a/settings.js
+++ b/settings.js
@@ -3,6 +3,11 @@ const MAX_FLIGHT_RANGE_CELLS = 30;
 const MIN_AMPLITUDE = 0;
 const MAX_AMPLITUDE = 30;
 
+const MAPS = [
+  { name: 'Clear Sky', file: 'map 1_ clear sky 2.png' },
+  { name: '5 Bricks', file: 'map 2 - 5 bricks.png' }
+];
+
 function getIntSetting(key, defaultValue){
   const value = parseInt(localStorage.getItem(key));
   return Number.isNaN(value) ? defaultValue : value;
@@ -13,6 +18,7 @@ let aimingAmplitude  = parseFloat(localStorage.getItem('settings.aimingAmplitude
 if(Number.isNaN(aimingAmplitude)) aimingAmplitude = 10 / 4;
 let addAA = localStorage.getItem('settings.addAA') === 'true';
 let sharpEdges = localStorage.getItem('settings.sharpEdges') === 'true';
+let mapIndex = getIntSetting('settings.mapIndex', 0);
 
 const flightRangeMinusBtn = document.getElementById('flightRangeMinus');
 const flightRangePlusBtn  = document.getElementById('flightRangePlus');
@@ -21,6 +27,7 @@ const amplitudePlusBtn    = document.getElementById('amplitudePlus');
 const addAAToggle = document.getElementById('addAAToggle');
 const sharpEdgesToggle = document.getElementById('sharpEdgesToggle');
 const backBtn = document.getElementById('backBtn');
+const mapSelect = document.getElementById('mapSelect');
 
 function updateFlightRangeDisplay(){
   const el = document.getElementById('flightRangeDisplay');
@@ -72,6 +79,7 @@ function saveSettings(){
   localStorage.setItem('settings.aimingAmplitude', aimingAmplitude);
   localStorage.setItem('settings.addAA', addAA);
   localStorage.setItem('settings.sharpEdges', sharpEdges);
+  localStorage.setItem('settings.mapIndex', mapIndex);
 }
 
 function setupRepeatButton(btn, cb){
@@ -106,6 +114,20 @@ if(sharpEdgesToggle){
   sharpEdgesToggle.checked = sharpEdges;
   sharpEdgesToggle.addEventListener('change', e => {
     sharpEdges = e.target.checked;
+    saveSettings();
+  });
+}
+
+if(mapSelect){
+  MAPS.forEach((m, idx) => {
+    const opt = document.createElement('option');
+    opt.value = idx;
+    opt.textContent = m.name;
+    mapSelect.appendChild(opt);
+  });
+  mapSelect.value = String(mapIndex);
+  mapSelect.addEventListener('change', e => {
+    mapIndex = parseInt(e.target.value);
     saveSettings();
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -290,6 +290,14 @@ body {
   margin-top: 8px;
 }
 
+#modeMenu .control-box select {
+  padding: 6px 10px;
+  border: 2px solid #ff0000c8;
+  border-radius: 8px;
+  background: #fff;
+  font-size: 16px;
+}
+
 /* Индикатор дальности — самолёт с огнём */
 #flightRangeIndicator {
   position: relative;


### PR DESCRIPTION
## Summary
- Support multiple maps and load "5 Bricks" layout
- Allow map selection in advanced settings with dropdown UI
- Randomize map choice in classic rules

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c124332700832da229e359903fc2e9