### PR TITLE
Integrate interface button and toggle art into advanced settings

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -35,8 +35,22 @@
             <div id="flightRangeDisplay" class="range-display">15</div>
           </div>
           <div class="control-buttons">
-            <button id="flightRangeMinus" class="control-btn">−</button>
-            <button id="flightRangePlus" class="control-btn">+</button>
+            <button
+              id="flightRangeMinus"
+              class="control-btn control-btn--minus"
+              type="button"
+              aria-label="Decrease flight range"
+            >
+              <span class="visually-hidden">Decrease flight range</span>
+            </button>
+            <button
+              id="flightRangePlus"
+              class="control-btn control-btn--plus"
+              type="button"
+              aria-label="Increase flight range"
+            >
+              <span class="visually-hidden">Increase flight range</span>
+            </button>
           </div>
         </div>
 
@@ -53,8 +67,22 @@
           </div>
           <div class="control-value"><span id="amplitudeAngleDisplay">40°</span></div>
           <div class="control-buttons">
-            <button id="amplitudeMinus" class="control-btn">−</button>
-            <button id="amplitudePlus" class="control-btn">+</button>
+            <button
+              id="amplitudeMinus"
+              class="control-btn control-btn--minus"
+              type="button"
+              aria-label="Decrease aiming amplitude"
+            >
+              <span class="visually-hidden">Decrease aiming amplitude</span>
+            </button>
+            <button
+              id="amplitudePlus"
+              class="control-btn control-btn--plus"
+              type="button"
+              aria-label="Increase aiming amplitude"
+            >
+              <span class="visually-hidden">Increase aiming amplitude</span>
+            </button>
           </div>
         </div>
       </div>
@@ -74,13 +102,21 @@
 
       <!-- Additional Settings -->
       <div class="control-box" id="additionalSettings">
-      <div class="control-label">Additional Settings</div>
-      <div class="aa-toggle">
-        <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
-      </div>
-      <div class="aa-toggle">
-        <label><input type="checkbox" id="sharpEdgesToggle" /> Sharp Edges</label>
-      </div>
+        <div class="control-label">Additional Settings</div>
+        <div class="aa-toggle">
+          <input type="checkbox" id="addAAToggle" class="toggle-input visually-hidden" />
+          <label for="addAAToggle" class="toggle-label">
+            <span class="toggle-visual" aria-hidden="true"></span>
+            <span class="toggle-text">Add Anti-Aircraft</span>
+          </label>
+        </div>
+        <div class="aa-toggle">
+          <input type="checkbox" id="sharpEdgesToggle" class="toggle-input visually-hidden" />
+          <label for="sharpEdgesToggle" class="toggle-label">
+            <span class="toggle-visual" aria-hidden="true"></span>
+            <span class="toggle-text">Sharp Edges</span>
+          </label>
+        </div>
       </div>
 
     </div>

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,19 @@ body, button {
   box-sizing: border-box;
 }
 
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Базовый шрифт/раскладка */
 
   body {
@@ -469,7 +482,49 @@ body, button {
 }
 
 #modeMenu #additionalSettings .aa-toggle {
-  margin: 5px 0;
+  margin: 8px 0;
+  display: flex;
+  justify-content: center;
+}
+
+#modeMenu #additionalSettings .toggle-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 16px;
+  color: #333;
+  cursor: pointer;
+  font-weight: 500;
+  padding: 6px 10px;
+  border-radius: 12px;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+#modeMenu #additionalSettings .toggle-visual {
+  width: 118px;
+  height: 86px;
+  background-image: url("interface/tumbler off.png");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  display: inline-block;
+  transition: transform 0.2s;
+}
+
+#modeMenu #additionalSettings .toggle-text {
+  text-transform: none;
+}
+
+#modeMenu #additionalSettings .toggle-label:hover .toggle-visual {
+  transform: translateY(-3px);
+}
+
+#modeMenu #additionalSettings .toggle-input:checked + .toggle-label .toggle-visual {
+  background-image: url("interface/tumbler on.png");
+}
+
+#modeMenu #additionalSettings .toggle-input:focus-visible + .toggle-label {
+  box-shadow: 0 0 0 3px rgba(255, 0, 0, 0.25);
 }
 
 #modeMenu .control-box > .control-label {
@@ -524,6 +579,7 @@ body, button {
   display: flex;
   gap: 10px;
   margin-top: 8px;
+  justify-content: center;
 }
 
 #modeMenu .control-box select {
@@ -652,14 +708,57 @@ body, button {
 }
 
 /* Control buttons */
-#modeMenu .control-buttons button {
-  width: 32px; height: 32px; font-size: 16px; color:#fff; border:none; border-radius:50%;
-  background: linear-gradient(145deg, #6c757d, #5a6268);
-  box-shadow: 0 3px 6px rgba(0,0,0,0.2);
-  cursor:pointer; transition: transform 0.2s, box-shadow 0.2s;
+#modeMenu .control-btn {
+  width: 72px;
+  height: 66px;
+  border: none;
+  padding: 0;
+  background-color: transparent;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  cursor: pointer;
+  transition: transform 0.2s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
-#modeMenu .control-buttons button:hover { transform: translateY(-3px); box-shadow: 0 6px 12px rgba(0,0,0,0.3); }
-#modeMenu .control-buttons button:disabled { background:#a1a1a1; cursor:not-allowed; }
+
+#modeMenu .control-btn--minus {
+  background-image: url("interface/button -.png");
+}
+
+#modeMenu .control-btn--plus {
+  background-image: url("interface/button +.png");
+}
+
+#modeMenu .control-btn--minus:hover,
+#modeMenu .control-btn--minus:focus-visible,
+#modeMenu .control-btn--minus:active {
+  background-image: url("interface/button - active.png");
+}
+
+#modeMenu .control-btn--plus:hover,
+#modeMenu .control-btn--plus:focus-visible,
+#modeMenu .control-btn--plus:active {
+  background-image: url("interface/button + active.png");
+}
+
+#modeMenu .control-btn:hover {
+  transform: translateY(-3px);
+}
+
+#modeMenu .control-btn:focus-visible {
+  outline: 2px solid #ff0000c8;
+  outline-offset: 4px;
+  transform: translateY(-2px);
+}
+
+#modeMenu .control-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
 
 #amplitudeIndicator {
   position: relative;


### PR DESCRIPTION
## Summary
- replace the numeric control buttons with the new minus/plus interface art and keep them accessible
- restyle the additional settings checkboxes to use the tumbler artwork for on/off states
- add a reusable visually hidden helper class and hover/focus treatments for the updated controls

## Testing
- Manual testing: opened settings.html in a browser

------
https://chatgpt.com/codex/tasks/task_e_68f913da5310832daf5c44729b5cd1fc