### PR TITLE
feat: overlay transparent HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,14 +9,8 @@
 </head>
 <body>
   <div id="gameContainer">
-    <!-- Top Scoreboard (Initially Hidden) -->
-    <canvas id="scoreCanvas" width="360" height="60" style="display:none;"></canvas>
-
     <!-- Game Field (Initially Hidden) -->
     <canvas id="gameCanvas" width="360" height="640" style="display:none;"></canvas>
-
-    <!-- Bottom Scoreboard (Initially Hidden) -->
-    <canvas id="scoreCanvasBottom" width="360" height="60" style="display:none;"></canvas>
 
     <!-- Turn indicators -->
     <div id="mantisIndicator" class="turn-indicator" style="display:none;"></div>

--- a/script.js
+++ b/script.js
@@ -5,12 +5,6 @@
  ***************************************************************/
 
 /* ======= DOM ======= */
-const scoreCanvas = document.getElementById("scoreCanvas");
-const scoreCtx    = scoreCanvas.getContext("2d");
-
-const scoreCanvasBottom = document.getElementById("scoreCanvasBottom");
-const scoreCtxBottom    = scoreCanvasBottom.getContext("2d");
-
 const mantisIndicator = document.getElementById("mantisIndicator");
 const goatIndicator   = document.getElementById("goatIndicator");
 
