### PR TITLE
feat: add turn indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,10 @@
 
     <!-- Bottom Scoreboard (Initially Hidden) -->
     <canvas id="scoreCanvasBottom" width="360" height="60" style="display:none;"></canvas>
+
+    <!-- Turn indicators -->
+    <div id="mantisIndicator" class="turn-indicator" style="display:none;"></div>
+    <div id="goatIndicator" class="turn-indicator" style="display:none;"></div>
   </div>
 
   <!-- Overlay canvas for aiming line -->

--- a/script.js
+++ b/script.js
@@ -11,6 +11,9 @@ const scoreCtx    = scoreCanvas.getContext("2d");
 const scoreCanvasBottom = document.getElementById("scoreCanvasBottom");
 const scoreCtxBottom    = scoreCanvasBottom.getContext("2d");
 
+const mantisIndicator = document.getElementById("mantisIndicator");
+const goatIndicator   = document.getElementById("goatIndicator");
+
 const gameCanvas  = document.getElementById("gameCanvas");
 const gameCtx     = gameCanvas.getContext("2d");
 
@@ -507,6 +510,8 @@ function resetGame(){
   scoreCanvas.style.display = "none";
   gameCanvas.style.display = "none";
   scoreCanvasBottom.style.display = "none";
+  mantisIndicator.style.display = "none";
+  goatIndicator.style.display = "none";
   aimCanvas.style.display = "none";
   planeCanvas.style.display = "none";
   planeCtx.clearRect(0,0,planeCanvas.width,planeCanvas.height);
@@ -2533,6 +2538,13 @@ function checkVictory(){
 function renderScoreboard(){
   drawPlayerPanel(scoreCtx, "blue", blueScore, turnColors[turnIndex] === "blue");
   drawPlayerPanel(scoreCtxBottom, "green", greenScore, turnColors[turnIndex] === "green");
+  updateTurnIndicators();
+}
+
+function updateTurnIndicators(){
+  const color = turnColors[turnIndex];
+  mantisIndicator.classList.toggle('active', color === 'blue');
+  goatIndicator.classList.toggle('active', color === 'green');
 }
 
 function drawPlayerPanel(ctx, color, score, isTurn){
@@ -2709,6 +2721,8 @@ function startNewRound(){
   scoreCanvas.style.display = "block";
   gameCanvas.style.display = "block";
   scoreCanvasBottom.style.display = "block";
+  mantisIndicator.style.display = "block";
+  goatIndicator.style.display = "block";
   planeCanvas.style.display = "block";
 
   initPoints(); // ориентации на базе

--- a/styles.css
+++ b/styles.css
@@ -77,6 +77,41 @@ body, button {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
+/* Turn indicators */
+.turn-indicator {
+  position: absolute;
+  left: 0;
+  width: 460px;
+  height: 400px;
+  background-image: url("goat and mantis.png");
+  background-size: 460px 800px;
+  background-repeat: no-repeat;
+  pointer-events: none;
+  opacity: 0.3;
+  transition: opacity 0.3s, filter 0.3s;
+  z-index: 40;
+}
+
+#mantisIndicator {
+  top: 0;
+  background-position: top center;
+}
+
+#goatIndicator {
+  bottom: 0;
+  background-position: center bottom;
+}
+
+#mantisIndicator.active {
+  opacity: 1;
+  filter: drop-shadow(0 0 10px #013c83);
+}
+
+#goatIndicator.active {
+  opacity: 1;
+  filter: drop-shadow(0 0 10px #7f8e40);
+}
+
 /* Overlay canvas for aiming line */
 #aimCanvas {
   position: fixed;


### PR DESCRIPTION
## Summary
- overlay mantis and goat turn indicators at top and bottom of game container
- highlight current player's indicator with a glow and fade the inactive player
- toggle indicator visibility with the scoreboard and update on turn changes

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c58f5b53e4832d84ea072e93b11ab7