### PR TITLE
Clear HUD overlay before drawing scoreboard

### DIFF
--- a/script.js
+++ b/script.js
@@ -2713,6 +2713,11 @@ function checkVictory(){
 
 function renderScoreboard(){
   updateTurnIndicators();
+
+  // Clear previous HUD drawings so the overlay canvas stays transparent and
+  // doesn't obscure the game field or planes.
+  planeCtx.clearRect(0, 0, planeCanvas.width, planeCanvas.height);
+
   planeCtx.save();
 
   const rect = gameCanvas.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- Clear the plane overlay canvas prior to rendering the HUD so previous drawings don't obscure the field or aircraft

## Testing
- `node --check script.js`
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c82c8e5608832db16752b2c0276b54