### PR TITLE
Brighten destroyed plane tint for better contrast

### DIFF
--- a/script.js
+++ b/script.js
@@ -2737,7 +2737,9 @@ function drawThinPlane(ctx2d, plane, glow = 0) {
   ctx2d.filter = "none";
 
   if (plane.burning && explosionFinished) {
-    ctx2d.filter = "saturate(0) brightness(0.6)";
+    // Desaturated crash debris looked too dark (#494744). Brighten it slightly so it
+    // reads closer to #827f7c against the playfield background.
+    ctx2d.filter = "saturate(0) brightness(0.85)";
   }
 
   const showEngine = !(plane.burning && explosionFinished);


### PR DESCRIPTION
## Summary
- brighten the desaturated crash-plane rendering so the wreck tint reads closer to #827f7c instead of #494744

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e20ff86334832dbacd4fa1718edf0b