### PR TITLE
Swap HUD positions for blue and green players

### DIFF
--- a/script.js
+++ b/script.js
@@ -3571,25 +3571,25 @@ function renderScoreboard(){
   const maxBlueHudY = containerTop + FRAME_BASE_HEIGHT * scaleY - margin;
   const blueHudY = Math.min(maxBlueHudY, Math.max(containerTop + margin, unclampedBlueHudY));
 
-  // Green player's HUD (mini planes and numeric score)
+  // Blue player's HUD (mini planes and numeric score)
   drawPlayerHUD(
     planeCtx,
     greenHudX,
     greenHudY,
-    "green",
-    greenScore,
-    turnColors[turnIndex] === "green",
+    "blue",
+    blueScore,
+    turnColors[turnIndex] === "blue",
     true
   );
 
-  // Blue player's HUD (numeric score)
+  // Green player's HUD (numeric score)
   drawPlayerHUD(
     planeCtx,
     blueHudX,
     blueHudY,
-    "blue",
-    blueScore,
-    turnColors[turnIndex] === "blue",
+    "green",
+    greenScore,
+    turnColors[turnIndex] === "green",
     false
   );
 
@@ -3600,9 +3600,9 @@ function renderScoreboard(){
 
 function updateTurnIndicators(){
   const color = turnColors[turnIndex];
-  const isBlueTurn = color === 'blue';
-  mantisIndicator.classList.toggle('active', isBlueTurn);
-  goatIndicator.classList.toggle('active', !isBlueTurn);
+  const isGreenTurn = color === 'green';
+  mantisIndicator.classList.toggle('active', isGreenTurn);
+  goatIndicator.classList.toggle('active', !isGreenTurn);
 }
 
 function drawPlayerHUD(ctx, x, y, color, score, isTurn, alignRight){


### PR DESCRIPTION
## Summary
- swap the player HUD drawing coordinates so blue uses the former green slot and vice versa
- update the turn indicator toggles to reflect the new HUD ordering

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68eb4c3af2b8832d9801bf431444da2e