### PR TITLE
Switch menu backgrounds to alternate image

### DIFF
--- a/script.js
+++ b/script.js
@@ -817,6 +817,8 @@ function resetGame(){
   phase = 'MENU';
   currentPlacer = null;
 
+  gameContainer.style.backgroundImage = "url('background behind the canvas.png')";
+
   // UI reset
   hotSeatBtn.classList.remove("selected");
   computerBtn.classList.remove("selected");
@@ -3191,6 +3193,8 @@ function startNewRound(){
   mantisIndicator.style.display = "block";
   goatIndicator.style.display = "block";
   planeCanvas.style.display = "block";
+
+  gameContainer.style.backgroundImage = "url('background behind the canvas 2.png')";
 
   initPoints(); // ориентации на базе
   blueFlagCarrier = null;

--- a/settings.html
+++ b/settings.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Patrick+Hand&family=Roboto&display=swap" rel="stylesheet">
 </head>
-<body>
+<body class="settings-page">
   <div id="modeMenu">
     <h1 class="game-title">Advanced Settings</h1>
     <div class="control-group-row">

--- a/styles.css
+++ b/styles.css
@@ -27,9 +27,16 @@ body, button {
     position: absolute;
     width: 460px;
     height: 800px;
-    background-image: url("background behind the canvas 2.png");
+    background-image: url("background behind the canvas.png");
     background-size: 460px 800px;
     background-repeat: no-repeat;
+  }
+
+  body.settings-page {
+    background-image: url("background behind the canvas.png");
+    background-size: 460px 800px;
+    background-repeat: no-repeat;
+    background-position: center top;
   }
 
 /* Игровое поле */


### PR DESCRIPTION
## Summary
- show the original background art on the landing menu
- swap the playfield backdrop to the second image once a round starts
- apply the same menu background artwork on the settings page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d19890136c832db7708ceb3be6e3a8