### PR TITLE
Add dynamic glow colors for crash effects

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -140,6 +140,10 @@ body, button {
   transform: translate(-50%, -50%);
   image-rendering: auto;
   pointer-events: none;
+  --fx-glow-color: rgba(255, 214, 153, 0.75);
+  filter:
+    drop-shadow(0 0 8px var(--fx-glow-color))
+    drop-shadow(0 0 18px var(--fx-glow-color));
 }
 
 .fx-flame {
@@ -149,6 +153,10 @@ body, button {
   transform: translate(-50%, -100%);
   image-rendering: auto;
   pointer-events: none;
+  --fx-glow-color: rgba(255, 214, 153, 0.85);
+  filter:
+    drop-shadow(0 0 6px var(--fx-glow-color))
+    drop-shadow(0 0 14px var(--fx-glow-color));
 }
 
 


### PR DESCRIPTION
## Summary
- add drop-shadow glow styling for flame and explosion FX using a shared CSS variable
- set the FX glow color in JavaScript based on the owning plane and ensure cleanup clears the custom style
- reuse the same helper when spawning explosions so their glow matches the triggering plane

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0ebba3984832dad9ea46d20cb0cc7