### PR TITLE
Make mode menu container transparent

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -151,7 +151,10 @@ body, button {
     text-align: center;
     padding: 10px;
     background: none;
-    box-shadow: none;
+    background-color: transparent !important;
+    background-image: none !important;
+    box-shadow: none !important;
+    border: none !important;
     z-index: 1000;
     width: min(90vw, 300px);
     height: auto;


### PR DESCRIPTION
## Summary
- ensure the mode menu container does not render a white block by forcing its background, border, and shadow to be transparent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d569c22c04832d88beddf1388c1e7a