### PR TITLE
Update board background and counter assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
 
     <div id="hudPlaneStyleProbes" aria-hidden="true"
          style="position:absolute;width:0;height:0;overflow:hidden;clip-path:inset(50%);">
-      <img src="planes/green counter 4.png" class="hud-plane green" alt="" draggable="false">
-      <img src="planes/blue counter 4.png" class="hud-plane blue" alt="" draggable="false">
+      <img src="planes/green counter.png" class="hud-plane green" alt="" draggable="false">
+      <img src="planes/blue counter.png" class="hud-plane blue" alt="" draggable="false">
     </div>
 
     <!-- Turn indicators -->

--- a/script.js
+++ b/script.js
@@ -471,10 +471,10 @@ const greenPlaneImg = new Image();
 greenPlaneImg.src = "green plane 3.png";
 
 const blueCounterPlaneImg = new Image();
-blueCounterPlaneImg.src = "planes/blue counter 4.png";
+blueCounterPlaneImg.src = "planes/blue counter.png";
 
 const greenCounterPlaneImg = new Image();
-greenCounterPlaneImg.src = "planes/green counter 4.png";
+greenCounterPlaneImg.src = "planes/green counter.png";
 
 const bluePlaneWreckImg = new Image();
 bluePlaneWreckImg.src = "planes/blue fall.png";
@@ -4255,7 +4255,7 @@ function startNewRound(){
   goatIndicator.style.display = "block";
   planeCanvas.style.display = "block";
 
-  setBackgroundImage('background behind the canvas 3.png');
+  setBackgroundImage('pics/background behind the canvas 5.png');
 
   initPoints(); // ориентации на базе
   blueFlagCarrier = null;

--- a/styles.css
+++ b/styles.css
@@ -15,7 +15,7 @@ body, button {
   body {
     position: relative;
     font-family: 'Roboto', sans-serif;
-    background-image: url("background behind the canvas 3.png");
+    background-image: url("pics/background behind the canvas 5.png");
     background-size: 460px 800px;
     background-repeat: no-repeat;
     background-position: center top;
@@ -30,7 +30,7 @@ body, button {
     position: absolute;
     width: 460px;
     height: 800px;
-    background-image: url("background behind the canvas 3.png");
+    background-image: url("pics/background behind the canvas 5.png");
     background-size: 460px 800px;
     background-repeat: no-repeat;
     --score-scale: 1;
@@ -181,7 +181,7 @@ body, button {
   }
 
   body.settings-page {
-    background-image: url("background behind the canvas 3.png");
+    background-image: url("pics/background behind the canvas 5.png");
     background-size: 460px 800px;
     background-repeat: no-repeat;
     background-position: center top;


### PR DESCRIPTION
## Summary
- replace the body and game container backgrounds with the new artwork from `pics/background behind the canvas 5.png`
- switch the HUD counter icons and runtime counter textures to the unnumbered blue and green sprites

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f11a2e2b50832db81e5304cd0ed09b