### PR TITLE
Correct HUD plane offsets

### DIFF
--- a/script.js
+++ b/script.js
@@ -3572,7 +3572,7 @@ function renderScoreboard(){
   drawPlayerHUD(
     planeCtx,
     greenHudX,
-    greenHudY,
+    blueHudY,
     "blue",
     blueScore,
     turnColors[turnIndex] === "blue",
@@ -3583,7 +3583,7 @@ function renderScoreboard(){
   drawPlayerHUD(
     planeCtx,
     blueHudX,
-    blueHudY,
+    greenHudY,
     "green",
     greenScore,
     turnColors[turnIndex] === "green",
@@ -3651,14 +3651,10 @@ function drawPlayerHUD(ctx, x, y, color, score, isTurn, alignRight){
   const stackDirection = color === 'green' ? -1 : 1;
 
   const centers = [];
-  const sinTilt = Math.sin(rotation);
-  const cosTilt = Math.cos(rotation);
 
   for (let i = 0; i < iconCount; i++) {
     const step = stackDirection * i * spacingY;
-    const cx = step * sinTilt;
-    const cy = step * cosTilt;
-    centers.push({ x: cx, y: cy, plane: planes[i] });
+    centers.push({ x: 0, y: step, plane: planes[i] });
   }
 
   if (!isTurn) {


### PR DESCRIPTION
## Summary
- ensure the plane counter icons stack straight in the scoreboard column by removing the horizontal offset from their layout
- anchor the blue HUD 120px from the top edge and the green HUD 120px from the bottom edge

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68ec7f764884832d95dcc321df495288