### PR TITLE
Обновить баннер раунда: текст победы и типографика

### DIFF
--- a/script.js
+++ b/script.js
@@ -991,7 +991,7 @@ function ensureTransferFrameElements() {
 
 function buildTransferWinnerText(player) {
   const winnerName = player === "green" ? "GREEN" : "BLUE";
-  return `${winnerName} WINS`;
+  return `${winnerName} WINS THE ROUND`;
 }
 
 function buildTransferTurnTexts(player, roundValue) {

--- a/styles.css
+++ b/styles.css
@@ -549,11 +549,13 @@ body, button {
     --transfer-content-x: 8;
     --transfer-content-y: 7;
     --transfer-content-width: 221;
-    --transfer-content-height: 94;
+    --transfer-content-height: 87;
     --transfer-zone-turn-top-y: 0;
     --transfer-zone-turn-top-height: 24;
     --transfer-zone-main-y: 28;
     --transfer-zone-main-height: 59;
+    --transfer-zone-win-y: 0;
+    --transfer-zone-win-height: 87;
     position: relative;
     width: min(86%, 330px);
     aspect-ratio: calc(1053 / 452);
@@ -611,8 +613,9 @@ body, button {
     height: calc((var(--transfer-zone-turn-top-height) / var(--transfer-frame-height)) * 100%);
     font-size: clamp(13px, 1.35vw, 14px);
     font-weight: 600;
+    font-family: "Cinzel", "Palatino Linotype", "Book Antiqua", Georgia, serif;
     color: #f2e4c9;
-    letter-spacing: 0.8px;
+    letter-spacing: 1px;
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.55);
     -webkit-text-stroke: 0;
   }
@@ -628,9 +631,9 @@ body, button {
   }
 
   .transfer-frame-text--win {
-    top: calc(((var(--transfer-content-y) + var(--transfer-zone-main-y)) / var(--transfer-frame-height)) * 100%);
-    height: calc((var(--transfer-zone-main-height) / var(--transfer-frame-height)) * 100%);
-    font-size: clamp(32px, 3.2vw, 39px);
+    top: calc(((var(--transfer-content-y) + var(--transfer-zone-win-y)) / var(--transfer-frame-height)) * 100%);
+    height: calc((var(--transfer-zone-win-height) / var(--transfer-frame-height)) * 100%);
+    font-size: clamp(27px, 2.9vw, 35px);
     font-weight: 700;
     color: #e8d6b0;
     letter-spacing: 1.2px;


### PR DESCRIPTION
### Motivation
- Исправить неверную семантику и позиционирование текста баннера раунда, чтобы сообщение о победе явно означало победу в раунде и располагалось по центру целевой зоны как в макете Figma.
- Устранить шрифтовой диссонанс верхней строки (`ROUND N`) и снизить риск обрезания более длинной фразы победы на экранах разных масштабов.

### Description
- Заменён копирайт победного сообщения в `script.js`: `GREEN/BLUE WINS` → `GREEN/BLUE WINS THE ROUND` для однозначности контекста раунда.
- В `styles.css` уменьшена внутренняя высота контента и добавлены токены зоны для победной надписи (`--transfer-zone-win-y` / `--transfer-zone-win-height`) чтобы привязать `win` к отдельной полной зоне 87px.
- Перепозиционирован селектор `.transfer-frame-text--win` на использование новой зоны и уменьшен максимальный размер шрифта (`clamp`) для устойчивого вмещения более длинной фразы.
- Подправлена типографика верхней строки: явно задано семейство шрифтов и увеличено `letter-spacing` для `.transfer-frame-text--turn-top`, чтобы убрать визуальный «шрифтовый косяк». (Файлы: `script.js`, `styles.css`)

### Testing
- Выполнена синтаксическая проверка JavaScript: `node --check script.js` — успешно.
- Локальные автоматические визуальные тесты не запускались в этой среде, поэтому визуальная валидация (скриншоты при 100%/125% UI) требуется отдельно в браузере и отмечена в задаче как ручная проверка.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9399cf0d4832d9a1471d6bf57d32c)