### PR TITLE
Point shard assets to shards 3 directory

### DIFF
--- a/script.js
+++ b/script.js
@@ -902,18 +902,18 @@ let greenFlagStolenBy = null;
 
 const DEFAULT_STAR_FRAGMENT_SOURCES = {
   green: [
-    "shards with yellow/shard green 1.png",
-    "shards with yellow/shard green 2.png",
-    "shards with yellow/shard green 3.png",
-    "shards with yellow/shard green 4.png",
-    "shards with yellow/shard green 5.png"
+    "shards 3/green shard 1.png",
+    "shards 3/green shard 2.png",
+    "shards 3/green shard 3.png",
+    "shards 3/green shard 4.png",
+    "shards 3/green shard 5.png"
   ],
   blue: [
-    "shards with yellow/shard blue 1.png",
-    "shards with yellow/shard blue 2.png",
-    "shards with yellow/shard blue 3.png",
-    "shards with yellow/shard blue 4.png",
-    "shards with yellow/shard blue 5.png"
+    "shards 3/blue shard 1.png",
+    "shards 3/blue shard 2.png",
+    "shards 3/blue shard 3.png",
+    "shards 3/blue shard 4.png",
+    "shards 3/blue shard 5.png"
   ]
 };
 


### PR DESCRIPTION
## Summary
- update the default star fragment asset paths to use the files in the `shards 3` directory

## Testing
- not run (UI smoke test requires interactive browser)

------
https://chatgpt.com/codex/tasks/task_e_68f61a1dd898832da4bf827f8a7ed18f