@@ -507,9 +501,7 @@ function resetGame(){
 
   // Показать меню, скрыть канвасы
   modeMenuDiv.style.display = "block";
-  scoreCanvas.style.display = "none";
   gameCanvas.style.display = "none";
-  scoreCanvasBottom.style.display = "none";
   mantisIndicator.style.display = "none";
   goatIndicator.style.display = "none";
   aimCanvas.style.display = "none";
@@ -2536,9 +2528,11 @@ function checkVictory(){
 /* ======= SCOREBOARD ======= */
 
 function renderScoreboard(){
-  drawPlayerPanel(scoreCtx, "blue", blueScore, turnColors[turnIndex] === "blue");
-  drawPlayerPanel(scoreCtxBottom, "green", greenScore, turnColors[turnIndex] === "green");
   updateTurnIndicators();
+  planeCtx.save();
+  drawPlayerHUD(planeCtx, 10, 10, "blue", blueScore, turnColors[turnIndex] === "blue", false);
+  drawPlayerHUD(planeCtx, planeCanvas.width - 10, 10, "green", greenScore, turnColors[turnIndex] === "green", true);
+  planeCtx.restore();
 }
 
 function updateTurnIndicators(){
@@ -2547,68 +2541,45 @@ function updateTurnIndicators(){
   goatIndicator.classList.toggle('active', color === 'green');
 }
 
-function drawPlayerPanel(ctx, color, score, isTurn){
-  const canvas = ctx.canvas;
-  ctx.clearRect(0,0, canvas.width, canvas.height);
-  ctx.fillStyle = "#fffbea";
-  ctx.fillRect(0,0, canvas.width, canvas.height);
+function drawPlayerHUD(ctx, x, y, color, score, isTurn, alignRight){
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.font = "14px 'Patrick Hand', cursive";
+  ctx.textBaseline = "top";
+  ctx.textAlign = alignRight ? "right" : "left";
 
-  const sectionW = canvas.width/3;
-
-  // separators
-  ctx.strokeStyle = "rgba(0,0,0,0.1)";
-  ctx.beginPath();
-  ctx.moveTo(sectionW,0); ctx.lineTo(sectionW,canvas.height);
-  ctx.moveTo(sectionW*2,0); ctx.lineTo(sectionW*2,canvas.height);
-  ctx.stroke();
-
-  // plane counters
-  const bluePlanes  = points.filter(p => p.color === "blue");
-  const greenPlanes = points.filter(p => p.color === "green");
+  const planes = points.filter(p => p.color === color);
   const maxPerRow = 4;
   const spacingX = 20;
-  const startX = sectionW / 2 - ((maxPerRow - 1) * spacingX) / 2;
-
-  const rowSpacingY = 20;
-  const startY = canvas.height / 2 - rowSpacingY / 2;
-  const blueY = startY;
-  const greenY = startY + rowSpacingY;
-  for (let i = 0; i < Math.min(bluePlanes.length, maxPerRow); i++) {
-    const p = bluePlanes[i];
-    const x = startX + i * spacingX;
-    drawMiniPlaneWithCross(ctx, x, blueY, "blue", p.isAlive, p.burning && isExplosionFinished(p), 0.8);
-  }
-  for (let i = 0; i < Math.min(greenPlanes.length, maxPerRow); i++) {
-    const p = greenPlanes[i];
-    const x = startX + i * spacingX;
-    drawMiniPlaneWithCross(ctx, x, greenY, "green", p.isAlive, p.burning && isExplosionFinished(p), 0.8);
+  for (let i = 0; i < Math.min(planes.length, maxPerRow); i++) {
+    const p = planes[i];
+    const px = alignRight ? -i * spacingX : i * spacingX;
+    drawMiniPlaneWithCross(ctx, px, 0, color, p.isAlive, p.burning && isExplosionFinished(p), 0.8);
   }
 
-  // turn indicator
-  ctx.font = "14px 'Patrick Hand', cursive";
-  ctx.textAlign = "center";
-  ctx.textBaseline = "middle";
+  ctx.fillStyle = colorFor(color);
+  const scoreX = 0;
+  ctx.fillText(String(score), scoreX, 20);
+
   let statusText;
   if (phase === 'AA_PLACEMENT') {
     if (currentPlacer === color) {
-      statusText = 'You are placing Anti-Aircraft';
+      statusText = 'Placing AA';
       ctx.fillStyle = colorFor(color);
     } else {
-      statusText = 'Enemy is placing Anti-Aircraft';
+      statusText = 'Enemy placing AA';
       ctx.fillStyle = '#888';
     }
   } else if (isTurn) {
-    statusText = "Your Turn";
+    statusText = 'Your Turn';
     ctx.fillStyle = colorFor(color);
   } else {
-    statusText = "Enemy Pilot's Turn";
-    ctx.fillStyle = "#888";
+    statusText = "Enemy's Turn";
+    ctx.fillStyle = '#888';
   }
-  ctx.fillText(statusText, sectionW*1.5, canvas.height/2);
+  ctx.fillText(statusText, scoreX, 40);
 
-  // score
-  ctx.fillStyle = colorFor(color);
-  ctx.fillText(String(score), sectionW*2.5, canvas.height/2);
+  ctx.restore();
 }
 
 
@@ -2718,9 +2689,7 @@ function startNewRound(){
   aaUnits = [];
 
   aiMoveScheduled = false;
-  scoreCanvas.style.display = "block";
   gameCanvas.style.display = "block";
-  scoreCanvasBottom.style.display = "block";
   mantisIndicator.style.display = "block";
   goatIndicator.style.display = "block";
   planeCanvas.style.display = "block";
@@ -2760,28 +2729,17 @@ function resizeCanvas() {
   }
   const BASE_WIDTH = 360;
   const BASE_HEIGHT = 640;
-  const SCORE_HEIGHT = 60;
   const MARGIN = 5;
 
   // Determine how much we can scale canvases to fit available space
   const scale = Math.min(
     window.innerWidth / BASE_WIDTH,
-    window.innerHeight / (BASE_HEIGHT + 2 * SCORE_HEIGHT + 6 * MARGIN)
+    window.innerHeight / (BASE_HEIGHT + 2 * MARGIN)
   );
 
   const scaledWidth = BASE_WIDTH * scale;
   const scaledHeight = BASE_HEIGHT * scale;
-  const scaledScoreHeight = SCORE_HEIGHT * scale;
   const scaledMargin = MARGIN * scale;
-
-  // Resize score canvases
-  [scoreCanvas, scoreCanvasBottom].forEach(canvas => {
-    canvas.style.width = scaledWidth + 'px';
-    canvas.style.height = scaledScoreHeight + 'px';
-    canvas.style.margin = scaledMargin + 'px auto';
-    canvas.width = BASE_WIDTH;
-    canvas.height = SCORE_HEIGHT;
-  });
 
   // Resize main game canvas
   const canvas = gameCanvas;

--- a/styles.css
+++ b/styles.css
@@ -29,25 +29,12 @@ body, button {
   #gameContainer {
     position: relative;
     width: 460px;
-    height: 800px;
+    height: 640px;
     padding: 5px 0;
     display: flex;
     flex-direction: column;
     align-items: center;
   }
-
-
-/* Верхнее табло */
-#scoreCanvas {
-  margin: 5px auto;
-  background-color: transparent;
-  border-radius: 8px;
-  width: 360px;
-  max-width: 360px;
-  height: 60px;
-  display: block;
-  box-shadow: none;
-}
 
 /* Игровое поле */
 #gameCanvas {
@@ -62,26 +49,15 @@ body, button {
   z-index: 11;
 }
 
-/* Нижнее табло */
-#scoreCanvasBottom {
-  margin: 5px auto;
-  background-color: transparent;
-  border-radius: 8px;
-  width: 360px;
-  max-width: 360px;
-  height: 60px;
-  display: block;
-  box-shadow: none;
-}
 
 /* Turn indicators */
 .turn-indicator {
   position: absolute;
   left: 0;
   width: 460px;
-  height: 400px;
+  height: 320px;
   background-image: url("goat and mantis.png");
-  background-size: 460px 800px;
+  background-size: 460px 640px;
   background-repeat: no-repeat;
   pointer-events: none;
   opacity: 0.3;


### PR DESCRIPTION
## Summary
- remove top and bottom scoreboard canvases
- draw plane, score and turn indicators on transparent overlay
- adjust layout sizing and turn indicator styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c59f0749c8832dbd297139e2e65c6d