### PR TITLE
Fix star counter overlay offsets so star pieces appear

### DIFF
--- a/script.js
+++ b/script.js
@@ -197,8 +197,12 @@ function drawCounterOverlay(ctx){
       pieces.forEach(fragIndex => {
         const rect = conf.sourceRects[fragIndex];
         const offset = conf.offsets[fragIndex];
-        const targetX = centerX + offset[0] * conf.scale * COUNTER_SCALE;
-        const targetY = centerY + offset[1] * conf.scale * COUNTER_SCALE;
+        // Offsets are defined in source sprite coordinates; scale them using
+        // the global STAR_CONFIG.scale. The previous implementation attempted
+        // to read a non-existent `conf.scale` per color, resulting in `NaN`
+        // positions and invisible star fragments.
+        const targetX = centerX + offset[0] * STAR_CONFIG.scale * COUNTER_SCALE;
+        const targetY = centerY + offset[1] * STAR_CONFIG.scale * COUNTER_SCALE;
         const dw = rect.w * baseScale;
         const dh = rect.h * baseScale;
         ctx.drawImage(


### PR DESCRIPTION
## Summary
- Scale star fragment offsets using global sprite scale to avoid NaN positions

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c8268a09d4832d9470f677f4d7d5cc