### PR TITLE
Draw stars over scoreboard HUD

### DIFF
--- a/script.js
+++ b/script.js
@@ -2700,6 +2700,8 @@ function renderScoreboard(){
     false
   );
 
+  drawStarsUI(planeCtx);
+
   planeCtx.restore();
 }
 


### PR DESCRIPTION
## Summary
- render the star UI after the scoreboard HUD while the plane canvas context remains saved
- ensure the star overlay is drawn on top of other HUD elements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfea8e50ec832d84286eea5b036c88