### PR TITLE
Remove mode menu backdrop

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -150,6 +150,8 @@ body, button {
     transform: translate(-50%, -50%);
     text-align: center;
     padding: 10px;
+    background: none;
+    box-shadow: none;
     z-index: 1000;
     width: min(90vw, 300px);
     height: auto;


### PR DESCRIPTION
## Summary
- remove the default white backdrop from the mode menu so the page background stays visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4c91ad44c832d971a7924878230fd