### PR TITLE
Adjust HUD mini-plane rotations

### DIFF
--- a/script.js
+++ b/script.js
@@ -3910,7 +3910,9 @@ function drawPlayerHUD(ctx, frame, color, isTurn){
 
   const baseIconSize = 16 * PLANE_SCALE * MINI_PLANE_ICON_SCALE;
   const tiltRadians = (PLANE_COUNTER_TILT_DEGREES * Math.PI) / 180;
-  const rotation = color === "blue" ? -tiltRadians : tiltRadians;
+  const rotation = color === "blue"
+    ? tiltRadians
+    : tiltRadians + Math.PI;
   const rotationFitFactor = Math.abs(Math.cos(rotation)) + Math.abs(Math.sin(rotation));
 
   const slots = Math.max(1, maxPerRow);


### PR DESCRIPTION
## Summary
- update player HUD mini-plane rotation logic so blue thumbnails tilt up-right and green thumbnails flip downward-left

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef335bfbac832d9361640fa25710a8