### PR TITLE
Handle flame fallback retry tracking

### DIFF
--- a/script.js
+++ b/script.js
@@ -124,6 +124,7 @@ function spawnBurningFlameFx(plane) {
   if (!flameSrc) return;
 
   const img = new Image();
+  let attemptedSrc = flameSrc;
   img.src = flameSrc;
   img.dataset.flameSrc = flameSrc;
   img.className = 'fx-flame';
@@ -143,10 +144,9 @@ function spawnBurningFlameFx(plane) {
       }
       return;
     }
-    plane.burningFlameSrc = fallback;
     attemptedSrc = fallback;
+    plane.burningFlameSrc = fallback;
     img.dataset.flameSrc = fallback;
-    img.onerror = null;
     img.src = fallback;
   };
 


### PR DESCRIPTION
## Summary
- track the currently attempted burning flame image source before setting the image src
- retry with the fallback source only once and keep the error handler active until the final failure

## Testing
- node - <<'NODE' # simulate missing flame GIF and ensure fallback cleanup


------
https://chatgpt.com/codex/tasks/task_e_68e0ebc5e3cc832d9e89714883209fad