### PR TITLE
Handle missing STAR_LAYOUT during star rendering

### DIFF
--- a/script.js
+++ b/script.js
@@ -350,107 +350,79 @@ function addPointToSide(color){
   console.log(`[STAR] ${color}+1 → slot ${slotIdx}, frag ${pick} (size=${slot.size})`);
 }
 
-// Основная отрисовка звёзд — БЕЗ аварий: ловим исключения, чтобы не уронить draw()
+// Основная отрисовка звёзд — работаем в макетных координатах, масштабируем один раз
 function drawStarsUI(ctx){
   if (!STAR_READY) return;
+
+  // 1) коэффициенты перевода МАКЕТ→ЭКРАН (используем только в самом конце)
+  const sx = (typeof STAR_LAYOUT?.sx === 'function') ? STAR_LAYOUT.sx() : 1;
+  const sy = (typeof STAR_LAYOUT?.sy === 'function') ? STAR_LAYOUT.sy() : 1;
+
+  // 2) рисуем без унаследованных трансформаций
+  ctx.save();
+  ctx.setTransform(1,0,0,1,0,0);
+  ctx.imageSmoothingEnabled = false;
+
   try {
-    const isOverlay = (ctx === planeCtx);
-    let originX;
-    let originY;
-    let scaleX;
-    let scaleY;
 
-    if (isOverlay){
-      const rect = gameCanvas.getBoundingClientRect();
-      if (rect.width > 0 && rect.height > 0){
-        scaleX = rect.width  / CANVAS_BASE_WIDTH;
-        scaleY = rect.height / CANVAS_BASE_HEIGHT;
-        originX = rect.left - FRAME_PADDING_X * scaleX;
-        originY = rect.top  - FRAME_PADDING_Y * scaleY;
-      }
-    }
+    // 3) утилита перевода макетных координат в экранные
+    const toScreenX = (mx) => Math.round(mx * sx);
+    const toScreenY = (my) => Math.round(my * sy);
 
-    if (scaleX === undefined || scaleY === undefined){
-      scaleX = gameCanvas.width  / CANVAS_BASE_WIDTH;
-      scaleY = gameCanvas.height / CANVAS_BASE_HEIGHT;
-      originX = -FRAME_PADDING_X * scaleX;
-      originY = -FRAME_PADDING_Y * scaleY;
-    }
+    // 4) обходим две стороны
+    ["blue","green"].forEach(color => {
+      const centers = STAR_CENTERS[color];           // [{x,y} ...] в МАКЕТЕ 460×800
+      const rects   = STAR_SOURCE_RECTS[color];      // [sx,sy,sw,sh] в ПИКСЕЛЯХ СПРАЙТА
+      const offs    = STAR_OFFSETS[color];           // [ox,oy]       в ПИКСЕЛЯХ СПРАЙТА (для «веера»)
+      const slots   = STAR_STATE[color].slots;       // Set фрагментов 1..5
 
-    const baseUnitX = CANVAS_BASE_WIDTH  / STAR_DESIGN.w;
-    const baseUnitY = CANVAS_BASE_HEIGHT / STAR_DESIGN.h;
-    const offsetScale = STAR_OFFSET_SCALE;
-    const pieceUnitX  = STAR_PIECE_SCALE  * baseUnitX;
-    const pieceUnitY  = STAR_PIECE_SCALE  * baseUnitY;
+      centers.forEach((c, slotIdx) => {
+        // ВАЖНО: baseX/baseY — в МАКЕТЕ (без *sx/sy!)
+        const anchorX = (typeof STAR_LAYOUT?.anchorX === 'number') ? STAR_LAYOUT.anchorX : 0;
+        const anchorY = (typeof STAR_LAYOUT?.anchorY === 'number') ? STAR_LAYOUT.anchorY : 0;
+        const baseX = anchorX + c.x;  // макетные координаты 460x800
+        const baseY = anchorY + c.y;
 
-    // Рисуем поверх игрового слоя в координатах фонового макета 460×800
-    ctx.save();
-    ctx.setTransform(scaleX, 0, 0, scaleY, originX, originY);
-    ctx.imageSmoothingEnabled = false;
-
-    ["blue","green"].forEach(color=>{
-      const centers = STAR_CENTERS[color];
-      const rects   = STAR_SOURCE_RECTS[color];
-
-      const colorOffsets = Array.isArray(STAR_OFFSETS[color]) ? STAR_OFFSETS[color] : [];
-
-      const slots   = STAR_STATE[color].slots;
-
-      centers.forEach((c, slotIdx)=>{
-        const baseX = c.x;
-        const baseY = c.y;
-
-
-        for (let frag=1; frag<=5; frag++){
+        for (let frag = 1; frag <= 5; frag++){
           if (!slots[slotIdx].has(frag)) continue;
 
+          const [srcX,srcY,srcW,srcH] = rects[frag-1];
 
+          // Размер фрагмента в ЭКРАННЫХ пикселях (масштаб размера отдельно)
+          const dstW = Math.round(srcW * (typeof STAR_PIECE_SCALE !== 'undefined' ? STAR_PIECE_SCALE : 1) * sx);
+          const dstH = Math.round(srcH * (typeof STAR_PIECE_SCALE !== 'undefined' ? STAR_PIECE_SCALE : 1) * sy);
 
-          const rect = rects[frag-1];
-          const slotOffsets = Array.isArray(colorOffsets[slotIdx]) ? colorOffsets[slotIdx] : null;
-          const off = slotOffsets?.[frag-1];
+          let screenX, screenY; // координаты ТОП-ЛЕВОГО угла в ЭКРАННЫХ пикселях
 
-          const hasOffset = Array.isArray(off) && off.length >= 2;
-          if (!rect || (!hasOffset && !STAR_FRAGMENT_BASE_OFFSETS[color])) {
-            console.warn('[STAR] bad rect/offset', color, frag);
-            continue;
-          }
-
-
-          const [srcX,srcY,srcW,srcH] = rect;
-          let dstW = Math.round(srcW * pieceUnitX);
-          let dstH = Math.round(srcH * pieceUnitY);
-          if (dstW < 2) dstW = 2;
-          if (dstH < 2) dstH = 2;
-          let targetX;
-          let targetY;
-
-          const customTarget = resolveStarFragmentTarget(color, slotIdx, frag-1, baseX, baseY, dstW, dstH);
-
-          if (customTarget){
-            targetX = customTarget.x;
-            targetY = customTarget.y;
-          } else if (hasOffset) {
-            const [dx, dy] = off;
-            const validDx = Number.isFinite(dx) ? dx : 0;
-            const validDy = Number.isFinite(dy) ? dy : 0;
-            targetX = baseX + validDx * offsetScale;
-            targetY = baseY + validDy * offsetScale;
+          if (typeof STAR_USE_MANUAL !== 'undefined' && STAR_USE_MANUAL) {
+            // РУЧНОЙ режим: смещение ТОП-ЛЕВО от центра слота в МАКЕТЕ
+            const m = (STAR_DEST_OFFSETS?.[color]?.[frag-1]) || {x:0, y:0};
+            screenX = toScreenX(baseX + m.x);
+            screenY = toScreenY(baseY + m.y);
           } else {
-            targetX = baseX;
-            targetY = baseY;
+            // «Веер»: смещение от центра слота в ПИКСЕЛЯХ СПРАЙТА, масштабирующееся ОТДЕЛЬНО
+            const slotOffsets = Array.isArray(offs?.[slotIdx]) ? offs[slotIdx] : offs;
+            const offset = Array.isArray(slotOffsets) ? slotOffsets[frag-1] : null;
+            const ox = Number.isFinite(offset?.[0]) ? offset[0] : 0;
+            const oy = Number.isFinite(offset?.[1]) ? offset[1] : 0;
+            const offScale = (typeof STAR_OFFSET_SCALE !== 'undefined' ? STAR_OFFSET_SCALE : 1);
+            // target в МАКЕТЕ:
+            const targetX = baseX + ox * offScale;
+            const targetY = baseY + oy * offScale;
+            // центр → топ-лево, потом в экран:
+            screenX = toScreenX(targetX) - Math.round(dstW/2);
+            screenY = toScreenY(targetY) - Math.round(dstH/2);
           }
-          const drawX = Math.round(targetX - dstW / 2);
-          const drawY = Math.round(targetY - dstH / 2);
 
-          ctx.drawImage(STAR_IMG, srcX,srcY,srcW,srcH, drawX,drawY, dstW,dstH);
+          ctx.drawImage(STAR_IMG, srcX,srcY,srcW,srcH, screenX, screenY, dstW, dstH);
         }
       });
     });
 
+  } catch (err) {
+    console.warn('[STAR] drawStarsUI error:', err);
+  } finally {
     ctx.restore();
-  } catch (err){
-    console.warn('[STAR] draw error:', err);
   }
 }
 
@@ -583,6 +555,13 @@ const goatIndicator   = document.getElementById("goatIndicator");
 const gameContainer = document.getElementById("gameContainer");
 const gameCanvas  = document.getElementById("gameCanvas");
 const gameCtx     = gameCanvas.getContext("2d");
+
+// ---- STAR_LAYOUT safe shim (защита от ReferenceError) ----
+window.STAR_LAYOUT = window.STAR_LAYOUT || {};
+if (typeof STAR_LAYOUT.sx !== 'function') STAR_LAYOUT.sx = () => gameCanvas.width  / 460;
+if (typeof STAR_LAYOUT.sy !== 'function') STAR_LAYOUT.sy = () => gameCanvas.height / 800;
+if (typeof STAR_LAYOUT.anchorX !== 'number') STAR_LAYOUT.anchorX = 0;
+if (typeof STAR_LAYOUT.anchorY !== 'number') STAR_LAYOUT.anchorY = 0;
 
 const aimCanvas   = document.getElementById("aimCanvas");
 const aimCtx      = aimCanvas.getContext("2d");


### PR DESCRIPTION
## Summary
- render the star fragments in layout coordinates and convert to screen pixels once
- guard star offset lookups so slot-based data continues to work and refresh the documentation comment
- add a STAR_LAYOUT fallback and defensive anchor lookups so the star draw routine does not throw when the global is missing
- wrap drawStarsUI in a try/finally to keep the render loop alive even if the star UI fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf0439eefc832d989725271558b38b