### PR TITLE
Adjust score counter positioning

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -50,16 +50,16 @@ body, button {
 
   .score-counter--green {
     left: calc(4px * var(--score-scale, 1));
-    top: calc(332px * var(--score-scale, 1));
+    top: calc(288px * var(--score-scale, 1));
     width: calc(43px * var(--score-scale, 1));
-    height: calc(360px * var(--score-scale, 1));
+    height: calc(124px * var(--score-scale, 1));
   }
 
   .score-counter--blue {
     left: calc(414px * var(--score-scale, 1));
-    top: calc(92px * var(--score-scale, 1));
+    top: calc(288px * var(--score-scale, 1));
     width: calc(43px * var(--score-scale, 1));
-    height: calc(280px * var(--score-scale, 1));
+    height: calc(124px * var(--score-scale, 1));
   }
 
   .score-counter .score-ink {


### PR DESCRIPTION
## Summary
- align the green and blue score counters to start at y=288 while preserving their horizontal placement
- reduce the counter container height to 124px so the ink animation stays within the bounds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5c84de19c832dab364a79290c07ff