### PR TITLE
Update star UI when scores increase via addScore

### DIFF
--- a/script.js
+++ b/script.js
@@ -526,6 +526,10 @@ function addScore(color, delta){
   } else if(color === "green"){
     greenScore = Math.max(0, greenScore + delta);
   }
+  const starFragments = Math.max(0, Math.floor(delta));
+  for(let i = 0; i < starFragments; i++){
+    addPointToSide(color);
+  }
   if(!isGameOver){
     if(blueScore >= POINTS_TO_WIN){
       isGameOver = true;


### PR DESCRIPTION
## Summary
- trigger star fragment awards whenever addScore increases a side's tally

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c84aabd5c4832dbcf80780cdff0a56