### PR TITLE
Show active player's turn text

### DIFF
--- a/script.js
+++ b/script.js
@@ -2756,11 +2756,15 @@ function renderScoreboard(){
 
 function updateTurnIndicators(){
   const color = turnColors[turnIndex];
-  mantisIndicator.classList.toggle('active', color === 'blue');
-  goatIndicator.classList.toggle('active', color === 'green');
+  const isBlueTurn = color === 'blue';
+  mantisIndicator.classList.toggle('active', isBlueTurn);
+  goatIndicator.classList.toggle('active', !isBlueTurn);
 
-  mantisText.textContent = '';
-goatText.textContent = '';
+  // Show an explicit text cue for the player whose turn it is.
+  // Previously both text fields were cleared every frame, leaving
+  // the indicators blank and confusing players.
+  mantisText.textContent = isBlueTurn ? 'Your Turn' : '';
+  goatText.textContent   = !isBlueTurn ? 'Your Turn' : '';
 }
 
 function drawPlayerHUD(ctx, x, y, color, score, isTurn, alignRight){

--- a/styles.css
+++ b/styles.css
@@ -101,6 +101,14 @@ body, button {
   filter: grayscale(0) drop-shadow(0 0 10px #7f8e40);
 }
 
+#mantisIndicator.active .turn-text {
+  color: #013c83;
+}
+
+#goatIndicator.active .turn-text {
+  color: #7f8e40;
+}
+
 /* Overlay canvas for aiming line */
 #aimCanvas {
   position: fixed;


### PR DESCRIPTION
## Summary
- Display "Your Turn" text on the active player's indicator
- Color indicator text using the appropriate player color for clarity

## Testing
- `node --check script.js && node --check settings.js`

------
https://chatgpt.com/codex/tasks/task_e_68c83087b8e0832db0c5f83dec46ab5f