### PR TITLE
Add early exit for already hit flying planes

### DIFF
--- a/script.js
+++ b/script.js
@@ -2746,6 +2746,7 @@ function awardPoint(color){
 }
 function checkPlaneHits(plane, fp){
   if(isGameOver) return;
+  if(fp?.hit) return;
   const enemyColor = (plane.color==="green") ? "blue" : "green";
   for(const p of points){
     if(!p.isAlive || p.burning) continue;


### PR DESCRIPTION
## Summary
- add an early return in checkPlaneHits to avoid reprocessing already hit flying planes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4445f3da0832da5b0349a5489aae8