### PR TITLE
Differentiate round vs game win messages

### DIFF
--- a/script.js
+++ b/script.js
@@ -3284,7 +3284,10 @@ function handleAAForPlane(p, fp){
   if(isGameOver && winnerColor){
     gameCtx.font="48px 'Patrick Hand', cursive";
     gameCtx.fillStyle= colorFor(winnerColor);
-    const text= `${winnerColor.charAt(0).toUpperCase() + winnerColor.slice(1)} wins!`;
+    const winnerName= `${winnerColor.charAt(0).toUpperCase() + winnerColor.slice(1)}`;
+    const text= shouldShowEndScreen
+      ? `${winnerName} wins the game!`
+      : `${winnerName} wins the round!`;
     const w= gameCtx.measureText(text).width;
     gameCtx.fillText(text, (gameCanvas.width - w)/2, gameCanvas.height/2 - 80);
   }


### PR DESCRIPTION
## Summary
- update the in-game overlay so round victories show a "wins the round" message
- show a "wins the game" message when the series concludes with the end screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f885be4024832da0541b74ad28407e