### PR TITLE
Remove turn text indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,12 +13,8 @@
     <canvas id="gameCanvas" width="360" height="640" style="display:none;"></canvas>
 
     <!-- Turn indicators -->
-    <div id="mantisIndicator" class="turn-indicator" style="display:none;">
-      <span class="turn-text"></span>
-    </div>
-    <div id="goatIndicator" class="turn-indicator" style="display:none;">
-      <span class="turn-text"></span>
-    </div>
+    <div id="mantisIndicator" class="turn-indicator" style="display:none;"></div>
+    <div id="goatIndicator" class="turn-indicator" style="display:none;"></div>
   </div>
 
   <!-- Overlay canvas for aiming line -->

--- a/script.js
+++ b/script.js
@@ -21,8 +21,6 @@ Star counter overlay built from sprite fragments.
 /* ======= DOM ======= */
 const mantisIndicator = document.getElementById("mantisIndicator");
 const goatIndicator   = document.getElementById("goatIndicator");
-const mantisText = mantisIndicator.querySelector('.turn-text');
-const goatText = goatIndicator.querySelector('.turn-text');
 
 const gameContainer = document.getElementById("gameContainer");
 const gameCanvas  = document.getElementById("gameCanvas");
@@ -2759,12 +2757,6 @@ function updateTurnIndicators(){
   const isBlueTurn = color === 'blue';
   mantisIndicator.classList.toggle('active', isBlueTurn);
   goatIndicator.classList.toggle('active', !isBlueTurn);
-
-  // Show an explicit text cue for the player whose turn it is.
-  // Previously both text fields were cleared every frame, leaving
-  // the indicators blank and confusing players.
-  mantisText.textContent = isBlueTurn ? 'Your Turn' : '';
-  goatText.textContent   = !isBlueTurn ? 'Your Turn' : '';
 }
 
 function drawPlayerHUD(ctx, x, y, color, score, isTurn, alignRight){

--- a/styles.css
+++ b/styles.css
@@ -63,26 +63,6 @@ body, button {
   z-index: 40;
 }
 
-.turn-indicator .turn-text {
-  position: absolute;
-
-  font-family: 'Patrick Hand', cursive;
-  font-size: 32px;
-  color: rgba(128, 128, 128, 0.6);
-  text-align: center;
-  pointer-events: none;
-}
-#mantisIndicator .turn-text {
-  top: 50px;
-  left: 262px;
-  transform: translate(-50%, -50%);
-}
-
-#goatIndicator .turn-text {
-  top: 362px;
-  left: 207px;
-  transform: translate(-50%, -50%);
-}
 #mantisIndicator {
   top: 0;
   background-position: top center;
@@ -101,13 +81,6 @@ body, button {
   filter: grayscale(0) drop-shadow(0 0 10px #7f8e40);
 }
 
-#mantisIndicator.active .turn-text {
-  color: #013c83;
-}
-
-#goatIndicator.active .turn-text {
-  color: #7f8e40;
-}
 
 /* Overlay canvas for aiming line */
 #aimCanvas {


### PR DESCRIPTION
## Summary
- remove unused `Your Turn` text from turn indicators
- clean up related HTML and CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c835484630832da90d2cde67389d4a