### PR TITLE
Restore overlay sizing helper for overlays

### DIFF
--- a/script.js
+++ b/script.js
@@ -371,6 +371,38 @@ function worldToOverlay(x, y, options = {}) {
   return { clientX, clientY, overlayX, overlayY, nx, ny, boardRect, overlayRect };
 }
 
+function sizeAndAlignOverlays() {
+  if (!(overlayContainer instanceof HTMLElement)) {
+    return;
+  }
+
+  const viewport = getVisualViewportState();
+  const safeScale = Number.isFinite(viewport.scale) && viewport.scale > 0 ? viewport.scale : 1;
+  const offsetLeft = Number.isFinite(viewport.offsetLeft) ? viewport.offsetLeft : 0;
+  const offsetTop = Number.isFinite(viewport.offsetTop) ? viewport.offsetTop : 0;
+
+  const baseWidth = Number.isFinite(viewport.width) && viewport.width > 0
+    ? viewport.width * safeScale
+    : (typeof window !== "undefined" && Number.isFinite(window.innerWidth) ? window.innerWidth : 0);
+  const baseHeight = Number.isFinite(viewport.height) && viewport.height > 0
+    ? viewport.height * safeScale
+    : (typeof window !== "undefined" && Number.isFinite(window.innerHeight) ? window.innerHeight : 0);
+
+  const width = Math.max(1, Math.round(baseWidth));
+  const height = Math.max(1, Math.round(baseHeight));
+
+  overlayContainer.style.left = `${offsetLeft}px`;
+  overlayContainer.style.top = `${offsetTop}px`;
+  overlayContainer.style.width = `${width}px`;
+  overlayContainer.style.height = `${height}px`;
+  overlayContainer.style.transform = "none";
+
+  if (fxLayerElement instanceof HTMLElement) {
+    fxLayerElement.style.width = `${width}px`;
+    fxLayerElement.style.height = `${height}px`;
+  }
+}
+
 // ---- ЕДИНЫЕ размеры макета ----
 const MOCKUP_W = 460;
 const MOCKUP_H = 800;


### PR DESCRIPTION
## Summary
- add the missing `sizeAndAlignOverlays` helper so the boot sequence no longer throws a ReferenceError
- compute overlay container dimensions from the visual viewport and keep the FX layer in sync

## Testing
- not run (frontend only)


------
https://chatgpt.com/codex/tasks/task_e_68f719d81658832d92dd637356b1e443