### PR TITLE
Fix STAR debug hotkey redeclarations

### DIFF
--- a/script.js
+++ b/script.js
@@ -280,8 +280,9 @@ window.addEventListener('keydown', (e)=>{
 /* ---------------- STAR DEBUG TOOLS ---------------- */
 
 let STAR_DEBUG = true;                  // включено по умолчанию (переключаем клавишей D)
-let STAR_PIECE_SCALE = 1.10;            // только РАЗМЕР кусочка (без влияния на позиции)
-let STAR_OFFSET_SCALE = 0.255;          // только ПОЗИЦИИ (оффсеты) — как у тебя в коде
+// используем уже объявленные глобальные коэффициенты, поэтому просто переопределяем значения
+STAR_PIECE_SCALE = 1.10;                // только РАЗМЕР кусочка (без влияния на позиции)
+STAR_OFFSET_SCALE = 0.255;              // только ПОЗИЦИИ (оффсеты) — как у тебя в коде
 
 // горячая клавиша D — вкл/выкл отрисовку отладочного слоя
 window.addEventListener('keydown', (e)=>{
@@ -292,8 +293,11 @@ window.addEventListener('keydown', (e)=>{
 });
 
 // клик по полю — печатаем координаты курсора (в тех же единицах, что и STAR_CENTERS)
-gameCanvas.addEventListener('click', (e)=>{
-  const rect = gameCanvas.getBoundingClientRect();
+function handleStarDebugClick(e){
+  const canvas = e.currentTarget;
+  if (!(canvas instanceof HTMLCanvasElement)) return;
+
+  const rect = canvas.getBoundingClientRect();
   const x = e.clientX - rect.left;
   const y = e.clientY - rect.top;
 
@@ -304,7 +308,7 @@ gameCanvas.addEventListener('click', (e)=>{
   const mx = Math.round(x / sx);
   const my = Math.round(y / sy);
   console.log(`[STAR DEBUG] click center ~ (${mx}, ${my})  (raw: ${Math.round(x)}, ${Math.round(y)})`);
-});
+}
 
 // рисуем точки центров и прямоугольники ожидаемых кусочков
 function drawStarsDebug(ctx){
@@ -391,6 +395,10 @@ const aimCtx      = aimCanvas.getContext("2d");
 
 const planeCanvas = document.getElementById("planeCanvas");
 const planeCtx    = planeCanvas.getContext("2d");
+
+if (gameCanvas) {
+  gameCanvas.addEventListener('click', handleStarDebugClick);
+}
 
 // Enable smoothing so rotated images (planes, arrows) don't appear jagged
 [gameCtx, aimCtx, planeCtx].forEach(ctx => {


### PR DESCRIPTION
## Summary
- stop redeclaring the STAR scale globals when toggling the debug hotkey to avoid runtime errors
- add a clarifying comment about reusing the existing coefficients
- defer the STAR debug click logger until after the canvas element exists so the first screen initializes normally again

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cd005c192c832d8ec96f0cfb89dabb