### PR TITLE
Expand in-game test controls for debugging

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,47 @@
     <button id="noButton" class="end-btn">No</button>
   </div>
 
+  <!-- In-game testing controls -->
+  <div id="testControlPanel" class="test-controls collapsed" aria-live="polite">
+    <button id="testControlsToggle" class="test-controls__toggle" aria-expanded="false" type="button">
+      Test Controls
+    </button>
+    <div class="test-controls__body" id="testControlsBody">
+      <div class="test-controls__field">
+        <label for="inGameMapSelect" class="test-controls__label">Map</label>
+        <select id="inGameMapSelect" class="test-controls__select"></select>
+      </div>
+      <div class="test-controls__field">
+        <label for="inGameFlameStyle" class="test-controls__label">Flame Style</label>
+        <select id="inGameFlameStyle" class="test-controls__select"></select>
+      </div>
+      <div class="test-controls__field">
+        <label for="testFlightRange" class="test-controls__label">Flight Range (cells)</label>
+        <input id="testFlightRange" class="test-controls__input" type="number" min="5" max="30" step="1" inputmode="numeric" />
+      </div>
+      <div class="test-controls__field">
+        <label for="testAmplitude" class="test-controls__label">Aiming Amplitude (°)</label>
+        <input id="testAmplitude" class="test-controls__input" type="number" min="0" max="120" step="1" inputmode="decimal" />
+      </div>
+      <label class="test-controls__checkbox">
+        <input type="checkbox" id="testAddAAToggle" />
+        <span>Include AA placement phase</span>
+      </label>
+      <label class="test-controls__checkbox">
+        <input type="checkbox" id="testSharpEdgesToggle" />
+        <span>Enable sharp arena edges</span>
+      </label>
+      <label class="test-controls__checkbox">
+        <input type="checkbox" id="testRandomizeToggle" />
+        <span>Randomize map each round</span>
+      </label>
+      <div class="test-controls__actions">
+        <button id="testApplyBtn" type="button">Apply</button>
+        <button id="testRestartBtn" type="button">Apply &amp; Restart</button>
+      </div>
+    </div>
+  </div>
+
     <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -26,6 +26,18 @@ const fxLayerElement = document.getElementById("fxLayer");
 const greenScoreCounter = document.getElementById("greenScoreCounter");
 const blueScoreCounter  = document.getElementById("blueScoreCounter");
 
