### PR TITLE
Fix active player mascot highlighting

### DIFF
--- a/script.js
+++ b/script.js
@@ -3598,9 +3598,10 @@ function renderScoreboard(){
 
 function updateTurnIndicators(){
   const color = turnColors[turnIndex];
-  const isGreenTurn = color === 'green';
-  mantisIndicator.classList.toggle('active', isGreenTurn);
-  goatIndicator.classList.toggle('active', !isGreenTurn);
+  const isBlueTurn = color === 'blue';
+  // Top (mantis) mascot belongs to the blue player, bottom (goat) to green.
+  mantisIndicator.classList.toggle('active', isBlueTurn);
+  goatIndicator.classList.toggle('active', !isBlueTurn);
 }
 
 function drawPlayerHUD(ctx, x, y, color, score, isTurn, alignRight){


### PR DESCRIPTION
## Summary
- update the turn indicator logic so the glowing mascot matches the active player
- document which mascot corresponds to each player to avoid future confusion

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec9c68072c832dbc11827052f9bb60