### PR TITLE
Center turn indicator text over animals

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,12 @@
     <canvas id="gameCanvas" width="360" height="640" style="display:none;"></canvas>
 
     <!-- Turn indicators -->
-    <div id="mantisIndicator" class="turn-indicator" style="display:none;"></div>
-    <div id="goatIndicator" class="turn-indicator" style="display:none;"></div>
+    <div id="mantisIndicator" class="turn-indicator" style="display:none;">
+      <span class="turn-text"></span>
+    </div>
+    <div id="goatIndicator" class="turn-indicator" style="display:none;">
+      <span class="turn-text"></span>
+    </div>
   </div>
 
   <!-- Overlay canvas for aiming line -->

--- a/script.js
+++ b/script.js
@@ -7,6 +7,8 @@
 /* ======= DOM ======= */
 const mantisIndicator = document.getElementById("mantisIndicator");
 const goatIndicator   = document.getElementById("goatIndicator");
+const mantisText = mantisIndicator.querySelector('.turn-text');
+const goatText = goatIndicator.querySelector('.turn-text');
 
 const gameContainer = document.getElementById("gameContainer");
 const gameCanvas  = document.getElementById("gameCanvas");
@@ -2554,13 +2556,13 @@ function updateTurnIndicators(){
   mantisIndicator.classList.toggle('active', color === 'blue');
   goatIndicator.classList.toggle('active', color === 'green');
 
-  mantisIndicator.textContent = '';
-  goatIndicator.textContent = '';
+  mantisText.textContent = '';
+  goatText.textContent = '';
   if (phase !== 'AA_PLACEMENT') {
     if (color === 'blue') {
-      goatIndicator.textContent = "Enemy's Turn";
+      goatText.textContent = "Enemy's Turn";
     } else {
-      mantisIndicator.textContent = "Enemy's Turn";
+      mantisText.textContent = "Enemy's Turn";
     }
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -58,15 +58,21 @@ body, button {
   background-size: 460px 800px;
   background-repeat: no-repeat;
   pointer-events: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: 'Patrick Hand', cursive;
-  font-size: 32px;
-  color: #000;
   filter: grayscale(1);
   transition: filter 0.3s;
   z-index: 40;
+}
+
+.turn-indicator .turn-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: 'Patrick Hand', cursive;
+  font-size: 32px;
+  color: rgba(128, 128, 128, 0.6);
+  text-align: center;
+  pointer-events: none;
 }
 
 #mantisIndicator {


### PR DESCRIPTION
## Summary
- place turn indicator text directly over the animal images and style it with semi-transparent gray text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b7a5632c832d81eba952d6becd95