+const testControlPanel = document.getElementById("testControlPanel");
+const testControlsToggle = document.getElementById("testControlsToggle");
+const inGameMapSelect = document.getElementById("inGameMapSelect");
+const inGameFlameStyleSelect = document.getElementById("inGameFlameStyle");
+const testFlightRangeInput = document.getElementById("testFlightRange");
+const testAmplitudeInput = document.getElementById("testAmplitude");
+const testAddAAToggle = document.getElementById("testAddAAToggle");
+const testSharpEdgesToggle = document.getElementById("testSharpEdgesToggle");
+const testRandomizeToggle = document.getElementById("testRandomizeToggle");
+const testApplyBtn = document.getElementById("testApplyBtn");
+const testRestartBtn = document.getElementById("testRestartBtn");
+
 const SCORE_COUNTER_ELEMENTS = {
   green: greenScoreCounter,
   blue: blueScoreCounter
@@ -146,6 +158,20 @@ function combineFilters(...filters) {
 }
 
 rebuildHudPlaneStyleCache();
+
+function formatNumericInputValue(value, fractionDigits = 2) {
+  if (!Number.isFinite(value)) {
+    return "";
+  }
+  const factor = Math.pow(10, fractionDigits);
+  const rounded = Math.round(value * factor) / factor;
+  if (Number.isInteger(rounded)) {
+    return String(rounded);
+  }
+  const fixed = rounded.toFixed(fractionDigits);
+  const trimmed = parseFloat(fixed);
+  return Number.isFinite(trimmed) ? String(trimmed) : fixed;
+}
 
 function getVisualViewportState() {
   const viewport = typeof window !== "undefined" ? window.visualViewport : null;
@@ -432,6 +458,9 @@ const DEFAULT_BURNING_FLAME_SRC = BURNING_FLAME_SRCS[0];
 
 const BURNING_FLAME_SRC_SET = new Set(BURNING_FLAME_SRCS);
 
+let flameCycleIndex = 0;
+let flameStyleRevision = 0;
+
 function pickRandomBurningFlame() {
   const pool = BURNING_FLAME_SRC_SET.size > 0
     ? Array.from(BURNING_FLAME_SRC_SET)
@@ -445,14 +474,94 @@ function pickRandomBurningFlame() {
 
 }
 
+function getCurrentFlameStyleKey() {
+  return normalizeFlameStyleKey(settings.flameStyle);
+}
+
+function getFlameStyleConfig(styleKey) {
+  return FLAME_STYLE_MAP.get(normalizeFlameStyleKey(styleKey)) || null;
+}
+
+function pickFlameSrcForStyle(styleKey) {
+  const normalized = normalizeFlameStyleKey(styleKey);
+  if (normalized === 'off') {
+    return '';
+  }
+
+  if (!Array.isArray(BURNING_FLAME_SRCS) || BURNING_FLAME_SRCS.length === 0) {
+    return DEFAULT_BURNING_FLAME_SRC || '';
+  }
+
+  if (normalized === 'cycle') {
+    const index = flameCycleIndex % BURNING_FLAME_SRCS.length;
+    flameCycleIndex = (flameCycleIndex + 1) % BURNING_FLAME_SRCS.length;
+    return BURNING_FLAME_SRCS[index];
+  }
+
+  return pickRandomBurningFlame();
+}
+
+function onFlameStyleChanged() {
+  const normalized = getCurrentFlameStyleKey();
+  if (settings.flameStyle !== normalized) {
+    settings.flameStyle = normalized;
+  }
+  flameCycleIndex = 0;
+  flameStyleRevision++;
+
+  for (const timer of planeFlameTimers.values()) {
+    clearTimeout(timer);
+  }
+  planeFlameTimers.clear();
+
+  for (const [plane, entry] of planeFlameFx.entries()) {
+    entry?.stop?.();
+    const element = entry?.element || entry;
+    element?.remove?.();
+    planeFlameFx.delete(plane);
+    if (plane) {
+      delete plane.burningFlameSrc;
+      delete plane.burningFlameStyleKey;
+      delete plane.burningFlameStyleRevision;
+    }
+  }
+
+  if (Array.isArray(points)) {
+    for (const plane of points) {
+      if (!plane) continue;
+      delete plane.burningFlameSrc;
+      delete plane.burningFlameStyleKey;
+      delete plane.burningFlameStyleRevision;
+      if (plane.burning && !plane.flameFxDisabled && isExplosionFinished(plane)) {
+        spawnBurningFlameFx(plane);
+      }
+    }
+  }
+
+  syncTestControls();
+}
+
 function ensurePlaneBurningFlame(plane) {
   if (!plane) {
     return DEFAULT_BURNING_FLAME_SRC || "";
   }
-  if (!plane.burningFlameSrc) {
-    plane.burningFlameSrc = pickRandomBurningFlame();
+  const styleKey = getCurrentFlameStyleKey();
+  if (styleKey === 'off') {
+    plane.burningFlameStyleKey = styleKey;
+    plane.burningFlameSrc = '';
+    return '';
   }
-  return plane.burningFlameSrc;
+
+  if (plane.burningFlameStyleRevision !== flameStyleRevision || plane.burningFlameStyleKey !== styleKey) {
+    plane.burningFlameSrc = null;
+    plane.burningFlameStyleKey = styleKey;
+    plane.burningFlameStyleRevision = flameStyleRevision;
+  }
+
+  if (!plane.burningFlameSrc) {
+    plane.burningFlameSrc = pickFlameSrcForStyle(styleKey);
+  }
+  return plane.burningFlameSrc || '';
 }
 
 
@@ -470,6 +579,14 @@ function applyFlameElementStyles(element) {
   element.style.pointerEvents = 'none';
   element.style.transform = 'translate(-50%, -100%)';
   element.style.zIndex = '9999';
+}
+
+function applyFlameVisualStyle(element, styleKey) {
+  if (!element) return;
+  const config = getFlameStyleConfig(styleKey);
+  const filter = config?.filter || '';
+  element.dataset.flameStyle = normalizeFlameStyleKey(styleKey);
+  element.style.filter = filter || '';
 }
 
 function createGifFlameEntry(plane, flameSrc) {
@@ -548,6 +665,12 @@ function cleanupBurningFx() {
     if (plane && plane.burningFlameSrc) {
       delete plane.burningFlameSrc;
     }
+    if (plane && plane.burningFlameStyleKey) {
+      delete plane.burningFlameStyleKey;
+    }
+    if (plane && Object.prototype.hasOwnProperty.call(plane, 'burningFlameStyleRevision')) {
+      delete plane.burningFlameStyleRevision;
+    }
     resetPlaneFlameFxDisabled(plane);
   }
   planeFlameFx.clear();
@@ -591,6 +714,7 @@ function spawnBurningFlameFx(plane) {
   }
 
   host.appendChild(entry.element);
+  applyFlameVisualStyle(entry.element, plane?.burningFlameStyleKey || getCurrentFlameStyleKey());
   planeFlameFx.set(plane, entry);
   updatePlaneFlameFxPosition(plane);
 }
@@ -1038,6 +1162,7 @@ let awaitingFlightResolution = false;
 let pendingRoundTransitionDelay = null;
 let pendingRoundTransitionStart = 0;
 let shouldShowEndScreen = false;
+let suppressAutoRandomMapForNextRound = false;
 let gameMode     = null;
 let selectedMode = null;
 
@@ -1072,10 +1197,29 @@ const MAPS = [
   { name: 'Clear Sky', file: 'map 1 - clear sky 3.png' },
   { name: '5 Bricks',  file: 'map 2 - 5 bricks.png' },
   { name: 'Diagonals', file: 'map 3 diagonals.png' }
-
 ];
 
-let settings = { addAA: false, sharpEdges: false, mapIndex: 0 };
+const FLAME_STYLE_OPTIONS = [
+  { value: 'random', label: 'Random Mix', filter: '' },
+  { value: 'cycle', label: 'Cycle (Deterministic)', filter: '' },
+  { value: 'icy', label: 'Icy Blue', filter: 'hue-rotate(200deg) saturate(1.6)' },
+  { value: 'inferno', label: 'Inferno', filter: 'hue-rotate(-30deg) saturate(1.8) brightness(1.05)' },
+  { value: 'off', label: 'Flames Disabled', filter: '' }
+];
+
+const FLAME_STYLE_MAP = new Map(FLAME_STYLE_OPTIONS.map(option => [option.value, option]));
+
+function normalizeFlameStyleKey(key) {
+  return FLAME_STYLE_MAP.has(key) ? key : 'random';
+}
+
+let settings = {
+  addAA: false,
+  sharpEdges: false,
+  mapIndex: 0,
+  flameStyle: 'random',
+  randomizeMapEachRound: false
+};
 
 let storageAvailable = true;
 function getStoredSetting(key){
@@ -1092,7 +1236,22 @@ function getStoredSetting(key){
   }
 }
 
+function setStoredSetting(key, value){
+  if(!storageAvailable){
+    return;
+  }
+  try {
+    const storage = window.localStorage;
+    if(!storage) return;
+    storage.setItem(key, value);
+  } catch(err){
+    storageAvailable = false;
+    console.warn('localStorage unavailable, settings changes will not persist.', err);
+  }
+}
+
 function loadSettings(){
+  const previousFlameStyle = settings.flameStyle;
   const fr = parseInt(getStoredSetting('settings.flightRangeCells'), 10);
   flightRangeCells = Number.isNaN(fr) ? 15 : fr;
   const amp = parseFloat(getStoredSetting('settings.aimingAmplitude'));
@@ -1101,6 +1260,9 @@ function loadSettings(){
   settings.sharpEdges = getStoredSetting('settings.sharpEdges') === 'true';
   const mapIdx = parseInt(getStoredSetting('settings.mapIndex'), 10);
   settings.mapIndex = Number.isNaN(mapIdx) ? 0 : Math.min(MAPS.length - 1, Math.max(0, mapIdx));
+  const storedFlameStyle = normalizeFlameStyleKey(getStoredSetting('settings.flameStyle'));
+  settings.flameStyle = storedFlameStyle;
+  settings.randomizeMapEachRound = getStoredSetting('settings.randomizeMapEachRound') === 'true';
 
   // Clamp loaded values so corrupted or out-of-range settings
   // don't break the game on startup
@@ -1108,6 +1270,10 @@ function loadSettings(){
                              Math.max(MIN_FLIGHT_RANGE_CELLS, flightRangeCells));
   aimingAmplitude  = Math.min(MAX_AMPLITUDE,
                              Math.max(MIN_AMPLITUDE, aimingAmplitude));
+
+  if(previousFlameStyle !== settings.flameStyle){
+    onFlameStyleChanged();
+  }
 }
 
 loadSettings();
@@ -1118,7 +1284,9 @@ const hasCustomSettings = storageAvailable && [
   'settings.aimingAmplitude',
   'settings.addAA',
   'settings.sharpEdges',
-  'settings.mapIndex'
+  'settings.mapIndex',
+  'settings.randomizeMapEachRound',
+  'settings.flameStyle'
 ].some(key => getStoredSetting(key) !== null);
 
 if(hasCustomSettings && classicRulesBtn && advancedSettingsBtn){
@@ -1675,8 +1843,9 @@ function resetGame(){
   globalFrame=0;
   flyingPoints= [];
   buildings = [];
-  if(!advancedSettingsBtn?.classList.contains('selected')){
+  if(shouldAutoRandomizeMap()){
     settings.mapIndex = Math.floor(Math.random() * MAPS.length);
+    setStoredSetting('settings.mapIndex', String(settings.mapIndex));
   }
   applyCurrentMap();
 
@@ -1716,6 +1885,7 @@ function resetGame(){
 
   initPoints();
   renderScoreboard();
+  syncTestControls();
 }
 
 
@@ -1752,7 +1922,11 @@ if(classicRulesBtn){
     settings.addAA = false;
     settings.sharpEdges = false;
     settings.mapIndex = Math.floor(Math.random() * MAPS.length);
+    settings.randomizeMapEachRound = true;
+    settings.flameStyle = 'random';
+    onFlameStyleChanged();
     applyCurrentMap();
+    syncTestControls();
     advancedSettingsBtn?.classList.remove('selected');
     classicRulesBtn.classList.add('selected');
   });
@@ -1789,6 +1963,209 @@ playBtn.addEventListener("click",()=>{
   modeMenuDiv.style.display = "none";
   startNewRound();
 });
+
+/* ======= Test Controls ======= */
+function populateTestControls(){
+  if(inGameMapSelect && !inGameMapSelect.options.length){
+    MAPS.forEach((map, index) => {
+      const option = document.createElement('option');
+      option.value = String(index);
+      option.textContent = map.name;
+      inGameMapSelect.appendChild(option);
+    });
+  }
+
+  if(inGameFlameStyleSelect && !inGameFlameStyleSelect.options.length){
+    FLAME_STYLE_OPTIONS.forEach(option => {
+      const opt = document.createElement('option');
+      opt.value = option.value;
+      opt.textContent = option.label;
+      inGameFlameStyleSelect.appendChild(opt);
+    });
+  }
+}
+
+function syncTestControls(){
+  if(inGameMapSelect){
+    const desired = String(Math.min(MAPS.length - 1, Math.max(0, settings.mapIndex)));
+    if(inGameMapSelect.value !== desired){
+      inGameMapSelect.value = desired;
+    }
+  }
+  if(inGameFlameStyleSelect){
+    const key = getCurrentFlameStyleKey();
+    if(!Array.from(inGameFlameStyleSelect.options).some(opt => opt.value === key)){
+      populateTestControls();
+    }
+    inGameFlameStyleSelect.value = key;
+  }
+  if(testFlightRangeInput){
+    const fallbackRange = Number.isFinite(flightRangeCells) ? flightRangeCells : 15;
+    const clampedRange = Math.min(MAX_FLIGHT_RANGE_CELLS, Math.max(MIN_FLIGHT_RANGE_CELLS, fallbackRange));
+    const rangeValue = String(Math.round(clampedRange));
+    if(testFlightRangeInput.value !== rangeValue){
+      testFlightRangeInput.value = rangeValue;
+    }
+  }
+  if(testAmplitudeInput){
+    const fallbackAmplitude = Number.isFinite(aimingAmplitude) ? aimingAmplitude : (10 / 4);
+    const clampedAmplitude = Math.min(MAX_AMPLITUDE, Math.max(MIN_AMPLITUDE, fallbackAmplitude));
+    const amplitudeDegrees = clampedAmplitude * 4;
+    const formattedAmplitude = formatNumericInputValue(amplitudeDegrees);
+    if(testAmplitudeInput.value !== formattedAmplitude){
+      testAmplitudeInput.value = formattedAmplitude;
+    }
+  }
+  if(testAddAAToggle){
+    testAddAAToggle.checked = !!settings.addAA;
+  }
+  if(testSharpEdgesToggle){
+    testSharpEdgesToggle.checked = !!settings.sharpEdges;
+  }
+  if(testRandomizeToggle){
+    testRandomizeToggle.checked = !!settings.randomizeMapEachRound;
+  }
+  if(testControlsToggle){
+    testControlsToggle.setAttribute('aria-expanded', String(!testControlPanel?.classList?.contains('collapsed')));
+  }
+}
+
+function applyTestControlSelections(){
+  let mapChanged = false;
+  let flameChanged = false;
+  let randomizeChanged = false;
+  let rangeChanged = false;
+  let amplitudeChanged = false;
+  let aaChanged = false;
+  let sharpChanged = false;
+
+  if(inGameMapSelect){
+    const nextIndex = parseInt(inGameMapSelect.value, 10);
+    if(Number.isInteger(nextIndex)){
+      const clamped = Math.min(MAPS.length - 1, Math.max(0, nextIndex));
+      if(clamped !== settings.mapIndex){
+        settings.mapIndex = clamped;
+        setStoredSetting('settings.mapIndex', String(settings.mapIndex));
+        mapChanged = true;
+      }
+    }
+  }
+
+  if(inGameFlameStyleSelect){
+    const nextStyle = normalizeFlameStyleKey(inGameFlameStyleSelect.value);
+    if(nextStyle !== settings.flameStyle){
+      settings.flameStyle = nextStyle;
+      setStoredSetting('settings.flameStyle', settings.flameStyle);
+      flameChanged = true;
+    }
+  }
+
+  if(testFlightRangeInput){
+    const rawValue = parseFloat(testFlightRangeInput.value);
+    if(Number.isFinite(rawValue)){
+      const clamped = Math.min(MAX_FLIGHT_RANGE_CELLS, Math.max(MIN_FLIGHT_RANGE_CELLS, rawValue));
+      const normalized = Math.round(clamped);
+      if(normalized !== flightRangeCells){
+        flightRangeCells = normalized;
+        setStoredSetting('settings.flightRangeCells', String(flightRangeCells));
+        rangeChanged = true;
+      }
+    }
+  }
+
+  if(testAmplitudeInput){
+    const rawDegrees = parseFloat(testAmplitudeInput.value);
+    if(Number.isFinite(rawDegrees)){
+      const clampedDegrees = Math.min(MAX_AMPLITUDE * 4, Math.max(MIN_AMPLITUDE * 4, rawDegrees));
+      const nextAmplitude = clampedDegrees / 4;
+      if(!Number.isFinite(aimingAmplitude) || Math.abs(nextAmplitude - aimingAmplitude) > 1e-6){
+        aimingAmplitude = nextAmplitude;
+        setStoredSetting('settings.aimingAmplitude', String(aimingAmplitude));
+        amplitudeChanged = true;
+      }
+    }
+  }
+
+  if(testAddAAToggle){
+    const nextAddAA = !!testAddAAToggle.checked;
+    if(nextAddAA !== settings.addAA){
+      settings.addAA = nextAddAA;
+      setStoredSetting('settings.addAA', nextAddAA ? 'true' : 'false');
+      aaChanged = true;
+    }
+  }
+
+  if(testSharpEdgesToggle){
+    const nextSharpEdges = !!testSharpEdgesToggle.checked;
+    if(nextSharpEdges !== settings.sharpEdges){
+      settings.sharpEdges = nextSharpEdges;
+      setStoredSetting('settings.sharpEdges', nextSharpEdges ? 'true' : 'false');
+      sharpChanged = true;
+    }
+  }
+
+  if(testRandomizeToggle){
+    const nextRandomize = !!testRandomizeToggle.checked;
+    if(nextRandomize !== settings.randomizeMapEachRound){
+      settings.randomizeMapEachRound = nextRandomize;
+      setStoredSetting('settings.randomizeMapEachRound', nextRandomize ? 'true' : 'false');
+      randomizeChanged = true;
+    }
+  }
+
+  if(flameChanged){
+    onFlameStyleChanged();
+  }
+
+  syncTestControls();
+
+  return {
+    mapChanged,
+    flameChanged,
+    randomizeChanged,
+    rangeChanged,
+    amplitudeChanged,
+    aaChanged,
+    sharpChanged
+  };
+}
+
+populateTestControls();
+syncTestControls();
+
+if(testControlsToggle && testControlPanel){
+  testControlsToggle.addEventListener('click', () => {
+    testControlPanel.classList.toggle('collapsed');
+    const expanded = !testControlPanel.classList.contains('collapsed');
+    testControlsToggle.setAttribute('aria-expanded', String(expanded));
+    if(expanded){
+      populateTestControls();
+      syncTestControls();
+    }
+  });
+}
+
+if(testApplyBtn){
+  testApplyBtn.addEventListener('click', () => {
+    const result = applyTestControlSelections();
+    if(result.mapChanged){
+      applyCurrentMap();
+      suppressAutoRandomMapForNextRound = true;
+    }
+  });
+}
+
+if(testRestartBtn){
+  testRestartBtn.addEventListener('click', () => {
+    const result = applyTestControlSelections();
+    if(!gameMode){
+      applyCurrentMap();
+      return;
+    }
+    const randomizeNow = shouldAutoRandomizeMap() && !result.mapChanged && !!settings.randomizeMapEachRound;
+    restartMatchWithCurrentSettings({ randomizeMap: randomizeNow });
+  });
+}
 
 /* ======= INPUT (slingshot) ======= */
 const handleCircle={
@@ -4513,10 +4890,11 @@ yesBtn.addEventListener("click", () => {
     greenScore = 0;
     syncAllStarStates();
     roundNumber = 0;
-    if(!advancedSettingsBtn?.classList.contains('selected')){
+    if(shouldAutoRandomizeMap()){
       settings.mapIndex = Math.floor(Math.random() * MAPS.length);
-      applyCurrentMap();
+      setStoredSetting('settings.mapIndex', String(settings.mapIndex));
     }
+    applyCurrentMap();
   }
   startNewRound();
 });
@@ -4530,6 +4908,13 @@ function startNewRound(){
     clearTimeout(roundTransitionTimeout);
     roundTransitionTimeout = null;
   }
+  const shouldRandomize = !suppressAutoRandomMapForNextRound && shouldAutoRandomizeMap() && roundNumber > 0;
+  if(shouldRandomize){
+    settings.mapIndex = Math.floor(Math.random() * MAPS.length);
+    setStoredSetting('settings.mapIndex', String(settings.mapIndex));
+    applyCurrentMap();
+  }
+  suppressAutoRandomMapForNextRound = false;
   cleanupGreenCrashFx();
   clearScoreCounters();
   endGameDiv.style.display = "none";
@@ -4578,9 +4963,31 @@ function startNewRound(){
     phase = 'TURN';
   }
   if(animationFrameId===null) startGameLoop();
+  syncTestControls();
 }
 
 /* ======= Map helpers ======= */
+function shouldAutoRandomizeMap(){
+  if(!advancedSettingsBtn?.classList.contains('selected')){
+    return true;
+  }
+  return !!settings.randomizeMapEachRound;
+}
+
+function restartMatchWithCurrentSettings(options = {}){
+  const { randomizeMap = false } = options;
+  if(randomizeMap){
+    settings.mapIndex = Math.floor(Math.random() * MAPS.length);
+    setStoredSetting('settings.mapIndex', String(settings.mapIndex));
+  }
+  applyCurrentMap();
+  blueScore = 0;
+  greenScore = 0;
+  roundNumber = 0;
+  suppressAutoRandomMapForNextRound = true;
+  startNewRound();
+}
+
 function applyCurrentMap(){
   buildings = [];
   const map = MAPS[settings.mapIndex] || MAPS[0];

--- a/styles.css
+++ b/styles.css
@@ -739,6 +739,127 @@ body, button {
 /* Плавные переходы */
 button, .control-box, #modeMenu, #endGameButtons { transition: all 0.3s ease; }
 
+/* ===== Test controls overlay ===== */
+.test-controls {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 1200;
+  width: min(280px, 90vw);
+  background: rgba(20, 24, 32, 0.88);
+  color: #f5f5f5;
+  border-radius: 14px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+  font-size: 14px;
+  backdrop-filter: blur(6px);
+}
+
+.test-controls.collapsed .test-controls__body {
+  display: none;
+}
+
+.test-controls__toggle {
+  width: 100%;
+  padding: 10px 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, #2d7dd2, #1e5ea8);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+
+.test-controls__toggle:focus-visible {
+  outline: 2px solid #ffde59;
+  outline-offset: 2px;
+}
+
+.test-controls__body {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.test-controls__field {
+  display: grid;
+  gap: 4px;
+}
+
+.test-controls__label {
+  font-weight: 600;
+  font-size: 13px;
+  text-align: left;
+}
+
+.test-controls__select,
+.test-controls__input {
+  width: 100%;
+  padding: 8px;
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.25);
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+}
+
+.test-controls__select:focus-visible,
+.test-controls__input:focus-visible {
+  outline: 2px solid #ffde59;
+  outline-offset: 2px;
+}
+
+.test-controls__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  user-select: none;
+}
+
+.test-controls__checkbox input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: #ffde59;
+}
+
+.test-controls__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.test-controls__actions button {
+  flex: 1 1 0;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.15);
+  color: inherit;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.test-controls__actions button:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.test-controls__actions button:focus-visible {
+  outline: 2px solid #ffde59;
+  outline-offset: 2px;
+}
+
+@media (max-width: 520px) {
+  .test-controls {
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    width: min(320px, 94vw);
+  }
+}
+
 /* === HUD planes: мягкая тень вместо подсветки === */
 .hud-plane{
   /* делаем их поверх всего на колонке */


### PR DESCRIPTION
## Summary
- add flight range, aiming amplitude, anti-aircraft, and sharp edge toggles to the in-game test controls for broader runtime experimentation
- update styling and logic so the expanded tester options sync correctly and persist when requested
- revert advanced settings back to their original scope so the new parameters remain test-only

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68f7ce68efbc832d9c702756dd61b9a8