### PR TITLE
Switch plane explosion animation to Explosion 5

### DIFF
--- a/script.js
+++ b/script.js
@@ -181,7 +181,7 @@ brickFrameImg.onload = () => {
 
 function createExplosionImage(){
   const img = document.createElement("img");
-  img.src = `explosion 4.gif?${Date.now()}`;
+  img.src = `explosion 5.gif?${Date.now()}`;
   img.style.position = "absolute";
   img.style.left = "-1000px";
   img.style.top = "-1000px";


### PR DESCRIPTION
## Summary
- update the explosion image preloader to use `explosion 5.gif` so the newer animation plays when a plane is shot down

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d19a162178832d9461bbcd9a368309