### PR TITLE
Stop fail-safe retries after exhausted forced-launch failure

### DIFF
--- a/script.js
+++ b/script.js
@@ -38160,6 +38160,16 @@ function failSafeAdvanceTurn(reason = "unspecified", details = {}){
             return true;
           }
         }
+        logAiDecision("fail_safe_retry_exhausted_forced_launch_failed", {
+          reason,
+          reasonCode: "fail_safe_retry_exhausted_forced_launch_failed",
+          goal: details?.goal || aiRoundState?.currentGoal || null,
+          retriesUsed: retryUsage.retriesUsed,
+          retryLimit: retryUsage.retryLimit,
+          forcedValidationOk: forcedValidation.ok === true,
+          source: details?.source || "failSafeAdvanceTurn",
+        });
+        return false;
       }
       aiMoveScheduled = true;
       logAiDecision("fail_safe_turn_retry_scheduled", {


### PR DESCRIPTION
### Motivation
- Avoid unintended retry scheduling when the AI fallback retry budget is exhausted and a forced launch attempt also fails, making the fail-safe path deterministic and preventing potential infinite retry loops.

### Description
- In `failSafeAdvanceTurn` (exhausted branch) added a diagnostic decision log `fail_safe_retry_exhausted_forced_launch_failed` and an immediate `return false` when a forced launch does not succeed.
- This prevents fallthrough into the code that sets `aiMoveScheduled = true` and calls `scheduleComputerMoveWithCargoGate(...)` for the same turn.
- Changed file: `script.js` (update around the `fallback_retry_budget_exhausted` handling).

### Testing
- Ran `node --check script.js` with no errors.
- Verified changes were staged and committed (`git status` / `git commit`) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9fa2cbcf8832d86e84b4b6af78145)