### PR TITLE
Reduce turn indicator glow intensity

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -229,11 +229,11 @@ body, button {
 }
 
 #mantisIndicator.active {
-  filter: grayscale(0) drop-shadow(0 0 10px #013c83);
+  filter: grayscale(0) drop-shadow(0 0 6px rgba(1, 60, 131, 0.6));
 }
 
 #goatIndicator.active {
-  filter: grayscale(0) drop-shadow(0 0 10px #7f8e40);
+  filter: grayscale(0) drop-shadow(0 0 6px rgba(127, 142, 64, 0.6));
 }
 
 


### PR DESCRIPTION
## Summary
- soften the active turn indicator glow by decreasing the drop shadow radius and opacity for both teams

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efe36aa000832d9d4630b32dbecce9