### PR TITLE
Align end-game overlay with winner text

### DIFF
--- a/script.js
+++ b/script.js
@@ -3288,8 +3288,47 @@ function handleAAForPlane(p, fp){
     const text= shouldShowEndScreen
       ? `${winnerName} wins the game!`
       : `${winnerName} wins the round!`;
-    const w= gameCtx.measureText(text).width;
-    gameCtx.fillText(text, (gameCanvas.width - w)/2, gameCanvas.height/2 - 80);
+    const metrics = gameCtx.measureText(text);
+    const w = metrics.width;
+    const textX = (gameCanvas.width - w) / 2;
+    const textBaselineY = gameCanvas.height / 2 - 80;
+    gameCtx.fillText(text, textX, textBaselineY);
+
+    if(shouldShowEndScreen && endGameDiv){
+      const descent = Number.isFinite(metrics.actualBoundingBoxDescent) ? metrics.actualBoundingBoxDescent : 0;
+      const anchorCanvasX = gameCanvas.width / 2;
+      const anchorCanvasY = textBaselineY + descent + 24;
+      const boardRect = getViewportAdjustedBoundingClientRect(gameCanvas);
+      const boardWidth = Number.isFinite(boardRect.width) ? boardRect.width : 0;
+      const boardHeight = Number.isFinite(boardRect.height) ? boardRect.height : 0;
+      const scaleX = gameCanvas.width !== 0 ? boardWidth / gameCanvas.width : 1;
+      const scaleY = gameCanvas.height !== 0 ? boardHeight / gameCanvas.height : 1;
+      const anchorClientX = (Number.isFinite(boardRect.left) ? boardRect.left : 0) + anchorCanvasX * scaleX;
+      const anchorClientY = (Number.isFinite(boardRect.top) ? boardRect.top : 0) + anchorCanvasY * scaleY;
+
+      if(endGameDiv.style.display !== "block"){
+        endGameDiv.style.display = "block";
+      }
+
+      const panelWidth = endGameDiv.offsetWidth || 0;
+      const targetLeft = Math.round(anchorClientX - panelWidth / 2);
+      const targetTop = Math.round(anchorClientY);
+
+      if(Number.isFinite(targetLeft)){
+        endGameDiv.style.left = `${targetLeft}px`;
+      }
+      if(Number.isFinite(targetTop)){
+        endGameDiv.style.top = `${targetTop}px`;
+      }
+    }
+  }
+
+  if(endGameDiv && (!shouldShowEndScreen || !isGameOver || !winnerColor)){
+    if(endGameDiv.style.display !== "none"){
+      endGameDiv.style.display = "none";
+    }
+    endGameDiv.style.left = "";
+    endGameDiv.style.top = "";
   }
 
   if(roundTextTimer > 0){

--- a/styles.css
+++ b/styles.css
@@ -720,7 +720,10 @@ body, button {
 
 /* Окно конца игры */
 #endGameButtons {
-  position: fixed; top:50%; left:50%; transform: translate(-50%, -50%);
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 250;
   background: linear-gradient(135deg, #ffffff, #eaeaea);
   padding: 40px; border: 2px solid #c1c1c1; border-radius: 20px;
   box-shadow: 0 12px 24px rgba(0,0,0,0.2);


### PR DESCRIPTION
## Summary
- allow the end-game buttons panel to be positioned relative to the overlay by switching it to absolute positioning
- compute the screen coordinates below the "wins the game!" message and place the panel on that anchor
- clear the inline positioning when the panel is hidden so it can be reset cleanly

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f889119d40832daba17c3745fc9da8