### PR TITLE
Align scoreboard plane icons vertically

### DIFF
--- a/script.js
+++ b/script.js
@@ -3651,14 +3651,10 @@ function drawPlayerHUD(ctx, x, y, color, score, isTurn, alignRight){
   const stackDirection = color === 'green' ? -1 : 1;
 
   const centers = [];
-  const sinTilt = Math.sin(rotation);
-  const cosTilt = Math.cos(rotation);
 
   for (let i = 0; i < iconCount; i++) {
     const step = stackDirection * i * spacingY;
-    const cx = step * sinTilt;
-    const cy = step * cosTilt;
-    centers.push({ x: cx, y: cy, plane: planes[i] });
+    centers.push({ x: 0, y: step, plane: planes[i] });
   }
 
   if (!isTurn) {


### PR DESCRIPTION
## Summary
- ensure the plane counter icons stack straight in the scoreboard column by removing the horizontal offset from their layout

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ec7f764884832d95dcc321df495288