### PR TITLE
Remove dependency on removed star counter

### DIFF
--- a/script.js
+++ b/script.js
@@ -434,6 +434,8 @@ function addScore(color, delta){
       winnerColor = "green";
     }
   }
+
+  renderScoreboard();
 }
 
 let animationFrameId = null;
@@ -2416,19 +2418,19 @@ function awardPoint(color){
   if(isGameOver) return;
   if(color === "blue"){
     greenScore++;
-    try { addPointToSide("green"); } catch(e){ console.warn('[STAR] addPointToSide:', e); }
     if(greenScore >= POINTS_TO_WIN){
       isGameOver = true;
       winnerColor = "green";
     }
   } else if(color === "green"){
     blueScore++;
-    try { addPointToSide("blue"); } catch(e){ console.warn('[STAR] addPointToSide:', e); }
     if(blueScore >= POINTS_TO_WIN){
       isGameOver = true;
       winnerColor = "blue";
     }
   }
+
+  renderScoreboard();
 }
 function checkPlaneHits(plane, fp){
   if(isGameOver) return;
@@ -2442,7 +2444,6 @@ function checkPlaneHits(plane, fp){
     if(d < POINT_RADIUS*2){
       p.isAlive = false;
       p.burning = true;
-      try { addPointToSide(plane.color); } catch(e){ console.warn('[STAR] addPointToSide:', e); }
       p.explosionImg = createExplosionImage();
       const img = p.explosionImg;
       img.onload = () => {


### PR DESCRIPTION
## Summary
- remove calls to the removed star counter when planes are destroyed
- refresh the HUD scoreboard whenever scores change so the internal counters stay visible

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cfbf70de6c832d8edfb328472b4465