### PR TITLE
Remove counter plane drop shadows

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
 
     <div id="hudPlaneStyleProbes" aria-hidden="true"
          style="position:absolute;width:0;height:0;overflow:hidden;clip-path:inset(50%);">
-      <img src="planes/green counter.png" class="hud-plane green" alt="" draggable="false">
-      <img src="planes/blue counter.png" class="hud-plane blue" alt="" draggable="false">
+      <img src="planes/green counter 6.png" class="hud-plane green" alt="" draggable="false">
+      <img src="planes/blue counter 6.png" class="hud-plane blue" alt="" draggable="false">
     </div>
 
     <!-- Turn indicators -->

--- a/script.js
+++ b/script.js
@@ -471,10 +471,10 @@ const greenPlaneImg = new Image();
 greenPlaneImg.src = "green plane 3.png";
 
 const blueCounterPlaneImg = new Image();
-blueCounterPlaneImg.src = "planes/blue counter.png";
+blueCounterPlaneImg.src = "planes/blue counter 6.png";
 
 const greenCounterPlaneImg = new Image();
-greenCounterPlaneImg.src = "planes/green counter.png";
+greenCounterPlaneImg.src = "planes/green counter 6.png";
 
 const bluePlaneWreckImg = new Image();
 bluePlaneWreckImg.src = "planes/blue fall.png";

--- a/styles.css
+++ b/styles.css
@@ -746,11 +746,6 @@ button, .control-box, #modeMenu, #endGameButtons { transition: all 0.3s ease; }
   transform: scale(1.2);
   transform-origin: center;
 
-  /* мягкая тень без яркой подсветки */
-  filter:
-    drop-shadow(0 1px 1px rgba(0,0,0,.35))
-    drop-shadow(0 5px 12px rgba(0,0,0,.35));
-
   /* чтобы гифка не мыльнилась при масштабировании */
   image-rendering: -webkit-optimize-contrast;
   image-rendering: crisp-edges;
@@ -758,17 +753,9 @@ button, .control-box, #modeMenu, #endGameButtons { transition: all 0.3s ease; }
 
 /* приглушённая тень с оттенком в цвет команды */
 .hud-plane.green{
-  filter:
-    drop-shadow(0 1px 1px rgba(0,0,0,.35))
-    drop-shadow(0 6px 14px rgba(32,60,32,.45))
-    drop-shadow(0 10px 22px rgba(0,0,0,.35));
 }
 
 .hud-plane.blue{
-  filter:
-    drop-shadow(0 1px 1px rgba(0,0,0,.35))
-    drop-shadow(0 6px 14px rgba(24,44,78,.45))
-    drop-shadow(0 10px 22px rgba(0,0,0,.35));
 }
 
 /* если вдруг кому-то будет слишком крупно — можно быстро откатить масштаб


### PR DESCRIPTION
## Summary
- remove drop-shadow filters from the HUD counter plane styles so the PNGs render without additional shading

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f120fc54bc832da81a11f7e68b6e6f