### PR TITLE
Update counter plane icons to variant 6

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
 
     <div id="hudPlaneStyleProbes" aria-hidden="true"
          style="position:absolute;width:0;height:0;overflow:hidden;clip-path:inset(50%);">
-      <img src="planes/green counter.png" class="hud-plane green" alt="" draggable="false">
-      <img src="planes/blue counter.png" class="hud-plane blue" alt="" draggable="false">
+      <img src="planes/green counter 6.png" class="hud-plane green" alt="" draggable="false">
+      <img src="planes/blue counter 6.png" class="hud-plane blue" alt="" draggable="false">
     </div>
 
     <!-- Turn indicators -->

--- a/script.js
+++ b/script.js
@@ -471,10 +471,10 @@ const greenPlaneImg = new Image();
 greenPlaneImg.src = "green plane 3.png";
 
 const blueCounterPlaneImg = new Image();
-blueCounterPlaneImg.src = "planes/blue counter.png";
+blueCounterPlaneImg.src = "planes/blue counter 6.png";
 
 const greenCounterPlaneImg = new Image();
-greenCounterPlaneImg.src = "planes/green counter.png";
+greenCounterPlaneImg.src = "planes/green counter 6.png";
 
 const bluePlaneWreckImg = new Image();
 bluePlaneWreckImg.src = "planes/blue fall.png";


### PR DESCRIPTION
## Summary
- switch HUD plane counter images to use the green and blue variant 6 assets
- update the runtime counter image sources accordingly in script.js

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f120fc54bc832da81a11f7e68b6e6f