### PR TITLE
Use dedicated counter icons for HUD planes

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
 
     <div id="hudPlaneStyleProbes" aria-hidden="true"
          style="position:absolute;width:0;height:0;overflow:hidden;clip-path:inset(50%);">
-      <img src="green plane 3.png" class="hud-plane green" alt="" draggable="false">
-      <img src="blue plane 24.png" class="hud-plane blue" alt="" draggable="false">
+      <img src="planes/green counter.png" class="hud-plane green" alt="" draggable="false">
+      <img src="planes/blue counter.png" class="hud-plane blue" alt="" draggable="false">
     </div>
 
     <!-- Turn indicators -->

--- a/script.js
+++ b/script.js
@@ -470,6 +470,12 @@ const greenPlaneImg = new Image();
 
 greenPlaneImg.src = "green plane 3.png";
 
+const blueCounterPlaneImg = new Image();
+blueCounterPlaneImg.src = "planes/blue counter.png";
+
+const greenCounterPlaneImg = new Image();
+greenCounterPlaneImg.src = "planes/green counter.png";
+
 const bluePlaneWreckImg = new Image();
 bluePlaneWreckImg.src = "planes/blue fall.png";
 
@@ -3206,12 +3212,12 @@ function drawMiniPlaneWithCross(ctx2d, x, y, plane, scale = 1, rotationRadians =
 
   let img = null;
   if (color === "blue") {
-    img = bluePlaneImg;
+    img = blueCounterPlaneImg;
   } else if (color === "green") {
-    img = greenPlaneImg;
+    img = greenCounterPlaneImg;
   }
 
-  let spriteReady = Boolean(
+  const spriteReady = Boolean(
     img &&
     img.complete &&
     img.naturalWidth > 0 &&
@@ -3221,7 +3227,7 @@ function drawMiniPlaneWithCross(ctx2d, x, y, plane, scale = 1, rotationRadians =
   if (spriteReady) {
     ctx2d.drawImage(img, -size / 2, -size / 2, size, size);
   } else {
-    // Fallback to simple outline if image isn't ready yet
+    // Fallback to simple outline if the counter icon isn't ready yet
     ctx2d.strokeStyle = colorFor(color);
     ctx2d.lineWidth = 2;
     ctx2d.beginPath();


### PR DESCRIPTION
## Summary
- add dedicated plane counter image assets for the HUD
- render scoreboard mini planes with the dedicated counter sprites and updated fallback logic
- point HUD style probes at the new counter icons to keep computed filters and scaling in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f09d29ccbc832da5797648623e5c3a