### PR TITLE
Add REALWIN debug command to trigger full round transition

### DIFF
--- a/script.js
+++ b/script.js
@@ -5008,6 +5008,16 @@ if(typeof window !== "undefined"){
       roundTextTimer = snapshot.roundTextTimer;
     }, lifeMs);
   };
+  window.REALWIN = () => {
+    if(isGameOver) return;
+    const winner = Math.random() < 0.5 ? "blue" : "green";
+    const canContinueSeries = isArcadeInfiniteScoreMode()
+      || (blueScore < POINTS_TO_WIN && greenScore < POINTS_TO_WIN);
+    const options = canContinueSeries
+      ? { roundTransitionDelay: MIN_ROUND_TRANSITION_DELAY_MS }
+      : { showEndScreen: true };
+    lockInWinner(winner, options);
+  };
   window.RNDMSG = () => {
     const lifeMs = Number.isFinite(Number(window.MSG_MS)) && Number(window.MSG_MS) > 0
       ? Number(window.MSG_MS)


### PR DESCRIPTION
### Motivation
- Provide a single debug command to exercise the real round-victory flow (winner banner followed by the actual round transition or end-match screen) instead of using separate visual-only helpers `WINMSG()` and `RNDMSG()`.

### Description
- Add a global `REALWIN()` in `script.js` that picks a random winner and calls `lockInWinner(winner, options)` using `roundTransitionDelay` when the series can continue or `showEndScreen: true` when the match should end.

### Testing
- Ran `node --check script.js` to validate the modified file syntax (passed).
- Confirmed the new symbol with `rg -n "REALWIN" script.js` (found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da137a7570832db20fdf68f5af40a1)