### PR TITLE
Adjust HUD counter visuals

### DIFF
--- a/script.js
+++ b/script.js
@@ -646,9 +646,9 @@ document.addEventListener('dblclick', (e) => {
 /* ======= CONFIG ======= */
 const PLANE_SCALE          = 0.9;    // 10% smaller planes
 const MINI_PLANE_ICON_SCALE = 0.7;    // make HUD plane icons smaller on the counter
-const HUD_PLANE_DIM_ALPHA = 0.75;     // dim HUD planes slightly for a softer look
-const HUD_PLANE_DIM_FILTER = "brightness(0.7) saturate(0.8)";  // soften HUD plane colors
-const HUD_KILL_MARKER_COLOR = "#91200f";
+const HUD_PLANE_DIM_ALPHA = 1;        // keep HUD planes at full opacity
+const HUD_PLANE_DIM_FILTER = "";     // no additional dimming filter for HUD planes
+const HUD_KILL_MARKER_COLOR = "#e42727";
 const HUD_KILL_MARKER_ALPHA = 0.85;
 const CELL_SIZE            = 20;     // px
 const POINT_RADIUS         = 15 * PLANE_SCALE;     // px (увеличено для мобильных)


### PR DESCRIPTION
## Summary
- update the HUD kill marker color to #e42727 for the counter strike-through
- remove the brightness and opacity dimming applied to HUD plane icons so they render at full strength

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f13d02ce0c832d814aa3dc3dd2853c