### PR TITLE
Remove green plane crash animations

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -142,13 +142,6 @@ body, button {
   pointer-events: none;
 }
 
-.fx-green-crash {
-  position: absolute;
-  transform: translate(-50%, -50%);
-  pointer-events: none;
-  image-rendering: auto;
-}
-
 /* Меню выбора режима */
   #modeMenu {
     position: fixed;


### PR DESCRIPTION
## Summary
- remove the green plane crash GIF logic so only explosions play after a hit
- drop the unused crash cleanup and styles for the retired effect

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da8c6e2278832db4110a73a935e9da