### PR TITLE
Remove enemy turn labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -2558,13 +2558,6 @@ function updateTurnIndicators(){
 
   mantisText.textContent = '';
   goatText.textContent = '';
-  if (phase !== 'AA_PLACEMENT') {
-    if (color === 'blue') {
-      goatText.textContent = "Enemy's Turn";
-    } else {
-      mantisText.textContent = "Enemy's Turn";
-    }
-  }
 }
 
 function drawPlayerHUD(ctx, x, y, color, score, isTurn, alignRight){


### PR DESCRIPTION
## Summary
- Remove "Enemy's Turn" indicators from both players' UI

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/p-p-online/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c670d53320832da0743f9e80490a40