### PR TITLE
Align blue score counter with right gutter

### DIFF
--- a/script.js
+++ b/script.js
@@ -30,7 +30,7 @@ const SCORE_COUNTER_ELEMENTS = {
 
 const SCORE_COUNTER_BASE_OFFSETS = {
   green: { x: 4,   y: 388 },
-  blue:  { x: 367, y: 388 }
+  blue:  { x: 414, y: 388 }
 };
 
 const SCORE_COUNTER_BASE_SIZE = { width: 43, height: 124 };

--- a/styles.css
+++ b/styles.css
@@ -56,7 +56,7 @@ body, button {
   }
 
   .score-counter--blue {
-    left: calc(367px * var(--score-scale, 1));
+    right: calc(3px * var(--score-scale, 1));
     top: calc(388px * var(--score-scale, 1));
     width: calc(43px * var(--score-scale, 1));
     height: calc(124px * var(--score-scale, 1));


### PR DESCRIPTION
## Summary
- align the blue score counter HUD element with the mockup by anchoring it to the right gutter in CSS
- update the fallback geometry for the blue score counter so JavaScript mirrors the new layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6071bc524832dbe76daaea399764d