### PR TITLE
Adjust score counter alignment within container

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -50,16 +50,16 @@ body, button {
 
   .score-counter--green {
     left: calc(4px * var(--score-scale, 1));
-    top: calc(288px * var(--score-scale, 1));
+    top: calc(332px * var(--score-scale, 1));
     width: calc(43px * var(--score-scale, 1));
-    height: calc(124px * var(--score-scale, 1));
+    height: calc(360px * var(--score-scale, 1));
   }
 
   .score-counter--blue {
     left: calc(414px * var(--score-scale, 1));
-    top: calc(288px * var(--score-scale, 1));
+    top: calc(92px * var(--score-scale, 1));
     width: calc(43px * var(--score-scale, 1));
-    height: calc(124px * var(--score-scale, 1));
+    height: calc(280px * var(--score-scale, 1));
   }
 
   .score-counter .score-ink {


### PR DESCRIPTION
## Summary
- align the green and blue score counters with their intended mockup coordinates
- expand each counter's bounding box so the score ink renders within the container

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5458516d4832db5c3f51653618e11