### PR TITLE
Add coordinate inspector to test harness

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -35,8 +35,22 @@
             <div id="flightRangeDisplay" class="range-display">15</div>
           </div>
           <div class="control-buttons">
-            <button id="flightRangeMinus" class="control-btn">−</button>
-            <button id="flightRangePlus" class="control-btn">+</button>
+            <button
+              id="flightRangeMinus"
+              class="control-btn control-btn--minus"
+              type="button"
+              aria-label="Decrease flight range"
+            >
+              <span class="visually-hidden">Decrease flight range</span>
+            </button>
+            <button
+              id="flightRangePlus"
+              class="control-btn control-btn--plus"
+              type="button"
+              aria-label="Increase flight range"
+            >
+              <span class="visually-hidden">Increase flight range</span>
+            </button>
           </div>
         </div>
 
@@ -53,8 +67,22 @@
           </div>
           <div class="control-value"><span id="amplitudeAngleDisplay">40°</span></div>
           <div class="control-buttons">
-            <button id="amplitudeMinus" class="control-btn">−</button>
-            <button id="amplitudePlus" class="control-btn">+</button>
+            <button
+              id="amplitudeMinus"
+              class="control-btn control-btn--minus"
+              type="button"
+              aria-label="Decrease aiming amplitude"
+            >
+              <span class="visually-hidden">Decrease aiming amplitude</span>
+            </button>
+            <button
+              id="amplitudePlus"
+              class="control-btn control-btn--plus"
+              type="button"
+              aria-label="Increase aiming amplitude"
+            >
+              <span class="visually-hidden">Increase aiming amplitude</span>
+            </button>
           </div>
         </div>
       </div>
@@ -74,13 +102,21 @@
 
       <!-- Additional Settings -->
       <div class="control-box" id="additionalSettings">
-      <div class="control-label">Additional Settings</div>
-      <div class="aa-toggle">
-        <label><input type="checkbox" id="addAAToggle" /> Add Anti-Aircraft</label>
-      </div>
-      <div class="aa-toggle">
-        <label><input type="checkbox" id="sharpEdgesToggle" /> Sharp Edges</label>
-      </div>
+        <div class="control-label">Additional Settings</div>
+        <div class="aa-toggle">
+          <input type="checkbox" id="addAAToggle" class="toggle-input visually-hidden" />
+          <label for="addAAToggle" class="toggle-label">
+            <span class="toggle-visual" aria-hidden="true"></span>
+            <span class="toggle-text">Add Anti-Aircraft</span>
+          </label>
+        </div>
+        <div class="aa-toggle">
+          <input type="checkbox" id="sharpEdgesToggle" class="toggle-input visually-hidden" />
+          <label for="sharpEdgesToggle" class="toggle-label">
+            <span class="toggle-visual" aria-hidden="true"></span>
+            <span class="toggle-text">Sharp Edges</span>
+          </label>
+        </div>
       </div>
 
     </div>

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,19 @@ body, button {
   box-sizing: border-box;
 }
 
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Базовый шрифт/раскладка */
 
   body {
@@ -469,7 +482,49 @@ body, button {
 }
 
 #modeMenu #additionalSettings .aa-toggle {
-  margin: 5px 0;
+  margin: 8px 0;
+  display: flex;
+  justify-content: center;
+}
+
+#modeMenu #additionalSettings .toggle-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 16px;
+  color: #333;
+  cursor: pointer;
+  font-weight: 500;
+  padding: 6px 10px;
+  border-radius: 12px;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+#modeMenu #additionalSettings .toggle-visual {
+  width: 118px;
+  height: 86px;
+  background-image: url("interface/tumbler off.png");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  display: inline-block;
+  transition: transform 0.2s;
+}
+
+#modeMenu #additionalSettings .toggle-text {
+  text-transform: none;
+}
+
+#modeMenu #additionalSettings .toggle-label:hover .toggle-visual {
+  transform: translateY(-3px);
+}
+
+#modeMenu #additionalSettings .toggle-input:checked + .toggle-label .toggle-visual {
+  background-image: url("interface/tumbler on.png");
+}
+
+#modeMenu #additionalSettings .toggle-input:focus-visible + .toggle-label {
+  box-shadow: 0 0 0 3px rgba(255, 0, 0, 0.25);
 }
 
 #modeMenu .control-box > .control-label {
