### PR TITLE
Fix initial map load

### DIFF
--- a/script.js
+++ b/script.js
@@ -52,7 +52,9 @@ backgroundImg.src = "background paper 1.png";
 const FIELD_BORDER_THICKNESS = 10; // px, width of brick frame edges
 
 const brickFrameImg = new Image();
-brickFrameImg.src = "brick frame 3.png";
+// Load the default map on startup so we don't request a missing image
+// and fail to initialize the playing field before `applyCurrentMap()` runs.
+brickFrameImg.src = "map 1_ clear sky 2.png";
 let brickFrameData = null;
 
 let FIELD_LEFT = 0;


### PR DESCRIPTION
## Summary
- Load default map on startup instead of missing placeholder image
- Avoids initialization failure before `applyCurrentMap` runs

## Testing
- `node --check script.js && echo "script.js syntax ok"`
- `node --check settings.js && echo "settings.js syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68c125b3124c832d84c44710e5cf58a2