### PR TITLE
Use target deltas for star fragment offsets

### DIFF
--- a/script.js
+++ b/script.js
@@ -127,26 +127,30 @@ const STAR_FRAGMENT_TARGETS = {
   ],
 };
 
-// 5) Смещения частей в пределах «звезды» (от композиционного центра строки спрайта)
-const STAR_OFFSETS = {
-  green: [
-    [-95.000, 11.500],
-    [-35.000,  3.500],
-    [-10.500,  3.000],
-    [ 40.500, -9.000],
-    [100.000, -9.000],
-  ],
-  blue:  [
-    [-100.500,  -9.000],
-    [-36.000,   3.500],
-    [-12.000,   3.000],
-    [ 53.000,  -9.000],
-    [ 95.500,  11.500],
-  ],
-};
+// 5) Смещения частей в пределах «звезды»: реальные dx/dy в макетных пикселях
+//    Структура: STAR_OFFSETS[color][slot][fragment] = [dx, dy]
+const STAR_OFFSETS = (() => {
+  const result = { blue: [], green: [] };
+  ["blue", "green"].forEach(color => {
+    const centers = STAR_CENTERS[color] || [];
+    const targetSlots = STAR_FRAGMENT_TARGETS?.[color];
+    const rects = STAR_SOURCE_RECTS[color] || [];
+    result[color] = centers.map((center, slotIdx) => {
+      const slotTargets = targetSlots?.[slotIdx] || [];
+      return rects.map((_, fragIdx) => {
+        const target = slotTargets[fragIdx];
+        if (center && target) {
+          return [target.x - center.x, target.y - center.y];
+        }
+        return [0, 0];
+      });
+    });
+  });
+  return result;
+})();
 
 // 6) Масштабы под контуры (подстроены под фон 460×800)
-const STAR_OFFSET_SCALE_FALLBACK = 0.234;
+const STAR_OFFSET_SCALE_FALLBACK = 1;
 const STAR_PIECE_SCALE_FALLBACK = 0.68;
 let STAR_OFFSET_SCALE = STAR_OFFSET_SCALE_FALLBACK;
 let STAR_PIECE_SCALE = STAR_PIECE_SCALE_FALLBACK;
