### PR TITLE
Coordinate green plane crash animation with explosion

### DIFF
--- a/script.js
+++ b/script.js
@@ -34,6 +34,14 @@ const BOARD_ORIGIN = { x: 0, y: 0 };
 
 const activeGreenCrashImages = new Set();
 
+// FX timings (ms) for coordinating explosion and crash animations
+const EXPLOSION_DURATION_MS = 700;   // also used before drawing the wreck cross
+const GREEN_FALL_OVERLAP_MS = 500;          // start fall 0.5 s before explosion ends
+const GREEN_PLANE_FALL_DURATION_MS = 1200;  // approximate duration of fall GIF before looping
+
+const GREEN_PLANE_FALL_SRC = encodeURI("green plane/green plane fall.gif");
+const GREEN_PLANE_LOOP_SRC = encodeURI("green plane/green down loop.gif");
+
 // Время (в секундах), в течение которого самолёт-атакующий
 // игнорирует повторный контакт с только что сбитой целью.
 const PLANE_HIT_COOLDOWN_SEC = 0.2;
@@ -84,7 +92,7 @@ function spawnExplosion(x, y, color = null) {
   document.body.appendChild(img);
 
   // убрать через длительность гифки
-  setTimeout(() => { img.remove(); }, 700);
+  setTimeout(() => { img.remove(); }, EXPLOSION_DURATION_MS);
 
 }
 // ----------------------------------------
@@ -95,12 +103,13 @@ function spawnGreenPlaneCrash(x, y) {
   const sy = rect.height / gameCanvas.height;
 
   const img = new Image();
-  img.src = 'green plane/green down loop.gif';
+  img.src = GREEN_PLANE_FALL_SRC;
   img.className = 'fx-green-crash';
   img.style.position = 'absolute';
   img.style.zIndex = '9998';
   img.style.pointerEvents = 'none';
   img.style.transform = 'translate(-50%, -50%)';
+  img.style.visibility = 'hidden';
   img.draggable = false;
   img.dataset.fx = 'green-crash';
 
@@ -113,12 +122,49 @@ function spawnGreenPlaneCrash(x, y) {
   img.style.left = absLeft + 'px';
   img.style.top  = absTop  + 'px';
 
-  const planeSize = 40;
-  img.style.width = planeSize * sx + 'px';
-  img.style.height = planeSize * sy + 'px';
-
   document.body.appendChild(img);
   activeGreenCrashImages.add(img);
+
+  const startDelay = Math.max(0, EXPLOSION_DURATION_MS - GREEN_FALL_OVERLAP_MS);
+  const applyImageSize = () => {
+    if (!img.isConnected) return;
+    const { naturalWidth, naturalHeight } = img;
+    if (naturalWidth > 0 && naturalHeight > 0) {
+      img.style.width = naturalWidth * sx + 'px';
+      img.style.height = naturalHeight * sy + 'px';
+    } else {
+      img.style.removeProperty('width');
+      img.style.removeProperty('height');
+    }
+  };
+
+  const startFall = () => {
+    if (!img.isConnected) return;
+    img.style.visibility = 'visible';
+    img.dataset.phase = 'fall';
+    setTimeout(() => {
+      if (!img.isConnected) return;
+      img.src = GREEN_PLANE_LOOP_SRC;
+      img.dataset.phase = 'loop';
+    }, GREEN_PLANE_FALL_DURATION_MS);
+  };
+
+  const scheduleFall = () => setTimeout(startFall, startDelay);
+
+  img.addEventListener('load', applyImageSize);
+
+  if (img.complete && img.naturalWidth > 0) {
+    applyImageSize();
+    scheduleFall();
+  } else {
+    img.addEventListener('load', () => {
+      scheduleFall();
+    }, { once: true });
+  }
+
+  img.addEventListener('error', (event) => {
+    console.warn('[FX] Failed to load green plane fall animation', event);
+  }, { once: true });
 }
 
 
@@ -330,8 +376,7 @@ const FLAG_POLE_HEIGHT     = 20;     // высота флагштока
 const FLAG_WIDTH           = 12;     // ширина полотна флага
 const FLAG_HEIGHT          = 8;      // высота полотна флага
 
-// Explosion effect
-const EXPLOSION_DURATION_MS = 500;   // time before showing cross
+// Explosion effect duration before showing cross (see EXPLOSION_DURATION_MS)
 
 function updateFieldBorderOffset(){
   if(settings.sharpEdges){


### PR DESCRIPTION
## Summary
- add shared FX timing constants to keep explosion and crash animations in sync
- trigger the green plane fall GIF half a second before the explosion finishes and then swap to the looping descent
- ensure the green plane fall GIF reliably loads at the correct size before transitioning into the looping descent
- fix the duplicated EXPLOSION_DURATION_MS definition so the script initializes without crashing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7b44350a0832d9f6a5e7f56fff040