### PR TITLE
Fix removal of destroyed planes

### DIFF
--- a/script.js
+++ b/script.js
@@ -1807,6 +1807,10 @@ function handleAAForPlane(p, fp){
     const current = [...flyingPoints];
     for(const fp of current){
       const p = fp.plane;
+      if(!p.isAlive || p.burning){
+        flyingPoints = flyingPoints.filter(other => other !== fp);
+        continue;
+      }
       const prevX = p.x;
       const prevY = p.y;
 
@@ -2752,6 +2756,7 @@ function checkPlaneHits(plane, fp){
     if(d < POINT_RADIUS*2){
       p.isAlive = false;
       p.burning = true;
+      flyingPoints = flyingPoints.filter(other => other.plane !== p);
       const cx = d === 0 ? plane.x : plane.x + dx / d * POINT_RADIUS;
       const cy = d === 0 ? plane.y : plane.y + dy / d * POINT_RADIUS;
       p.collisionX = cx;


### PR DESCRIPTION
## Summary
- drop flying entries whose planes are already burning or destroyed before updating physics
- remove destroyed planes from `flyingPoints` inside `checkPlaneHits` to prevent ghost collisions

## Testing
- playwright headless scenario that forces a head-on collision and logs explosion count

------
https://chatgpt.com/codex/tasks/task_e_68d381bd0624832d8a90a927522ec70c