### PR TITLE
Align burning flame effect with plane center

### DIFF
--- a/script.js
+++ b/script.js
@@ -85,7 +85,7 @@ function spawnBurningFlameFx(plane) {
   img.className = 'fx-flame';
   img.style.position = 'absolute';
   img.style.pointerEvents = 'none';
-  img.style.transform = 'translate(-50%, -50%)';
+  img.style.transform = 'translate(-50%, -100%)';
   img.style.zIndex = '9999';
 
   host.appendChild(img);

--- a/styles.css
+++ b/styles.css
@@ -146,7 +146,7 @@ body, button {
   position: absolute;
   width: auto;
   height: 40px;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -100%);
   image-rendering: auto;
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- adjust the flame effect transform so the GIF's bottom center lines up with the plane position
- update the shared CSS transform for flame sprites to keep alignment consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc27843ab0832d9cf79b60d6b05c00