### PR TITLE
Fix star sprite loading logs

### DIFF
--- a/script.js
+++ b/script.js
@@ -509,12 +509,14 @@ function syncAllStarStates(){
 }
 
 STAR_IMG.onload = () => {
+  console.log("[STAR] sprite loaded", STAR_IMG.width, STAR_IMG.height);
   window.STAR_READY = true;
   syncAllStarStates();
   if (typeof renderScoreboard === "function"){
     renderScoreboard();
   }
 };
+STAR_IMG.onerror = (e) => console.warn("[STAR] sprite load ERROR", e);
 STAR_IMG.src = "sprite star 3.png";
 syncAllStarStates();
 


### PR DESCRIPTION
## Summary
- log successful star sprite load dimensions and keep scoreboard sync when the image is ready
- warn when the star sprite fails to load so asset path issues can be diagnosed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d00f99618c832d88b0bc9fc1f2fe3d