### PR TITLE
Show enemy turn on inactive indicator and remove player turn text

### DIFF
--- a/script.js
+++ b/script.js
@@ -2553,6 +2553,16 @@ function updateTurnIndicators(){
   const color = turnColors[turnIndex];
   mantisIndicator.classList.toggle('active', color === 'blue');
   goatIndicator.classList.toggle('active', color === 'green');
+
+  mantisIndicator.textContent = '';
+  goatIndicator.textContent = '';
+  if (phase !== 'AA_PLACEMENT') {
+    if (color === 'blue') {
+      goatIndicator.textContent = "Enemy's Turn";
+    } else {
+      mantisIndicator.textContent = "Enemy's Turn";
+    }
+  }
 }
 
 function drawPlayerHUD(ctx, x, y, color, score, isTurn, alignRight){
@@ -2575,7 +2585,7 @@ function drawPlayerHUD(ctx, x, y, color, score, isTurn, alignRight){
   const scoreX = 0;
   ctx.fillText(String(score), scoreX, 20);
 
-  let statusText;
+  let statusText = '';
   if (phase === 'AA_PLACEMENT') {
     if (currentPlacer === color) {
       statusText = 'Placing AA';
@@ -2584,14 +2594,10 @@ function drawPlayerHUD(ctx, x, y, color, score, isTurn, alignRight){
       statusText = 'Enemy placing AA';
       ctx.fillStyle = '#888';
     }
-  } else if (isTurn) {
-    statusText = 'Your Turn';
-    ctx.fillStyle = colorFor(color);
-  } else {
-    statusText = "Enemy's Turn";
-    ctx.fillStyle = '#888';
   }
-  ctx.fillText(statusText, scoreX, 40);
+  if (statusText) {
+    ctx.fillText(statusText, scoreX, 40);
+  }
 
   ctx.restore();
 }

--- a/styles.css
+++ b/styles.css
@@ -58,8 +58,14 @@ body, button {
   background-size: 460px 800px;
   background-repeat: no-repeat;
   pointer-events: none;
-  opacity: 0.3;
-  transition: opacity 0.3s, filter 0.3s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Patrick Hand', cursive;
+  font-size: 32px;
+  color: #000;
+  filter: grayscale(1);
+  transition: filter 0.3s;
   z-index: 40;
 }
 
@@ -74,13 +80,11 @@ body, button {
 }
 
 #mantisIndicator.active {
-  opacity: 1;
-  filter: drop-shadow(0 0 10px #013c83);
+  filter: grayscale(0) drop-shadow(0 0 10px #013c83);
 }
 
 #goatIndicator.active {
-  opacity: 1;
-  filter: drop-shadow(0 0 10px #7f8e40);
+  filter: grayscale(0) drop-shadow(0 0 10px #7f8e40);
 }
 
 /* Overlay canvas for aiming line */


### PR DESCRIPTION
## Summary
- Remove scoreboard messages for "Your Turn" and use turn indicators for enemy turn display.
- Overlay "Enemy's Turn" text on the inactive player's indicator.
- Style turn indicators for centered text and grayscale when inactive.

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b6072f88832d97da88ef8d996f56