### PR TITLE
Soften HUD plane counter lighting

### DIFF
--- a/script.js
+++ b/script.js
@@ -639,9 +639,9 @@ document.addEventListener('dblclick', (e) => {
 
 /* ======= CONFIG ======= */
 const PLANE_SCALE          = 0.9;    // 10% smaller planes
-const MINI_PLANE_ICON_SCALE = 0.9;    // 10% smaller HUD plane icons
-const HUD_PLANE_DIM_ALPHA = 1;        // full brightness for HUD planes
-const HUD_PLANE_DIM_FILTER = "none";  // no color dimming on HUD planes
+const MINI_PLANE_ICON_SCALE = 0.7;    // make HUD plane icons smaller on the counter
+const HUD_PLANE_DIM_ALPHA = 0.75;     // dim HUD planes slightly for a softer look
+const HUD_PLANE_DIM_FILTER = "brightness(0.7) saturate(0.8)";  // soften HUD plane colors
 const HUD_KILL_MARKER_COLOR = "#91200f";
 const HUD_KILL_MARKER_ALPHA = 0.85;
 const CELL_SIZE            = 20;     // px

--- a/styles.css
+++ b/styles.css
@@ -736,7 +736,7 @@ body, button {
 /* Плавные переходы */
 button, .control-box, #modeMenu, #endGameButtons { transition: all 0.3s ease; }
 
-/* === HUD planes: усиление видимости (обводка + свечение + масштаб) === */
+/* === HUD planes: мягкая тень вместо подсветки === */
 .hud-plane{
   /* делаем их поверх всего на колонке */
   position: relative;
@@ -746,34 +746,29 @@ button, .control-box, #modeMenu, #endGameButtons { transition: all 0.3s ease; }
   transform: scale(1.2);
   transform-origin: center;
 
-  /* белая «псевдообводка» + мягкая тень */
-  /* первый drop-shadow = тонкая белая кромка,
-     второй = чуть шире, третий = мягкая тень */
+  /* мягкая тень без яркой подсветки */
   filter:
-    drop-shadow(0 0 0 #fff)
-    drop-shadow(0 0 2px #fff)
-    drop-shadow(0 2px 4px rgba(0,0,0,.25));
+    drop-shadow(0 1px 1px rgba(0,0,0,.35))
+    drop-shadow(0 5px 12px rgba(0,0,0,.35));
 
   /* чтобы гифка не мыльнилась при масштабировании */
   image-rendering: -webkit-optimize-contrast;
   image-rendering: crisp-edges;
 }
 
-/* добавляем лёгкое цветное свечение в тон колонки */
+/* приглушённая тень с оттенком в цвет команды */
 .hud-plane.green{
   filter:
-    drop-shadow(0 0 0 #fff)
-    drop-shadow(0 0 2px #fff)
-    drop-shadow(0 0 6px rgba(90,140,50,.8))   /* зелёное свечение */
-    drop-shadow(0 2px 4px rgba(0,0,0,.25));
+    drop-shadow(0 1px 1px rgba(0,0,0,.35))
+    drop-shadow(0 6px 14px rgba(32,60,32,.45))
+    drop-shadow(0 10px 22px rgba(0,0,0,.35));
 }
 
 .hud-plane.blue{
   filter:
-    drop-shadow(0 0 0 #fff)
-    drop-shadow(0 0 2px #fff)
-    drop-shadow(0 0 6px rgba(60,110,190,.85)) /* синее свечение */
-    drop-shadow(0 2px 4px rgba(0,0,0,.25));
+    drop-shadow(0 1px 1px rgba(0,0,0,.35))
+    drop-shadow(0 6px 14px rgba(24,44,78,.45))
+    drop-shadow(0 10px 22px rgba(0,0,0,.35));
 }
 
 /* если вдруг кому-то будет слишком крупно — можно быстро откатить масштаб


### PR DESCRIPTION
## Summary
- replace the HUD plane counter glow with layered drop-shadows for a shadowed look
- tint the shadows per team color while avoiding bright highlights

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f07f56031c832d9c5cfbdbcc6d4cb3