### PR TITLE
Bypass strict commit-meta guard when starting AI planner and add diagnostic logging

### DIFF
--- a/script.js
+++ b/script.js
@@ -13874,9 +13874,9 @@ function tryStartAiPlanningFromCommittedState(trigger = "unspecified"){
     && !lastPlayerMoveCommitMeta.finished
     && lastPlayerMoveCommitMeta.turnCommitSequence < turnCommitSequence
   );
-  if(!playerMoveCommitFinishedBeforePlannerStart && !initialAiTurnWithoutPlayerCommit && !staleCommitMetaRecovered){
-    return false;
-  }
+  const commitMetaMismatch = !playerMoveCommitFinishedBeforePlannerStart
+    && !initialAiTurnWithoutPlayerCommit
+    && !staleCommitMetaRecovered;
   if(staleCommitMetaRecovered){
     logAiDecision("ai_planner_recovered_from_stale_player_commit_meta", {
       trigger,
@@ -13888,6 +13888,23 @@ function tryStartAiPlanningFromCommittedState(trigger = "unspecified"){
         finished: Boolean(lastPlayerMoveCommitMeta.finished),
       },
       reasonCode: "stale_player_commit_meta",
+      ...getAiTurnTimingSnapshot(),
+    });
+  }
+  if(commitMetaMismatch){
+    // Жёсткая привязка к метаданным коммита может зациклить ход ИИ:
+    // матч уже на синем ходе, а planner молча не стартует из-за расхождения служебных метаданных.
+    // В такой ситуации безопаснее запустить планировщик и зафиксировать обход.
+    logAiDecision("ai_planner_commit_guard_bypassed", {
+      trigger,
+      turnNumber: turnAdvanceCount,
+      turnCommitSequence,
+      lastPlayerMoveCommitMeta: {
+        turnCommitSequence: lastPlayerMoveCommitMeta.turnCommitSequence,
+        turnNumber: lastPlayerMoveCommitMeta.turnNumber,
+        finished: Boolean(lastPlayerMoveCommitMeta.finished),
+      },
+      reasonCode: "commit_meta_mismatch_bypassed",
       ...getAiTurnTimingSnapshot(),
     });
   }


### PR DESCRIPTION
### Motivation
- Prevent the AI planner from silently refusing to start when player commit metadata slightly diverges, which can stall the AI's turn. 
- Provide diagnostic information when such mismatches occur so the behavior can be traced and debugged.

### Description
- Replace the strict early-return condition with a computed `commitMetaMismatch` flag so the planner can proceed when metadata mismatches would otherwise block it. 
- Add a detailed diagnostic log `ai_planner_commit_guard_bypassed` including `turnNumber`, `turnCommitSequence`, `lastPlayerMoveCommitMeta` and a `reasonCode` when the guard is bypassed. 
- Preserve existing `staleCommitMetaRecovered` handling and its `ai_planner_recovered_from_stale_player_commit_meta` logging, and keep planner startup behavior unchanged after the new logging.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3c8600954832dbdacb5e399ad8aa5)