### PR TITLE
Remove HUD plane tilt from player counter

### DIFF
--- a/script.js
+++ b/script.js
@@ -3789,7 +3789,6 @@ function drawStarsUI(ctx){
   }
 }
 
-const PLANE_COUNTER_TILT_DEGREES = 35;
 const PLANE_COUNTER_PADDING      = 2;
 const PLANE_COUNTER_CONTAINERS   = {
   blue:  { left: 4,   top: 97,  right: 50,  bottom: 337 },
@@ -4067,11 +4066,7 @@ function drawPlayerHUD(ctx, frame, color, isTurn){
   const availableHeight = Math.max(0, height - paddingY * 2);
 
   const baseIconSize = 16 * PLANE_SCALE * MINI_PLANE_ICON_SCALE;
-  const tiltRadians = (PLANE_COUNTER_TILT_DEGREES * Math.PI) / 180;
-  const rotation = color === "blue"
-    ? tiltRadians
-    : tiltRadians + Math.PI;
-  const rotationFitFactor = Math.abs(Math.cos(rotation)) + Math.abs(Math.sin(rotation));
+  const rotationFitFactor = 1;
 
   const slots = Math.max(1, maxPerRow);
   const slotHeight = availableHeight / slots;
@@ -4109,7 +4104,7 @@ function drawPlayerHUD(ctx, frame, color, isTurn){
     const slotIndex = stackDirection === -1 ? (slots - 1 - i) : i;
     const centerY = paddingY + slotHeight * (slotIndex + 0.5);
     if (iconScale > 0) {
-      drawMiniPlaneWithCross(ctx, centerX, centerY, plane, iconScale, rotation);
+      drawMiniPlaneWithCross(ctx, centerX, centerY, plane, iconScale, 0);
     }
   }
 


### PR DESCRIPTION
## Summary
- remove the unused mini plane tilt constant and always render the counter icons without rotation
- simplify the HUD mini plane scaling math now that the icons remain upright

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f09d2ac05c832d9be25228cdbf1d9e