### PR TITLE
Fix AI fail-safe move normalization and retry deadlock handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -17918,6 +17918,75 @@ function isAiFallbackRetryBudgetExhausted(){
   return state.exhausted === true || state.retriesUsed >= state.limit;
 }
 
+function isFailSafeSpecialRouteCandidate(move){
+  const routeClass = `${move?.routeClass || ""}`.trim().toLowerCase();
+  return routeClass === "gap" || routeClass === "ricochet";
+}
+
+function normalizeFailSafeLaunchCandidate(move, defaults = {}){
+  if(!move || typeof move !== "object"){
+    return null;
+  }
+  const plane = move?.plane || defaults?.plane || null;
+  if(!plane || typeof plane !== "object"){
+    return null;
+  }
+
+  const vx = Number(move?.vx);
+  const vy = Number(move?.vy);
+  if(!Number.isFinite(vx) || !Number.isFinite(vy)){
+    return null;
+  }
+
+  const flightDurationSec = Number.isFinite(FIELD_FLIGHT_DURATION_SEC) && FIELD_FLIGHT_DURATION_SEC > 0
+    ? FIELD_FLIGHT_DURATION_SEC
+    : 1;
+  const totalDistRaw = Number(move?.totalDist);
+  const totalDist = Number.isFinite(totalDistRaw) && totalDistRaw > 0
+    ? totalDistRaw
+    : Math.hypot(vx, vy) * flightDurationSec;
+
+  const goalName = defaults?.goalName || move?.goalName || aiRoundState?.currentGoal || "v2_safe_turn_resolution";
+  const decisionReason = defaults?.decisionReason || move?.decisionReason || "fail_safe_candidate";
+  const routeClass = `${defaults?.routeClass || move?.routeClass || "direct"}`.trim().toLowerCase() || "direct";
+  const targetEnemy = defaults?.targetEnemy || move?.targetEnemy || move?.enemy || defaults?.enemy || null;
+
+  const profile = (typeof getAiFlightRangeProfile === "function")
+    ? getAiFlightRangeProfile(plane)
+    : null;
+  const effectiveFlightRangeCells = Number.isFinite(move?.effectiveFlightRangeCells)
+    ? move.effectiveFlightRangeCells
+    : (Number.isFinite(profile?.effectiveFlightRangeCells) ? profile.effectiveFlightRangeCells : null);
+  const effectiveFlightDistancePx = Number.isFinite(move?.effectiveFlightDistancePx)
+    ? move.effectiveFlightDistancePx
+    : (Number.isFinite(profile?.flightDistancePx) ? Number(profile.flightDistancePx.toFixed(1)) : null);
+  const score = Number.isFinite(move?.score)
+    ? move.score
+    : (typeof getAiPlaneAdjustedScore === "function" ? getAiPlaneAdjustedScore(totalDist, plane) : totalDist);
+  const idleTurns = Number.isFinite(move?.idleTurns)
+    ? move.idleTurns
+    : (typeof getAiPlaneIdleTurns === "function" ? getAiPlaneIdleTurns(plane) : 0);
+
+  return {
+    ...move,
+    plane,
+    enemy: targetEnemy,
+    targetEnemy,
+    vx,
+    vy,
+    totalDist,
+    goalName,
+    decisionReason,
+    routeClass,
+    effectiveFlightRangeCells,
+    effectiveFlightDistancePx,
+    score,
+    idleTurns,
+    isFallbackMove: true,
+    failSafeRouteCandidate: isFailSafeSpecialRouteCandidate({ routeClass }),
+  };
+}
+
 function ensureFinalMineGateDeadlockBudgetScope(){
   if(!aiRoundState || typeof aiRoundState !== "object"){
     return {
@@ -38034,11 +38103,71 @@ function failSafeAdvanceTurn(reason = "unspecified", details = {}){
       && flyingPoints.length === 0
     );
     if(canRetrySameTurn){
+      const retryUsage = incrementAiFallbackRetryUsage(reason, {
+        goal: details?.goal || aiRoundState?.currentGoal || null,
+        routeClass: details?.routeClass || null,
+      });
+      const retryBudgetExhausted = isAiFallbackRetryBudgetExhausted();
+      if(retryBudgetExhausted){
+        logAiDecision("fallback_retry_budget_exhausted", {
+          reason,
+          reasonCode: "fallback_retry_budget_exhausted",
+          goal: details?.goal || aiRoundState?.currentGoal || null,
+          retriesUsed: retryUsage.retriesUsed,
+          retryLimit: retryUsage.retryLimit,
+          source: details?.source || "failSafeAdvanceTurn",
+        });
+        recordAiSelfAnalyzerDecision("fallback_retry_budget_exhausted", {
+          goal: details?.goal || aiRoundState?.currentGoal || null,
+          reasonCodes: ["fallback_retry_budget_exhausted", "fail_safe_turn_advance"],
+          rejectReasons: Array.isArray(details?.rejectReasons) ? details.rejectReasons : [reason],
+          planeId: details?.planeId ?? null,
+        });
+        const forcedLaunchMove = getMandatoryTurnMove({
+          aiPlanes: rankAiPlanesForCurrentTurn(points.filter((plane) => (
+            plane?.color === "blue"
+            && plane?.isAlive === true
+            && plane?.burning !== true
+            && !flyingPoints.some((fp) => fp.plane === plane)
+          ))),
+          enemies: points.filter((plane) => (
+            plane?.color === "green"
+            && plane?.isAlive === true
+            && plane?.burning !== true
+          )),
+        });
+        const forcedValidation = validateAiLaunchMoveCandidate(forcedLaunchMove);
+        if(forcedValidation.ok){
+          const forcedLaunchResult = issueAIMove(
+            forcedLaunchMove.plane,
+            forcedLaunchMove.vx,
+            forcedLaunchMove.vy,
+            {
+              isFallbackMove: true,
+              source: "fallback_retry_budget_exhausted",
+              reasonCode: "fallback_retry_budget_exhausted",
+              routeClass: forcedLaunchMove?.routeClass || "direct",
+            },
+          );
+          if(forcedLaunchResult?.ok){
+            logAiDecision("fail_safe_forced_launch_selected", {
+              reasonCode: "fail_safe_forced_launch_selected",
+              reason,
+              goal: details?.goal || aiRoundState?.currentGoal || null,
+              planeId: forcedLaunchMove?.plane?.id ?? null,
+              routeClass: forcedLaunchMove?.routeClass || "direct",
+            });
+            return true;
+          }
+        }
+      }
       aiMoveScheduled = true;
       logAiDecision("fail_safe_turn_retry_scheduled", {
         reason,
         reasonCode: details?.reasonCode || reason || "fail_safe_turn_retry_scheduled",
         goal: details?.goal || aiRoundState?.currentGoal || null,
+        retriesUsed: retryUsage?.retriesUsed ?? null,
+        retryLimit: retryUsage?.retryLimit ?? null,
         source: details?.source || "failSafeAdvanceTurn",
       });
       scheduleComputerMoveWithCargoGate(performance.now(), 90, {


### PR DESCRIPTION
### Motivation
- Исправить падение ИИ в fail-safe пути: вызовы обработки аварийных кандидатов существовали, а сами helper-функции были удалены, что приводило к ReferenceError и зацикливанию поведения.
- Убедиться, что при многократных неудачных попытках не происходит бесконечного retry-loop и ИИ всегда предпринимает любую возможную попытку хода (принудительный запуск), ведь пропуск хода недопустим.

### Description
- Восстановлены и добавлены helper-функции `normalizeFailSafeLaunchCandidate` и `isFailSafeSpecialRouteCandidate` в `script.js`, которые проверяют `plane/vx/vy`, вычисляют `totalDist` и заполняют метаданные кандидата (goalName, decisionReason, routeClass, score, idleTurns и т.д.).
- Упрощена логика `isFallbackMove` (ставится в `true` в нормализованном кандидате) и добавлено поле `failSafeRouteCandidate` для пометки специальных маршрутов (`gap`/`ricochet`).
- Интегрирован retry‑бюджет в `failSafeAdvanceTurn`: при повторном срабатывании увеличивается счётчик (`incrementAiFallbackRetryUsage`), логируется исчерпание бюджета (`fallback_retry_budget_exhausted`) и при исчерпании выполняется попытка принудительного запуска через `getMandatoryTurnMove` + `issueAIMove` с логом `fail_safe_forced_launch_selected`.
- При отсутствии возможности принудительного запуска поведение остаётся прежним: планируется повтор (retry) в пределах бюджета, или фиксируется невозможность повтора и возвращается отказ.

### Testing
- Запуск простого проверки наличия функций в `script.js` (`node - <<'NODE' ...`), подтверждающей что `normalizeFailSafeLaunchCandidate` и `isFailSafeSpecialRouteCandidate` объявлены — тест прошёл успешно.
- `node scripts/smoke-ai-fallback-retry-budget.js` завершился ошибкой в тестовом окружении из-за отсутствия в vm-контексте теста переменной/флага `failSafeAdvanceTurnInProgress`, поэтому smoke-тест не прошёл в стенде, но ошибка относится к harness-изоляции, а не к внесённой логике.
- `node scripts/smoke-ai-no-move-failsafe.js` упал в текущем запуске из-за отсутствующих зависимостей в vm-контексте (например, `isPlaneLaunchStateReady`), поэтому интеграционные smoke-тесты в изолированном окружении не завершились успешно.
- Рекомендация: прогнать полноценные smoke/интеграционные тесты в реальном окружении (браузер/интеграционный vm), где доступны все глобальные функции и состояния, чтобы подтвердить поведение fail-safe и принудительных запусков на реальные игровые сценарии.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9eef4ce30832db678e6cf922b0716)