### PR TITLE
Adjust flame animation sizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -144,8 +144,8 @@ body, button {
 
 .fx-flame {
   position: absolute;
-  width: 80px;
-  height: 80px;
+  width: auto;
+  height: 40px;
   transform: translate(-50%, -50%);
   image-rendering: auto;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- reduce the flame effect height to half while allowing width to follow the intrinsic aspect ratio

## Testing
- Manual QA - Loaded index.html in browser to verify flame overlay positioning

------
https://chatgpt.com/codex/tasks/task_e_68dac27f68a8832db8b88da1745de1a6