### PR TITLE
Fix blue score counter placement

### DIFF
--- a/script.js
+++ b/script.js
@@ -30,7 +30,7 @@ const SCORE_COUNTER_ELEMENTS = {
 
 const SCORE_COUNTER_BASE_OFFSETS = {
   green: { x: 4,   y: 288 },
-  blue:  { x: 414, y: 288 }
+  blue:  { x: 367, y: 288 }
 };
 
 const SCORE_COUNTER_BASE_SIZE = { width: 43, height: 124 };

--- a/styles.css
+++ b/styles.css
@@ -56,7 +56,7 @@ body, button {
   }
 
   .score-counter--blue {
-    left: calc(414px * var(--score-scale, 1));
+    left: calc(367px * var(--score-scale, 1));
     top: calc(288px * var(--score-scale, 1));
     width: calc(43px * var(--score-scale, 1));
     height: calc(124px * var(--score-scale, 1));


### PR DESCRIPTION
## Summary
- reposition the blue score counter container so score ink renders between the kill column and star rack
- update the blue counter base offset constant to match the new HUD anchor

## Testing
- Manual verification in browser (Playwright screenshot)

------
https://chatgpt.com/codex/tasks/task_e_68f5caa76484832d9fe967b24431b32c