### PR TITLE
Add dynamic map preview to settings page

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -61,12 +61,15 @@
 
       <!-- Map Selection -->
       <div class="control-box">
-      <div class="control-label">Map</div>
-      <div class="control-visual"></div>
-      <div class="control-value"></div>
-      <div class="control-buttons">
-        <select id="mapSelect"></select>
-      </div>
+        <div class="control-label">Map</div>
+        <div class="control-visual map-preview">
+          <div class="map-preview-layer map-preview-paper"></div>
+          <div class="map-preview-layer map-preview-image" id="mapPreview"></div>
+        </div>
+        <div class="control-value"></div>
+        <div class="control-buttons">
+          <select id="mapSelect"></select>
+        </div>
       </div>
 
       <!-- Additional Settings -->

--- a/settings.js
+++ b/settings.js
@@ -47,6 +47,7 @@ if(Number.isNaN(aimingAmplitude)) aimingAmplitude = 10 / 4;
 let addAA = getStoredItem('settings.addAA') === 'true';
 let sharpEdges = getStoredItem('settings.sharpEdges') === 'true';
 let mapIndex = getIntSetting('settings.mapIndex', 0);
+if(mapIndex < 0 || mapIndex >= MAPS.length) mapIndex = 0;
 
 const flightRangeMinusBtn = document.getElementById('flightRangeMinus');
 const flightRangePlusBtn  = document.getElementById('flightRangePlus');
@@ -56,6 +57,7 @@ const addAAToggle = document.getElementById('addAAToggle');
 const sharpEdgesToggle = document.getElementById('sharpEdgesToggle');
 const backBtn = document.getElementById('backBtn');
 const mapSelect = document.getElementById('mapSelect');
+const mapPreview = document.getElementById('mapPreview');
 
 function updateFlightRangeDisplay(){
   const el = document.getElementById('flightRangeDisplay');
@@ -110,6 +112,12 @@ function saveSettings(){
   setStoredItem('settings.mapIndex', mapIndex);
 }
 
+function updateMapPreview(){
+  if(!mapPreview) return;
+  const map = MAPS[mapIndex];
+  mapPreview.style.backgroundImage = map ? `url('${map.file}')` : '';
+}
+
 function setupRepeatButton(btn, cb){
   if(!btn) return;
   let timeoutId = null;
@@ -154,10 +162,17 @@ if(mapSelect){
     mapSelect.appendChild(opt);
   });
   mapSelect.value = String(mapIndex);
+  updateMapPreview();
   mapSelect.addEventListener('change', e => {
-    mapIndex = parseInt(e.target.value);
+    const newIndex = parseInt(e.target.value, 10);
+    mapIndex = Number.isNaN(newIndex) ? 0 : newIndex;
+    updateMapPreview();
     saveSettings();
   });
+}
+
+if(!mapSelect){
+  updateMapPreview();
 }
 
 setupRepeatButton(flightRangeMinusBtn, () => {

--- a/styles.css
+++ b/styles.css
@@ -488,6 +488,30 @@ body, button {
   margin: 6px 0;
 }
 
+#modeMenu .control-box > .control-visual.map-preview {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.map-preview-layer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  transform: rotate(90deg);
+  opacity: 0.5;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.map-preview-paper {
+  background-image: url("background paper 1.png");
+}
+
 #modeMenu .control-box > .control-value {
   font-size: 20px;
   color: #ee0000;


### PR DESCRIPTION
## Summary
- add a layered map preview element to the map selector in settings.html
- style the map preview container and layers, including the paper background texture
- update settings.js to refresh the preview based on the selected map

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f8c7b20e24832da72de0a270a52583