### PR TITLE
Align game field and mascots with background

### DIFF
--- a/script.js
+++ b/script.js
@@ -2764,11 +2764,11 @@ function resizeCanvas() {
 
   [mantisIndicator, goatIndicator].forEach(ind => {
     ind.style.width = containerWidth + 'px';
-    ind.style.height = CANVAS_BASE_HEIGHT / 2 * scale + 'px';
-    ind.style.backgroundSize = containerWidth + 'px ' + CANVAS_BASE_HEIGHT * scale + 'px';
+    ind.style.height = FRAME_BASE_HEIGHT / 2 * scale + 'px';
+    ind.style.backgroundSize = containerWidth + 'px ' + containerHeight + 'px';
   });
-  mantisIndicator.style.top = FRAME_PADDING_Y * scale + 'px';
-  goatIndicator.style.top = (FRAME_PADDING_Y + CANVAS_BASE_HEIGHT / 2) * scale + 'px';
+  mantisIndicator.style.top = '0px';
+  goatIndicator.style.top = containerHeight / 2 + 'px';
 
   updateFieldDimensions();
 

--- a/styles.css
+++ b/styles.css
@@ -53,9 +53,9 @@ body, button {
   position: absolute;
   left: 0;
   width: 460px;
-  height: 320px;
+  height: 400px;
   background-image: url("goat and mantis.png");
-  background-size: 460px 640px;
+  background-size: 460px 800px;
   background-repeat: no-repeat;
   pointer-events: none;
   opacity: 0.3;
@@ -64,7 +64,7 @@ body, button {
 }
 
 #mantisIndicator {
-  top: 80px;
+  top: 0;
   background-position: top center;
 }
 


### PR DESCRIPTION
## Summary
- Correct turn indicator sizing and positioning to cover the full frame and align mascots with the board.
- Update resize logic to scale indicators using frame dimensions and place them at the top and midpoint of the container.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5aa6acf88832da0edb0eef4ad7eda