### PR TITLE
Ensure score ink anchors update on HUD scale changes

### DIFF
--- a/script.js
+++ b/script.js
@@ -3829,6 +3829,17 @@ const activeScoreInkEntries = {
   green: null
 };
 
+function refreshScoreInkAnchors(){
+  for(const [color, host] of Object.entries(SCORE_COUNTER_ELEMENTS)){
+    if(!(host instanceof HTMLElement)){
+      continue;
+    }
+
+    const targetScore = activeScoreInkEntries[color]?.targetScore ?? getScoreForColor(color);
+    setScoreInkAnchor(host, color, targetScore);
+  }
+}
+
 function spawnScorePopup(color, delta, targetScore){
   if(delta <= 0) return;
   if(color !== "blue" && color !== "green") return;
@@ -4413,6 +4424,8 @@ function resizeCanvas() {
   if(points.length === 0) {
     initPoints();
   }
+
+  refreshScoreInkAnchors();
 }
 
 window.addEventListener('resize', resizeCanvas);


### PR DESCRIPTION
## Summary
- add a helper that recalculates score ink anchors from the latest target scores
- call the helper after canvas resize so HUD scaling keeps popups aligned

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f60c0dc178832dbb8d9e9073d93cb9