### PR TITLE
feat: add background image behind game canvases

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,14 +8,16 @@
   <link href="https://fonts.googleapis.com/css2?family=Patrick+Hand&family=Roboto&display=swap" rel="stylesheet">
 </head>
 <body>
-  <!-- Top Scoreboard (Initially Hidden) -->
-  <canvas id="scoreCanvas" width="360" height="60" style="display:none;"></canvas>
+  <div id="gameContainer">
+    <!-- Top Scoreboard (Initially Hidden) -->
+    <canvas id="scoreCanvas" width="360" height="60" style="display:none;"></canvas>
 
-  <!-- Game Field (Initially Hidden) -->
-  <canvas id="gameCanvas" width="360" height="640" style="display:none;"></canvas>
+    <!-- Game Field (Initially Hidden) -->
+    <canvas id="gameCanvas" width="360" height="640" style="display:none;"></canvas>
 
-  <!-- Bottom Scoreboard (Initially Hidden) -->
-  <canvas id="scoreCanvasBottom" width="360" height="60" style="display:none;"></canvas>
+    <!-- Bottom Scoreboard (Initially Hidden) -->
+    <canvas id="scoreCanvasBottom" width="360" height="60" style="display:none;"></canvas>
+  </div>
 
   <!-- Overlay canvas for aiming line -->
   <canvas id="aimCanvas" style="display:none;"></canvas>

--- a/styles.css
+++ b/styles.css
@@ -11,19 +11,32 @@ body, button {
 }
 
 /* Базовый шрифт/раскладка */
-body {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  font-family: 'Roboto', sans-serif;
-  background-color: #fff0f0;
-  margin: 0;
-  padding: 0;
-  height: 100dvh;
-  overflow: hidden;
-  touch-action: none;
-}
+  body {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: 'Roboto', sans-serif;
+    background-color: #fff0f0;
+    margin: 0;
+    padding: 0;
+    height: 100dvh;
+    overflow: hidden;
+    touch-action: none;
+  }
+
+  #gameContainer {
+    position: relative;
+    width: 460px;
+    height: 800px;
+    padding: 5px 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-image: url("background behind the canvas.png");
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+  }
 
 /* Верхнее табло */
 #scoreCanvas {


### PR DESCRIPTION
## Summary
- layer a new page background image under the game elements so the field sits on a custom backdrop

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c581efbf54832d9bb10938c95d8409