@@ -225,8 +229,7 @@ function drawStarsUI(ctx){
 
     const baseUnitX = CANVAS_BASE_WIDTH  / STAR_DESIGN.w;
     const baseUnitY = CANVAS_BASE_HEIGHT / STAR_DESIGN.h;
-    const offsetUnitX = STAR_OFFSET_SCALE * baseUnitX;
-    const offsetUnitY = STAR_OFFSET_SCALE * baseUnitY;
+    const offsetScale = STAR_OFFSET_SCALE;
     const pieceUnitX  = STAR_PIECE_SCALE  * baseUnitX;
     const pieceUnitY  = STAR_PIECE_SCALE  * baseUnitY;
 
@@ -238,36 +241,45 @@ function drawStarsUI(ctx){
     ["blue","green"].forEach(color=>{
       const centers = STAR_CENTERS[color];
       const rects   = STAR_SOURCE_RECTS[color];
-      const offs    = STAR_OFFSETS[color];
-      const targets = STAR_FRAGMENT_TARGETS[color];
+      const offsetSlots = STAR_OFFSETS[color];
+      const targets = STAR_FRAGMENT_TARGETS?.[color];
       const slots   = STAR_STATE[color].slots;
 
       centers.forEach((c, slotIdx)=>{
         const baseX = c.x;
         const baseY = c.y;
         const slotTargets = targets && targets[slotIdx];
+        const slotOffsets = offsetSlots && offsetSlots[slotIdx];
 
         for (let frag=1; frag<=5; frag++){
           if (!slots[slotIdx].has(frag)) continue;
 
-          const rect = rects[frag-1], off = offs[frag-1];
-          if (!rect || (!off && !slotTargets)) { console.warn('[STAR] bad rect/offset', color, frag); continue; }
+          const rect = rects[frag-1];
+          const off = slotOffsets && slotOffsets[frag-1];
+          const customTarget = slotTargets && slotTargets[frag-1];
+          const hasOffset = Array.isArray(off) && off.length >= 2;
+          if (!rect || (!customTarget && !hasOffset)) {
+            console.warn('[STAR] bad rect/offset', color, 'slot', slotIdx, 'frag', frag);
+            continue;
+          }
 
           const [srcX,srcY,srcW,srcH] = rect;
-          const [ox,oy] = off;
           let dstW = Math.round(srcW * pieceUnitX);
           let dstH = Math.round(srcH * pieceUnitY);
           if (dstW < 2) dstW = 2;
           if (dstH < 2) dstH = 2;
           let targetX;
           let targetY;
-          const customTarget = slotTargets && slotTargets[frag-1];
           if (customTarget){
             targetX = customTarget.x;
             targetY = customTarget.y;
+          } else if (hasOffset) {
+            const [dx, dy] = off;
+            targetX = baseX + dx * offsetScale;
+            targetY = baseY + dy * offsetScale;
           } else {
-            targetX = baseX + ox * offsetUnitX;
-            targetY = baseY + oy * offsetUnitY;
+            targetX = baseX;
+            targetY = baseY;
           }
           const drawX = Math.round(targetX - dstW / 2);
           const drawY = Math.round(targetY - dstH / 2);
@@ -296,7 +308,7 @@ window.addEventListener('keydown', (e)=>{
 let STAR_DEBUG = true;                  // включено по умолчанию (переключаем клавишей D)
 // используем уже объявленные глобальные коэффициенты, поэтому просто переопределяем значения
 STAR_PIECE_SCALE = 1.10;                // только РАЗМЕР кусочка (без влияния на позиции)
-STAR_OFFSET_SCALE = 0.255;              // только ПОЗИЦИИ (оффсеты) — как у тебя в коде
+STAR_OFFSET_SCALE = 1;                  // смещения уже в макетных пикселях
 
 // горячая клавиша D — вкл/выкл отрисовку отладочного слоя
 window.addEventListener('keydown', (e)=>{
@@ -356,14 +368,17 @@ function drawStarsDebug(ctx){
   // GREEN preview
   {
     const center = STAR_CENTERS.green[previewSlot];
+    const slotOffsets = STAR_OFFSETS.green?.[previewSlot] || [];
     STAR_SOURCE_RECTS.green.forEach((r, i)=>{
       const [sw, sh] = [r[2], r[3]];
-      const [ox, oy] = STAR_OFFSETS.green[i];
+      const offset = slotOffsets[i];
+      const dx = Array.isArray(offset) ? offset[0] : 0;
+      const dy = Array.isArray(offset) ? offset[1] : 0;
 
       const dstW = sw * STAR_PIECE_SCALE;
       const dstH = sh * STAR_PIECE_SCALE;
-      const tx   = center.x + ox * STAR_OFFSET_SCALE - dstW/2;
-      const ty   = center.y + oy * STAR_OFFSET_SCALE - dstH/2;
+      const tx   = center.x + dx * STAR_OFFSET_SCALE - dstW/2;
+      const ty   = center.y + dy * STAR_OFFSET_SCALE - dstH/2;
 
       drawRect(tx, ty, dstW, dstH, 'rgba(60,180,60,0.5)');
       // номер кусочка
@@ -376,14 +391,17 @@ function drawStarsDebug(ctx){
   // BLUE preview
   {
     const center = STAR_CENTERS.blue[previewSlot];
+    const slotOffsets = STAR_OFFSETS.blue?.[previewSlot] || [];
     STAR_SOURCE_RECTS.blue.forEach((r, i)=>{
       const [sw, sh] = [r[2], r[3]];
-      const [ox, oy] = STAR_OFFSETS.blue[i];
+      const offset = slotOffsets[i];
+      const dx = Array.isArray(offset) ? offset[0] : 0;
+      const dy = Array.isArray(offset) ? offset[1] : 0;
 
       const dstW = sw * STAR_PIECE_SCALE;
       const dstH = sh * STAR_PIECE_SCALE;
-      const tx   = center.x + ox * STAR_OFFSET_SCALE - dstW/2;
-      const ty   = center.y + oy * STAR_OFFSET_SCALE - dstH/2;
+      const tx   = center.x + dx * STAR_OFFSET_SCALE - dstW/2;
+      const ty   = center.y + dy * STAR_OFFSET_SCALE - dstH/2;
 
       drawRect(tx, ty, dstW, dstH, 'rgba(80,140,255,0.5)');
       ctx.fillStyle = 'rgba(80,140,255,0.9)';


### PR DESCRIPTION
## Summary
- derive star fragment offsets per slot from the target points so STAR_OFFSETS holds real dx/dy values
- default the offset scale to 1 and update drawStarsUI to add the new deltas directly when STAR_FRAGMENT_TARGETS are unavailable
- adjust the debug overlay to read the per-slot offsets that match the new data layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd507f3860832dbf62ca4bb2e5b55e