@@ -524,6 +579,7 @@ body, button {
   display: flex;
   gap: 10px;
   margin-top: 8px;
+  justify-content: center;
 }
 
 #modeMenu .control-box select {
@@ -652,14 +708,57 @@ body, button {
 }
 
 /* Control buttons */
-#modeMenu .control-buttons button {
-  width: 32px; height: 32px; font-size: 16px; color:#fff; border:none; border-radius:50%;
-  background: linear-gradient(145deg, #6c757d, #5a6268);
-  box-shadow: 0 3px 6px rgba(0,0,0,0.2);
-  cursor:pointer; transition: transform 0.2s, box-shadow 0.2s;
+#modeMenu .control-btn {
+  width: 72px;
+  height: 66px;
+  border: none;
+  padding: 0;
+  background-color: transparent;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  cursor: pointer;
+  transition: transform 0.2s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
-#modeMenu .control-buttons button:hover { transform: translateY(-3px); box-shadow: 0 6px 12px rgba(0,0,0,0.3); }
-#modeMenu .control-buttons button:disabled { background:#a1a1a1; cursor:not-allowed; }
+
+#modeMenu .control-btn--minus {
+  background-image: url("interface/button -.png");
+}
+
+#modeMenu .control-btn--plus {
+  background-image: url("interface/button +.png");
+}
+
+#modeMenu .control-btn--minus:hover,
+#modeMenu .control-btn--minus:focus-visible,
+#modeMenu .control-btn--minus:active {
+  background-image: url("interface/button - active.png");
+}
+
+#modeMenu .control-btn--plus:hover,
+#modeMenu .control-btn--plus:focus-visible,
+#modeMenu .control-btn--plus:active {
+  background-image: url("interface/button + active.png");
+}
+
+#modeMenu .control-btn:hover {
+  transform: translateY(-3px);
+}
+
+#modeMenu .control-btn:focus-visible {
+  outline: 2px solid #ff0000c8;
+  outline-offset: 4px;
+  transform: translateY(-2px);
+}
+
+#modeMenu .control-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
 
 #amplitudeIndicator {
   position: relative;

--- a/test-harness.html
+++ b/test-harness.html
@@ -211,6 +211,101 @@
       color: #8095d5;
     }
 
