### PR TITLE
Keep downed planes visible after explosions

### DIFF
--- a/script.js
+++ b/script.js
@@ -2512,14 +2512,16 @@ function drawThinPlane(ctx2d, plane, glow = 0) {
   ctx2d.translate(cx, cy);
   ctx2d.rotate(angle);
   ctx2d.scale(PLANE_SCALE, PLANE_SCALE);
-  ctx2d.filter = "blur(0.3px)"; // slight blur to soften rotated edges
 
+  const filterParts = ["blur(0.3px)"]; // slight blur to soften rotated edges
   if (plane.burning && explosionFinished) {
-    ctx2d.restore();
-    return;
+    filterParts.push("saturate(0) brightness(0.6)");
   }
+  ctx2d.filter = filterParts.join(" ");
 
-  const blend = Math.max(0, Math.min(1, glow));
+  const blend = (plane.burning && explosionFinished)
+    ? 0
+    : Math.max(0, Math.min(1, glow));
   if (blend > 0) {
     const glowStrength = blend * 1.25; // boost brightness slightly
     ctx2d.shadowColor = colorWithAlpha(color, Math.min(1, glowStrength));
@@ -2530,6 +2532,9 @@ function drawThinPlane(ctx2d, plane, glow = 0) {
   }
 
   const showEngine = !(plane.burning && explosionFinished);
+  if (plane.burning && explosionFinished) {
+    ctx2d.globalAlpha = 0.85;
+  }
   if (color === "blue") {
     if (showEngine) {
       const flicker = 1 + 0.05 * Math.sin(globalFrame * 0.1);

--- a/styles.css
+++ b/styles.css
@@ -144,8 +144,8 @@ body, button {
 
 .fx-flame {
   position: absolute;
-  width: 80px;
-  height: 80px;
+  width: auto;
+  height: 40px;
   transform: translate(-50%, -50%);
   image-rendering: auto;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- keep wrecked planes visible once the explosion animation finishes by continuing to render the plane sprite
- desaturate and dim wrecked planes while disabling their glow and engine effects so they read as destroyed

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac27f68a8832db8b88da1745de1a6