### PR TITLE
Validate AI launch start after inventory usage and trigger fail-safe on unconfirmed launches

### DIFF
--- a/script.js
+++ b/script.js
@@ -26022,6 +26022,33 @@ function issueAIMoveWithInventoryUsage(context, plannedMove){
     );
   }
 
+  function handleFinalLaunchResult(stageLabel, launchResult){
+    const launchSucceeded = launchResult?.ok === true;
+    if(launchSucceeded) return true;
+
+    const planeId = plannedMove?.plane?.id ?? null;
+    const goal = plannedMove?.goalName || aiRoundState?.currentGoal || null;
+    const reasonCode = "final_launch_start_not_confirmed";
+    const launchReason = launchResult?.reason || null;
+    logAiDecision("ai_final_launch_start_failed", {
+      stage: stageLabel,
+      planeId,
+      goal,
+      reasonCode,
+      launchReason,
+    });
+
+    failSafeHandler("final_launch_start_not_confirmed", {
+      goal: goal || "final_launch_start_not_confirmed",
+      planeId,
+      reasonCodes: [reasonCode, "fail_safe_turn_advance"],
+      rejectReasons: [launchReason || "launch_result_missing_success_confirmation"],
+      errorMessage: launchResult?.message || null,
+      launchResultReason: launchReason,
+    });
+    return false;
+  }
+
   if(plannedMove?.aiFuelTacticalDecision){
     logAiDecision("fuel_tactical_plan_final", {
       stage: "launch_vector_post_processing",
@@ -26357,13 +26384,15 @@ function issueAIMoveWithInventoryUsage(context, plannedMove){
         });
       }
       registerFinalInventoryUsage(effectiveItemUsed);
-      issueMoveAfterFinalMineGate("post_inventory_delay_launch");
+      const delayedLaunchResult = issueMoveAfterFinalMineGate("post_inventory_delay_launch");
+      handleFinalLaunchResult("post_inventory_delay_launch", delayedLaunchResult);
     }, AI_POST_INVENTORY_LAUNCH_DELAY_MS);
     return;
   }
 
   registerFinalInventoryUsage(effectiveItemUsed);
-  issueMoveAfterFinalMineGate("immediate_launch");
+  const immediateLaunchResult = issueMoveAfterFinalMineGate("immediate_launch");
+  handleFinalLaunchResult("immediate_launch", immediateLaunchResult);
 }
 
 function markAiLinearLaunchEvent(event, payload = {}){


### PR DESCRIPTION
### Motivation
- Inventory usage previously led to two places where a launch was triggered without robustly verifying the launch was actually started, which could leave a turn unresolved or “hung”.
- The change ensures any unconfirmed or failed launch is diagnosed and routed into the deterministic fail-safe path so the AI turn cannot silently continue without resolution.

### Description
- Capture and check the return value from both `issueMoveAfterFinalMineGate(...)` call sites (delayed `setTimeout` launch and immediate launch) instead of ignoring the result. 
- Add a helper `handleFinalLaunchResult(stageLabel, launchResult)` that treats `launchResult?.ok === true` as success and otherwise logs a dedicated diagnostic `logAiDecision("ai_final_launch_start_failed", ...)` containing `planeId`, `goal`, `reasonCode`, and the launch result `reason`.
- On failure the helper calls the existing `failSafeHandler(...)` with contextual `reasonCodes`, `rejectReasons` and `errorMessage` so the existing deterministic fail-safe path is used to advance the turn.
- File modified: `script.js` (added `handleFinalLaunchResult` and integrated checks at both `issueMoveAfterFinalMineGate` call sites).

### Testing
- Syntax check: `node --check script.js` — succeeded.
- Basic repository operations: `git status --short` and commit of `script.js` — changes staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9fb81e9b0832dbde2cf8a80096b7b)