### PR TITLE
Adjust HUD plane scale and kill marker stroke

### DIFF
--- a/script.js
+++ b/script.js
@@ -3157,7 +3157,7 @@ function drawRedCross(ctx2d, cx, cy, size = 20, progress = 1){
   ctx2d.filter = "none";
   ctx2d.strokeStyle = HUD_KILL_MARKER_COLOR;
   ctx2d.globalAlpha *= HUD_KILL_MARKER_ALPHA;
-  ctx2d.lineWidth = 2 * PLANE_SCALE;
+  ctx2d.lineWidth = 4 * PLANE_SCALE;
   ctx2d.lineCap = "round";
 
   const halfSize = size / 2;

--- a/styles.css
+++ b/styles.css
@@ -742,8 +742,8 @@ button, .control-box, #modeMenu, #endGameButtons { transition: all 0.3s ease; }
   position: relative;
   z-index: 3;
 
-  /* +20% размер, центр остаётся на месте */
-  transform: scale(1.2);
+  /* +8% размер, центр остаётся на месте */
+  transform: scale(1.08);
   transform-origin: center;
 
   /* чтобы гифка не мыльнилась при масштабировании */


### PR DESCRIPTION
## Summary
- reduce the HUD counter plane sprites by 10% to fine-tune their scale
- double the thickness of the red kill marker stroke for better legibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f1435c8920832da1f804c3e1cd290a