### PR TITLE
Fix transfer winner text to render on two lines

### DIFF
--- a/script.js
+++ b/script.js
@@ -991,7 +991,7 @@ function ensureTransferFrameElements() {
 
 function buildTransferWinnerText(player) {
   const winnerName = player === "green" ? "GREEN" : "BLUE";
-  return `${winnerName} WINS THE ROUND`;
+  return `${winnerName} WINS\nTHE ROUND`;
 }
 
 function buildTransferTurnTexts(player, roundValue) {

--- a/styles.css
+++ b/styles.css
@@ -639,6 +639,8 @@ body, button {
     letter-spacing: 1.2px;
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.65);
     -webkit-text-stroke: 0;
+    white-space: pre-line;
+    line-height: 1.05;
   }
 
   body.inventory-pointer-hidden,


### PR DESCRIPTION
### Motivation
- The winner banner copy could overflow the fixed Figma text container when rendered on a single long line, so the banner must render as two strict lines to match the design and avoid visual clipping.

### Description
- Insert an explicit line break into the generated winner string in `buildTransferWinnerText` so it becomes `"GREEN WINS\nTHE ROUND"` (or `BLUE`), and update `.transfer-frame-text--win` in `styles.css` to `white-space: pre-line;` and `line-height: 1.05` so the browser respects the break and keeps both lines inside the existing container (files changed: `script.js`, `styles.css`).

### Testing
- Ran a syntax check with `node --check script.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9f07175b8832d8b85dfee2ea96ab5)