### PR TITLE
Switch HUD counter planes to fourth variant

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
 
     <div id="hudPlaneStyleProbes" aria-hidden="true"
          style="position:absolute;width:0;height:0;overflow:hidden;clip-path:inset(50%);">
-      <img src="planes/green counter 3.png" class="hud-plane green" alt="" draggable="false">
-      <img src="planes/blue counter 3.png" class="hud-plane blue" alt="" draggable="false">
+      <img src="planes/green counter 4.png" class="hud-plane green" alt="" draggable="false">
+      <img src="planes/blue counter 4.png" class="hud-plane blue" alt="" draggable="false">
     </div>
 
     <!-- Turn indicators -->

--- a/script.js
+++ b/script.js
@@ -471,10 +471,10 @@ const greenPlaneImg = new Image();
 greenPlaneImg.src = "green plane 3.png";
 
 const blueCounterPlaneImg = new Image();
-blueCounterPlaneImg.src = "planes/blue counter 3.png";
+blueCounterPlaneImg.src = "planes/blue counter 4.png";
 
 const greenCounterPlaneImg = new Image();
-greenCounterPlaneImg.src = "planes/green counter 3.png";
+greenCounterPlaneImg.src = "planes/green counter 4.png";
 
 const bluePlaneWreckImg = new Image();
 bluePlaneWreckImg.src = "planes/blue fall.png";


### PR DESCRIPTION
## Summary
- update the HUD counter plane image assets to use the green and blue variant 4 artwork
- keep the runtime image preload paths in sync with the markup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f115f89518832db307bc7653ed4fbd