### PR TITLE
Fix star sprite URL to use space

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@
 /* ========================= STAR SCORE UI (hardened) ========================= */
 
 // 1) Путь к спрайту (имя с пробелом безопасно кодируем)
-const STAR_SPRITE_URL = new URL('./sprite%20star.png', location.href).href;
+const STAR_SPRITE_URL = new URL('./sprite star.png', location.href).href;
 
 // 2) Центры «гнёзд» на поле под макет 460×800 (файл есть в репо). См. root: 'background behind the canvas 2.png'.
 const STAR_DESIGN = { w: 460, h: 800 };


### PR DESCRIPTION
## Summary
- Update the star sprite URL to match the file name with a space so the asset loads correctly.

## Testing
- browser_container Playwright smoke check for `[STAR] sprite loaded` log and star rendering


------
https://chatgpt.com/codex/tasks/task_e_68c86a4e0bec832db20ef0133d640a46