### PR TITLE
Synchronize body and container backgrounds

### DIFF
--- a/script.js
+++ b/script.js
@@ -846,7 +846,9 @@ function resetGame(){
   phase = 'MENU';
   currentPlacer = null;
 
-  gameContainer.style.backgroundImage = "url('background behind the canvas.png')";
+  const menuBackground = "url('background behind the canvas.png')";
+  gameContainer.style.backgroundImage = menuBackground;
+  document.body.style.backgroundImage = menuBackground;
 
   // UI reset
   hotSeatBtn.classList.remove("selected");
@@ -3206,7 +3208,9 @@ function startNewRound(){
   goatIndicator.style.display = "block";
   planeCanvas.style.display = "block";
 
-  gameContainer.style.backgroundImage = "url('background behind the canvas 2.png')";
+  const inGameBackground = "url('background behind the canvas 2.png')";
+  gameContainer.style.backgroundImage = inGameBackground;
+  document.body.style.backgroundImage = inGameBackground;
 
   initPoints(); // ориентации на базе
   blueFlagCarrier = null;


### PR DESCRIPTION
## Summary
- sync the menu reset to apply the same background image to the body and game container
- ensure in-game rounds update the body background alongside the container background

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4cbe3288c832dbe642d0df270efbd