### PR TITLE
Fix missing blue HUD indicators

### DIFF
--- a/script.js
+++ b/script.js
@@ -2597,6 +2597,17 @@ function renderScoreboard(){
     scale
   );
 
+  // Blue player's HUD (mini planes and numeric score)
+  drawPlayerHUD(
+    planeCtx,
+    containerLeft + containerWidth - BLUE_COUNTER_TILE_W * scale - 10,
+    containerTop + 10,
+    "blue",
+    blueScore,
+    turnColors[turnIndex] === "blue",
+    true
+  );
+
   // Green player's HUD (numeric score)
   drawPlayerHUD(
     planeCtx,


### PR DESCRIPTION
## Summary
- Restore blue player's HUD to display mini-plane status and score alongside star counter

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f1bb609c832dbc0847203e70b28e