### PR TITLE
feat: add layered blue star counter

### DIFF
--- a/script.js
+++ b/script.js
@@ -74,8 +74,15 @@ arrowSprite.src = "sprite_ copy.png";
 // Sprite for blue player score counter (star meter)
 const blueCounterImg = new Image();
 blueCounterImg.src = "blue plane counter.png";
-const BLUE_COUNTER_COLS = 5;
-const BLUE_COUNTER_ROWS = 10;
+
+// There are five star outlines stacked vertically on the HUD. Each star
+// fills in five steps, giving a maximum of 25 points. The first row in the
+// sprite sheet contains the static contours (s1–s5). Subsequent rows contain
+// the fill levels for each star (s11–s55).
+const BLUE_COUNTER_STARS  = 5; // number of star slots
+const BLUE_COUNTER_LEVELS = 5; // points needed to fill one star
+const BLUE_COUNTER_COLS   = BLUE_COUNTER_STARS;
+const BLUE_COUNTER_ROWS   = BLUE_COUNTER_LEVELS + 1; // +1 for contour row
 const BLUE_COUNTER_TILE_W = 460 / BLUE_COUNTER_COLS; // 92px
 const BLUE_COUNTER_TILE_H = 800 / BLUE_COUNTER_ROWS; // 80px
 
@@ -2636,15 +2643,19 @@ function drawBlueCounter(ctx, x, y, score, scale){
   const srcH = BLUE_COUNTER_TILE_H;
   const destW = srcW * scale;
   const destH = srcH * scale;
-  for(let i = 0; i < 5; i++){
+  for(let i = 0; i < BLUE_COUNTER_STARS; i++){
     const dy = i * destH;
-    // draw contour for each star
+    // Draw contour for each star
     ctx.drawImage(
       blueCounterImg,
       i * srcW, 0, srcW, srcH,
       x, y + dy, destW, destH
     );
-    const local = Math.min(Math.max(score - i * 5, 0), 5);
+    // How filled is the star at this index?
+    const local = Math.min(
+      Math.max(score - i * BLUE_COUNTER_LEVELS, 0),
+      BLUE_COUNTER_LEVELS
+    );
     if(local > 0){
       ctx.drawImage(
         blueCounterImg,


### PR DESCRIPTION
## Summary
- configure blue star counter sprite with 5-star, 25‑point layout
- render star contours and fill levels using sprite sheet frames

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f66ec568832d85be894a7466cf71