### PR TITLE
Align score popup exit direction

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -111,8 +111,8 @@ body, button {
     }
     100% {
       opacity: 0;
-      -webkit-clip-path: inset(0 100% 0 0);
-      clip-path: inset(0 100% 0 0);
+      -webkit-clip-path: inset(0 0 0 100%);
+      clip-path: inset(0 0 0 100%);
     }
   }
 


### PR DESCRIPTION
## Summary
- adjust the score popup clip-path animation so the exit erases text from left to right
- keep reveal and disappearance directions consistent for queued score increments

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ed2db65030832da24badf8d4114f69