### PR TITLE
fix: prevent tiny star fragments

### DIFF
--- a/script.js
+++ b/script.js
@@ -127,6 +127,7 @@ function drawStarsUI(ctx){
 
     // Рисуем поверх игрового слоя в координатах фонового макета 460×800
     ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.imageSmoothingEnabled = false;
 
     ["blue","green"].forEach(color=>{
@@ -147,8 +148,10 @@ function drawStarsUI(ctx){
 
           const [srcX,srcY,srcW,srcH] = rect;
           const [ox,oy] = off;
-          const dstW = Math.round(srcW * pieceScaleX);
-          const dstH = Math.round(srcH * pieceScaleY);
+          let dstW = Math.round(srcW * pieceScaleX);
+          let dstH = Math.round(srcH * pieceScaleY);
+          if (dstW < 2) dstW = 2;
+          if (dstH < 2) dstH = 2;
           const targetX = baseX + ox * offsetScaleX;
           const targetY = baseY + oy * offsetScaleY;
           const drawX = Math.round(targetX - dstW / 2);


### PR DESCRIPTION
## Summary
- avoid tiny star fragments by enforcing minimum size
- reset star-drawing transform and disable smoothing to avoid scaling leftovers

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c8f47142c8832da93c7cb160329d12