### PR TITLE
Define star offsets for fallback scoreboard

### DIFF
--- a/script.js
+++ b/script.js
@@ -449,6 +449,31 @@ const STAR_SOURCE_RECTS = {
   ]
 };
 
+const STAR_FALLBACK_FRAGMENT_GAP = 6;
+
+function buildStarOffsets(rects){
+  if (!Array.isArray(rects) || rects.length === 0) {
+    return [];
+  }
+
+  const totalHeight = rects.reduce((acc, rect) => acc + (rect?.[3] || 0), 0) +
+    STAR_FALLBACK_FRAGMENT_GAP * (rects.length - 1);
+
+  let cursor = -totalHeight / 2;
+
+  return rects.map((rect) => {
+    const height = rect?.[3] || 0;
+    const centerY = cursor + height / 2;
+    cursor += height + STAR_FALLBACK_FRAGMENT_GAP;
+    return [0, centerY];
+  });
+}
+
+const STAR_OFFSETS = {
+  green: buildStarOffsets(STAR_SOURCE_RECTS.green),
+  blue: buildStarOffsets(STAR_SOURCE_RECTS.blue)
+};
+
 const STAR_CENTERS = {
   green: [
     { x: 0, y: 0 },
@@ -2760,6 +2785,8 @@ function drawStarsUI(ctx){
       const anchorX = (typeof STAR_LAYOUT?.anchorX === 'number') ? STAR_LAYOUT.anchorX : 0;
       const anchorY = (typeof STAR_LAYOUT?.anchorY === 'number') ? STAR_LAYOUT.anchorY : 0;
 
+      if (!Array.isArray(centers) || !Array.isArray(rects)) return;
+
       centers.forEach((_, slotIdx) => {
 
         for (let frag = 1; frag <= 5; frag++){
@@ -2782,9 +2809,11 @@ function drawStarsUI(ctx){
             screenY = Math.round(frameTop + pos.y * sy);
           } else {
             // Старый вариант «от центра + смещение»
-            const [ox, oy] = STAR_OFFSETS[color][frag-1] || [0,0];
-            const baseX = (typeof STAR_LAYOUT?.anchorX === 'number' ? STAR_LAYOUT.anchorX : 0) + (STAR_CENTERS[color]?.[slotIdx]?.x || 0);
-            const baseY = (typeof STAR_LAYOUT?.anchorY === 'number' ? STAR_LAYOUT.anchorY : 0) + (STAR_CENTERS[color]?.[slotIdx]?.y || 0);
+            const offset = STAR_OFFSETS?.[color]?.[frag-1];
+            const [ox, oy] = Array.isArray(offset) ? offset : [0, 0];
+            const center = centers?.[slotIdx];
+            const baseX = anchorX + (center?.x || 0);
+            const baseY = anchorY + (center?.y || 0);
             const targetX = baseX + ox; // макет
             const targetY = baseY + oy;
             screenX = Math.round(frameLeft + targetX * sx) - Math.round(dstW/2);


### PR DESCRIPTION
## Summary
- compute STAR_OFFSETS from the sprite dimensions so the fallback scoreboard path has valid placement data
- guard the fallback rendering branch against missing layout arrays while reusing the computed anchor offsets

## Testing
- Verified manual grid layout by loading the app in Playwright (no runtime errors)
- Verified fallback layout by toggling STAR_USE_MANUAL_GRID off and loading in Playwright (no runtime errors)


------
https://chatgpt.com/codex/tasks/task_e_68d020816994832d84fa0b0b4df060dd