### PR TITLE
fix: register counter image load handler before source

### DIFF
--- a/script.js
+++ b/script.js
@@ -150,8 +150,10 @@ const COUNTER_SCALE  = 1;
 
 const counterImg = new Image();
 let counterReady = false;
+counterImg.onload = () => {
+  counterReady = true;
+};
 counterImg.src = COUNTER_SPRITE_URL;
-counterImg.onload = ()=> counterReady = true;
 
 function drawCounterColumn(ctx, n, col){
   if(!counterReady) return;


### PR DESCRIPTION
## Summary
- ensure counter image onload handler set before assigning src

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7101e34b0832d9eeb9ded0663885b