### PR TITLE
Switch menu background to transparent art

### DIFF
--- a/script.js
+++ b/script.js
@@ -867,7 +867,7 @@ function resetGame(){
   phase = 'MENU';
   currentPlacer = null;
 
-  setBackgroundImage('background behind the canvas.png');
+  setBackgroundImage('background behind the canvas 2.png');
 
   // UI reset
   hotSeatBtn.classList.remove("selected");

--- a/styles.css
+++ b/styles.css
@@ -15,7 +15,7 @@ body, button {
   body {
     position: relative;
     font-family: 'Roboto', sans-serif;
-    background-image: url("background behind the canvas.png");
+    background-image: url("background behind the canvas 2.png");
     background-size: 460px 800px;
     background-repeat: no-repeat;
     background-position: center top;
@@ -30,13 +30,13 @@ body, button {
     position: absolute;
     width: 460px;
     height: 800px;
-    background-image: url("background behind the canvas.png");
+    background-image: url("background behind the canvas 2.png");
     background-size: 460px 800px;
     background-repeat: no-repeat;
   }
 
   body.settings-page {
-    background-image: url("background behind the canvas.png");
+    background-image: url("background behind the canvas 2.png");
     background-size: 460px 800px;
     background-repeat: no-repeat;
     background-position: center top;
@@ -151,7 +151,10 @@ body, button {
     text-align: center;
     padding: 10px;
     background: none;
-    box-shadow: none;
+    background-color: transparent !important;
+    background-image: none !important;
+    box-shadow: none !important;
+    border: none !important;
     z-index: 1000;
     width: min(90vw, 300px);
     height: auto;


### PR DESCRIPTION
## Summary
- use the transparent background art for the initial menu state in both CSS and `resetGame()`
- ensure the menu no longer shows the baked-in white panel once the transparent asset is applied

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d569c22c04832d88beddf1388c1e7a