+    .inspector-overlay {
+      position: absolute;
+      inset: 0;
+      z-index: 500;
+      pointer-events: none;
+      font-family: 'Roboto', sans-serif;
+      display: none;
+    }
+
+    .inspector-overlay__svg {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+
+    .inspector-overlay__crosshair {
+      stroke: rgba(94, 154, 255, 0.65);
+      stroke-width: 1.5;
+      vector-effect: non-scaling-stroke;
+      display: none;
+    }
+
+    .inspector-overlay__ruler-line {
+      stroke: rgba(255, 204, 102, 0.9);
+      stroke-width: 2;
+      stroke-dasharray: 6 4;
+      vector-effect: non-scaling-stroke;
+      display: none;
+    }
+
+    .inspector-overlay__point {
+      fill: rgba(255, 204, 102, 0.95);
+      stroke: rgba(12, 18, 32, 0.85);
+      stroke-width: 1.6;
+      vector-effect: non-scaling-stroke;
+      display: none;
+    }
+
+    .inspector-overlay__tooltip {
+      position: absolute;
+      left: 0;
+      top: 0;
+      transform: translate(-9999px, -9999px);
+      pointer-events: none;
+      display: none;
+    }
+
+    .inspector-overlay__tooltip-content {
+      background: rgba(9, 15, 28, 0.88);
+      border: 1px solid rgba(129, 170, 255, 0.4);
+      border-radius: 10px;
+      box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4);
+      padding: 8px 10px;
+      color: #f5f7ff;
+      min-width: 180px;
+      max-width: 240px;
+    }
+
+    .inspector-overlay__row {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      font-size: 0.78rem;
+      line-height: 1.35;
+    }
+
+    .inspector-overlay__row + .inspector-overlay__row {
+      margin-top: 6px;
+    }
+
+    .inspector-overlay__row strong {
+      font-size: 0.7rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #9ab4ff;
+    }
+
+    .inspector-overlay__value {
+      white-space: pre-line;
+      font-size: 0.82rem;
+      font-weight: 500;
+      color: #f5f7ff;
+    }
+
+    .inspector-status {
+      grid-template-columns: minmax(0, 1fr);
+      gap: 6px;
+      margin-top: 12px;
+    }
+
+    .inspector-status dd {
+      white-space: normal;
+      word-break: break-word;
+    }
+
     @media (max-width: 1280px) {
       .harness-panel {
         width: 240px;
@@ -330,6 +425,31 @@
 
       <div id="mantisIndicator" class="turn-indicator" style="display:none;"></div>
       <div id="goatIndicator" class="turn-indicator" style="display:none;"></div>
+      <div id="harnessInspectorOverlay" class="inspector-overlay" aria-hidden="true">
+        <svg id="inspectorSvg" class="inspector-overlay__svg" viewBox="0 0 460 800" preserveAspectRatio="none">
+          <line id="inspectorCrosshairH" class="inspector-overlay__crosshair" x1="0" y1="0" x2="460" y2="0"></line>
+          <line id="inspectorCrosshairV" class="inspector-overlay__crosshair" x1="0" y1="0" x2="0" y2="800"></line>
+          <line id="inspectorRulerLine" class="inspector-overlay__ruler-line" x1="0" y1="0" x2="0" y2="0"></line>
+          <circle id="inspectorPointA" class="inspector-overlay__point" cx="0" cy="0" r="5"></circle>
+          <circle id="inspectorPointB" class="inspector-overlay__point" cx="0" cy="0" r="5"></circle>
+        </svg>
+        <div id="inspectorTooltip" class="inspector-overlay__tooltip" role="status" aria-live="polite">
+          <div id="inspectorTooltipContent" class="inspector-overlay__tooltip-content">
+            <div class="inspector-overlay__row">
+              <strong>Курсор</strong>
+              <span id="inspectorCursorText" class="inspector-overlay__value">—</span>
+            </div>
+            <div class="inspector-overlay__row">
+              <strong>Объект</strong>
+              <span id="inspectorTargetText" class="inspector-overlay__value">—</span>
+            </div>
+            <div class="inspector-overlay__row">
+              <strong>Линейка</strong>
+              <span id="inspectorRulerText" class="inspector-overlay__value">—</span>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div id="overlayContainer" aria-hidden="true">
@@ -364,6 +484,22 @@
 
   <aside class="harness-panel harness-panel--right" aria-label="Сценарии и эффекты">
     <h1>Сценарии</h1>
+
+    <div class="harness-section" aria-labelledby="inspectorTitle">
+      <h2 id="inspectorTitle">Инспектор поля</h2>
+      <div class="harness-button-group">
+        <button id="toggleInspectorBtn" class="full-width">Курсор: выкл.</button>
+        <button id="toggleRulerBtn" class="full-width" disabled>Линейка: выкл.</button>
+      </div>
+      <dl class="status-grid inspector-status">
+        <div><dt>Курсор</dt><dd id="inspectorCursorPanel">—</dd></div>
+        <div><dt>Объект</dt><dd id="inspectorTargetPanel">—</dd></div>
+        <div><dt>Точка A</dt><dd id="inspectorPointAPanel">—</dd></div>
+        <div><dt>Точка B</dt><dd id="inspectorPointBPanel">—</dd></div>
+        <div><dt>Расстояние</dt><dd id="inspectorDistancePanel">—</dd></div>
+      </dl>
+      <p class="harness-note">Активируйте курсор, чтобы видеть координаты и объект под указателем. Линейка фиксирует две точки и рассчитывает расстояние между ними.</p>
+    </div>
 
     <div class="harness-section" aria-labelledby="stateTitle">
       <h2 id="stateTitle">Состояние</h2>
@@ -441,6 +577,7 @@
       const planeDetails = document.getElementById('planeDetails');
       const explosionXInput = document.getElementById('explosionX');
       const explosionYInput = document.getElementById('explosionY');
+      const gameContainerEl = document.getElementById('gameContainer');
       const statusElements = {
         round: document.getElementById('statusRound'),
         phase: document.getElementById('statusPhase'),
@@ -452,8 +589,422 @@
         scoreBlue: document.getElementById('scoreBlue')
       };
 
+      const HARNESS_FIELD_WIDTH = 460;
+      const HARNESS_FIELD_HEIGHT = 800;
+
+      const inspectorElements = {
+        overlay: document.getElementById('harnessInspectorOverlay'),
+        tooltip: document.getElementById('inspectorTooltip'),
+        tooltipContent: document.getElementById('inspectorTooltipContent'),
+        cursorValue: document.getElementById('inspectorCursorText'),
+        targetValue: document.getElementById('inspectorTargetText'),
+        rulerValue: document.getElementById('inspectorRulerText'),
+        crosshairH: document.getElementById('inspectorCrosshairH'),
+        crosshairV: document.getElementById('inspectorCrosshairV'),
+        rulerLine: document.getElementById('inspectorRulerLine'),
+        pointA: document.getElementById('inspectorPointA'),
+        pointB: document.getElementById('inspectorPointB')
+      };
+
+      const inspectorPanelElements = {
+        cursor: document.getElementById('inspectorCursorPanel'),
+        target: document.getElementById('inspectorTargetPanel'),
+        pointA: document.getElementById('inspectorPointAPanel'),
+        pointB: document.getElementById('inspectorPointBPanel'),
+        distance: document.getElementById('inspectorDistancePanel')
+      };
+
+      const inspectorButtons = {
+        cursor: document.getElementById('toggleInspectorBtn'),
+        ruler: document.getElementById('toggleRulerBtn')
+      };
+
+      const inspectorState = {
+        active: false,
+        pointerInside: false,
+        rulerActive: false,
+        firstPoint: null,
+        secondPoint: null,
+        lastCursor: null,
+        lastTarget: null
+      };
+
+      function formatPoint(point){
+        if(!point) return '—';
+        const x = Number.isFinite(point.baseX) ? Math.round(point.baseX) : null;
+        const y = Number.isFinite(point.baseY) ? Math.round(point.baseY) : null;
+        if(x === null || y === null){
+          return '—';
+        }
+        return `${x}, ${y}`;
+      }
+
+      function formatDistanceValue(a, b){
+        if(!a || !b) return null;
+        const distance = Math.hypot(a.baseX - b.baseX, a.baseY - b.baseY);
+        if(!Number.isFinite(distance)) return null;
+        return distance >= 100 ? `${Math.round(distance)} px` : `${distance.toFixed(1)} px`;
+      }
+
+      function resetTooltipPosition(){
+        if(inspectorElements.tooltip){
+          inspectorElements.tooltip.style.transform = 'translate(-9999px, -9999px)';
+        }
+      }
+
+      function updateInspectorButtons(){
+        if(inspectorButtons.cursor){
+          inspectorButtons.cursor.textContent = inspectorState.active ? 'Курсор: вкл.' : 'Курсор: выкл.';
+        }
+        if(inspectorButtons.ruler){
+          inspectorButtons.ruler.textContent = inspectorState.rulerActive ? 'Линейка: вкл.' : 'Линейка: выкл.';
+          inspectorButtons.ruler.disabled = !inspectorState.active;
+        }
+      }
+
+      function updateOverlayVisibility(){
+        const overlay = inspectorElements.overlay;
+        if(!overlay) return;
+        const visible = inspectorState.active;
+        overlay.style.display = visible ? 'block' : 'none';
+        overlay.hidden = !visible;
+        overlay.setAttribute('aria-hidden', visible ? 'false' : 'true');
+      }
+
+      function updateCursorVisibility(show){
+        const display = show ? 'block' : 'none';
+        if(inspectorElements.crosshairH){
+          inspectorElements.crosshairH.style.display = display;
+        }
+        if(inspectorElements.crosshairV){
+          inspectorElements.crosshairV.style.display = display;
+        }
+        if(inspectorElements.tooltip){
+          inspectorElements.tooltip.style.display = show ? 'block' : 'none';
+          if(!show){
+            resetTooltipPosition();
+          }
+        }
+      }
+
+      function renderCrosshair(cursorData){
+        if(!cursorData) return;
+        if(inspectorElements.crosshairH){
+          inspectorElements.crosshairH.setAttribute('x1', '0');
+          inspectorElements.crosshairH.setAttribute('x2', String(HARNESS_FIELD_WIDTH));
+          inspectorElements.crosshairH.setAttribute('y1', String(cursorData.baseY));
+          inspectorElements.crosshairH.setAttribute('y2', String(cursorData.baseY));
+        }
+        if(inspectorElements.crosshairV){
+          inspectorElements.crosshairV.setAttribute('x1', String(cursorData.baseX));
+          inspectorElements.crosshairV.setAttribute('x2', String(cursorData.baseX));
+          inspectorElements.crosshairV.setAttribute('y1', '0');
+          inspectorElements.crosshairV.setAttribute('y2', String(HARNESS_FIELD_HEIGHT));
+        }
+      }
+
+      function updateTooltipContent(cursorData, targetInfo){
+        if(inspectorElements.cursorValue){
+          inspectorElements.cursorValue.textContent = cursorData ? formatPoint(cursorData) : '—';
+        }
+        if(inspectorElements.targetValue){
+          if(targetInfo){
+            const lines = [targetInfo.label];
+            if(targetInfo.coordsText){
+              lines.push(`@ ${targetInfo.coordsText}`);
+            }
+            if(targetInfo.sizeText){
+              lines.push(targetInfo.sizeText);
+            }
+            inspectorElements.targetValue.textContent = lines.join('\n');
+          } else {
+            inspectorElements.targetValue.textContent = '—';
+          }
+        }
+        if(inspectorElements.rulerValue){
+          if(inspectorState.rulerActive && inspectorState.firstPoint){
+            const parts = [`A: ${formatPoint(inspectorState.firstPoint)}`];
+            if(inspectorState.secondPoint){
+              parts.push(`B: ${formatPoint(inspectorState.secondPoint)}`);
+              const distance = formatDistanceValue(inspectorState.firstPoint, inspectorState.secondPoint);
+              if(distance){
+                parts.push(`Δ: ${distance}`);
+              }
+            } else {
+              parts.push('Выберите точку B');
+            }
+            inspectorElements.rulerValue.textContent = parts.join('\n');
+          } else if(inspectorState.rulerActive){
+            inspectorElements.rulerValue.textContent = 'ЛКМ — точка A';
+          } else {
+            inspectorElements.rulerValue.textContent = '—';
+          }
+        }
+      }
+
+      function updateTooltipPosition(cursorData, rect){
+        if(!cursorData || !rect) return;
+        const tooltip = inspectorElements.tooltip;
+        const content = inspectorElements.tooltipContent;
+        if(!tooltip || !content) return;
+        const width = content.offsetWidth || 0;
+        const height = content.offsetHeight || 0;
+        const offset = 12;
+        let x = cursorData.cssX + offset;
+        let y = cursorData.cssY + offset;
+        const maxX = Math.max(rect.width - width - 4, 0);
+        const maxY = Math.max(rect.height - height - 4, 0);
+        if(x > maxX){
+          x = maxX;
+        }
+        if(y > maxY){
+          y = maxY;
+        }
+        tooltip.style.transform = `translate(${Math.max(0, x)}px, ${Math.max(0, y)}px)`;
+      }
+
+      function updatePanelData(){
+        if(inspectorPanelElements.cursor){
+          inspectorPanelElements.cursor.textContent = inspectorState.active && inspectorState.lastCursor ? formatPoint(inspectorState.lastCursor) : '—';
+        }
+        if(inspectorPanelElements.target){
+          if(inspectorState.active && inspectorState.lastTarget){
+            const parts = [inspectorState.lastTarget.label];
+            if(inspectorState.lastTarget.coordsText){
+              parts.push(inspectorState.lastTarget.coordsText);
+            }
+            if(inspectorState.lastTarget.sizeText){
+              parts.push(inspectorState.lastTarget.sizeText);
+            }
+            inspectorPanelElements.target.textContent = parts.join(' · ');
+          } else {
+            inspectorPanelElements.target.textContent = '—';
+          }
+        }
+        const pointA = inspectorState.rulerActive ? inspectorState.firstPoint : null;
+        const pointB = inspectorState.rulerActive ? inspectorState.secondPoint : null;
+        if(inspectorPanelElements.pointA){
+          inspectorPanelElements.pointA.textContent = pointA ? formatPoint(pointA) : '—';
+        }
+        if(inspectorPanelElements.pointB){
+          inspectorPanelElements.pointB.textContent = pointB ? formatPoint(pointB) : '—';
+        }
+        if(inspectorPanelElements.distance){
+          const dist = pointA && pointB ? formatDistanceValue(pointA, pointB) : null;
+          inspectorPanelElements.distance.textContent = dist || '—';
+        }
+      }
+
+      function updateMeasurementOverlay(){
+        const showA = inspectorState.active && inspectorState.rulerActive && inspectorState.firstPoint;
+        if(inspectorElements.pointA){
+          inspectorElements.pointA.style.display = showA ? 'block' : 'none';
+          if(showA){
+            inspectorElements.pointA.setAttribute('cx', String(inspectorState.firstPoint.baseX));
+            inspectorElements.pointA.setAttribute('cy', String(inspectorState.firstPoint.baseY));
+          }
+        }
+        const showB = inspectorState.active && inspectorState.rulerActive && inspectorState.secondPoint;
+        if(inspectorElements.pointB){
+          inspectorElements.pointB.style.display = showB ? 'block' : 'none';
+          if(showB){
+            inspectorElements.pointB.setAttribute('cx', String(inspectorState.secondPoint.baseX));
+            inspectorElements.pointB.setAttribute('cy', String(inspectorState.secondPoint.baseY));
+          }
+        }
+        const showLine = inspectorState.active && inspectorState.rulerActive && inspectorState.firstPoint && inspectorState.secondPoint;
+        if(inspectorElements.rulerLine){
+          inspectorElements.rulerLine.style.display = showLine ? 'block' : 'none';
+          if(showLine){
+            inspectorElements.rulerLine.setAttribute('x1', String(inspectorState.firstPoint.baseX));
+            inspectorElements.rulerLine.setAttribute('y1', String(inspectorState.firstPoint.baseY));
+            inspectorElements.rulerLine.setAttribute('x2', String(inspectorState.secondPoint.baseX));
+            inspectorElements.rulerLine.setAttribute('y2', String(inspectorState.secondPoint.baseY));
+          }
+        }
+        updatePanelData();
+        updateTooltipContent(inspectorState.lastCursor, inspectorState.lastTarget);
+      }
+
+      function resetInspectorReadouts(){
+        inspectorState.lastCursor = null;
+        inspectorState.lastTarget = null;
+        resetTooltipPosition();
+        updateTooltipContent(null, null);
+      }
+
+      function setInspectorActive(active){
+        if(inspectorState.active === active) return;
+        inspectorState.active = active;
+        if(!active){
+          inspectorState.pointerInside = false;
+          inspectorState.rulerActive = false;
+          inspectorState.firstPoint = null;
+          inspectorState.secondPoint = null;
+          resetInspectorReadouts();
+        }
+        updateInspectorButtons();
+        updateOverlayVisibility();
+        updateCursorVisibility(active && inspectorState.pointerInside);
+        updateMeasurementOverlay();
+      }
+
+      function setRulerActive(active){
+        if(inspectorState.rulerActive === active) return;
+        inspectorState.rulerActive = active;
+        if(!active){
+          inspectorState.firstPoint = null;
+          inspectorState.secondPoint = null;
+        }
+        updateInspectorButtons();
+        updateMeasurementOverlay();
+      }
+
+      function pickInspectableNode(node, container){
+        let current = node;
+        while(current && current !== container){
+          if(current.dataset && current.dataset.inspectorIgnore === 'true'){
+            return null;
+          }
+          const hasLabel = current.getAttribute?.('data-inspector-name') || current.getAttribute?.('aria-label') || current.id || (current.classList && current.classList.length);
+          if(hasLabel){
+            break;
+          }
+          current = current.parentElement;
+        }
+        if(!current || current === document.body){
+          return container;
+        }
+        return current;
+      }
+
+      function buildElementLabel(element){
+        if(!element) return '—';
+        const explicit = element.getAttribute?.('data-inspector-name');
+        if(explicit) return explicit;
+        const aria = element.getAttribute?.('aria-label');
+        if(aria) return aria;
+        if(element.id) return `#${element.id}`;
+        if(element.classList && element.classList.length){
+          return `${element.tagName.toLowerCase()}.${Array.from(element.classList).join('.')}`;
+        }
+        return element.tagName ? element.tagName.toLowerCase() : 'элемент';
+      }
+
+      function describeTargetAt(clientX, clientY, containerRect){
+        if(!gameContainerEl || !containerRect || containerRect.width <= 0 || containerRect.height <= 0) return null;
+        const elements = typeof document.elementsFromPoint === 'function' ? document.elementsFromPoint(clientX, clientY) : [];
+        const fallback = elements && elements.length ? elements : [document.elementFromPoint(clientX, clientY)].filter(Boolean);
+        let target = null;
+        for(const el of fallback){
+          if(!el) continue;
+          if(el === inspectorElements.overlay || el.closest?.('#harnessInspectorOverlay')) continue;
+          if(gameContainerEl.contains(el)){
+            target = el;
+            break;
+          }
+        }
+        if(!target) return null;
+        const inspected = pickInspectableNode(target, gameContainerEl);
+        if(!inspected) return null;
+        const rect = inspected.getBoundingClientRect();
+        if(!rect) return null;
+        const relativeLeft = rect.left - containerRect.left;
+        const relativeTop = rect.top - containerRect.top;
+        const baseLeft = clamp(Math.round((relativeLeft / containerRect.width) * HARNESS_FIELD_WIDTH), 0, HARNESS_FIELD_WIDTH);
+        const baseTop = clamp(Math.round((relativeTop / containerRect.height) * HARNESS_FIELD_HEIGHT), 0, HARNESS_FIELD_HEIGHT);
+        const baseWidth = Math.max(0, Math.round((rect.width / containerRect.width) * HARNESS_FIELD_WIDTH));
+        const baseHeight = Math.max(0, Math.round((rect.height / containerRect.height) * HARNESS_FIELD_HEIGHT));
+        return {
+          element: inspected,
+          label: buildElementLabel(inspected),
+          coordsText: `${baseLeft}, ${baseTop}`,
+          sizeText: `${baseWidth}×${baseHeight}`
+        };
+      }
+
+      function handlePointerMove(event){
+        if(!inspectorState.active || !gameContainerEl) return;
+        const rect = gameContainerEl.getBoundingClientRect();
+        const width = rect.width;
+        const height = rect.height;
+        if(width <= 0 || height <= 0) return;
+        const cssX = event.clientX - rect.left;
+        const cssY = event.clientY - rect.top;
+        const inside = cssX >= 0 && cssY >= 0 && cssX <= width && cssY <= height;
+        inspectorState.pointerInside = inside;
+        updateCursorVisibility(inside);
+        if(!inside){
+          resetInspectorReadouts();
+          updatePanelData();
+          return;
+        }
+        const baseX = clamp(Math.round((cssX / width) * HARNESS_FIELD_WIDTH), 0, HARNESS_FIELD_WIDTH);
+        const baseY = clamp(Math.round((cssY / height) * HARNESS_FIELD_HEIGHT), 0, HARNESS_FIELD_HEIGHT);
+        const cursorData = { baseX, baseY, cssX, cssY };
+        inspectorState.lastCursor = cursorData;
+        const targetInfo = describeTargetAt(event.clientX, event.clientY, rect);
+        inspectorState.lastTarget = targetInfo;
+        renderCrosshair(cursorData);
+        updateTooltipContent(cursorData, targetInfo);
+        updateTooltipPosition(cursorData, rect);
+        updatePanelData();
+      }
+
+      function handlePointerLeave(){
+        if(!inspectorState.active) return;
+        inspectorState.pointerInside = false;
+        resetInspectorReadouts();
+        updateCursorVisibility(false);
+        updatePanelData();
+      }
+
+      function handlePointerDown(event){
+        if(!inspectorState.active || !inspectorState.rulerActive || !gameContainerEl) return;
+        if(event.button !== 0) return;
+        const rect = gameContainerEl.getBoundingClientRect();
+        const width = rect.width;
+        const height = rect.height;
+        if(width <= 0 || height <= 0) return;
+        const cssX = event.clientX - rect.left;
+        const cssY = event.clientY - rect.top;
+        if(cssX < 0 || cssY < 0 || cssX > width || cssY > height) return;
+        const baseX = clamp(Math.round((cssX / width) * HARNESS_FIELD_WIDTH), 0, HARNESS_FIELD_WIDTH);
+        const baseY = clamp(Math.round((cssY / height) * HARNESS_FIELD_HEIGHT), 0, HARNESS_FIELD_HEIGHT);
+        const point = { baseX, baseY };
+        if(!inspectorState.firstPoint || inspectorState.secondPoint){
+          inspectorState.firstPoint = point;
+          inspectorState.secondPoint = null;
+        } else {
+          inspectorState.secondPoint = point;
+        }
+        updateMeasurementOverlay();
+      }
+
+      inspectorButtons.cursor?.addEventListener('click', () => {
+        setInspectorActive(!inspectorState.active);
+      });
+
+      inspectorButtons.ruler?.addEventListener('click', () => {
+        const enable = !inspectorState.rulerActive;
+        if(enable && !inspectorState.active){
+          setInspectorActive(true);
+        }
+        setRulerActive(enable);
+      });
+
+      gameContainerEl?.addEventListener('pointermove', handlePointerMove);
+      gameContainerEl?.addEventListener('pointerleave', handlePointerLeave);
+      gameContainerEl?.addEventListener('pointerdown', handlePointerDown);
+
+      updateInspectorButtons();
+      updateOverlayVisibility();
+      updateCursorVisibility(false);
+      resetInspectorReadouts();
+      updateMeasurementOverlay();
+
       function adjustHarnessLayout(){
-        const game = document.getElementById('gameContainer');
+        const game = gameContainerEl;
         if(!game) return;
         const leftPanel = document.querySelector('.harness-panel--left');
         const rightPanel = document.querySelector('.harness-panel--right');


### PR DESCRIPTION
## Summary
- add a coordinate inspector overlay with a movable tooltip and crosshair tied to the 460×800 playfield
- expose ruler controls and readouts in the right-hand panel to capture two clicks and show their distance in pixels
- surface metadata about the element under the cursor, including its name, position, and size, in both the tooltip and side panel

## Testing
- Manual testing: not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f913da5310832daf5c44729b5cd1fc