### PR TITLE
Склейка дубликатов AI-запусков и защита от неизвестных этапов

### DIFF
--- a/script.js
+++ b/script.js
@@ -37687,6 +37687,8 @@ function buildAiLaunchSession(plane, vx, vy, options = {}){
     lastTickAt: now,
     maxLifetimeMs: AI_LAUNCH_SESSION_MAX_LIFETIME_MS,
     turnStartedAt: Number.isFinite(aiTurnTimingState.turnStartedAt) ? aiTurnTimingState.turnStartedAt : now,
+    turnNumber: Number.isFinite(aiRoundState?.turnNumber) ? aiRoundState.turnNumber : turnAdvanceCount,
+    turnCommitSequence: Number.isFinite(turnCommitSequence) ? turnCommitSequence : 0,
     visiblePreparationStartedAt: Number.isFinite(aiTurnTimingState.visiblePreparationStartedAt) ? aiTurnTimingState.visiblePreparationStartedAt : now,
     minReleaseAt,
     stage: telemetryEnabled && targetSelectionDurationMs > 0 ? "targeting" : "pull",
@@ -37867,6 +37869,21 @@ function runAiLaunchSessionTick(now = performance.now()){
     return;
   }
 
+  const knownStage = session.stage === "targeting"
+    || session.stage === "pull"
+    || session.stage === "oscillate";
+  if(!knownStage){
+    resolveAiLaunchSessionAnomaly(session, {
+      kind: "unknown_launch_stage",
+      reasonCode: "unknown_launch_stage",
+      frameGapMs,
+      sessionAgeMs,
+      now,
+      releaseReason: "unknown_stage_emergency_release",
+    });
+    return;
+  }
+
   if(session.stage === "targeting"){
     if(now < (session.targetSelectionEndsAt || 0)){
       aimSession.baseX = session.plane.x;
@@ -37928,10 +37945,38 @@ function runAiLaunchSessionTick(now = performance.now()){
 
 function issueAIMove(plane, vx, vy, options = {}){
   if(aiLaunchSession){
+    const requestedTurnNumber = Number.isFinite(aiRoundState?.turnNumber) ? aiRoundState.turnNumber : turnAdvanceCount;
+    const activeTurnNumber = Number.isFinite(aiLaunchSession?.turnNumber)
+      ? aiLaunchSession.turnNumber
+      : requestedTurnNumber;
+    const samePlane = aiLaunchSession?.plane === plane;
+    const sameTurn = activeTurnNumber === requestedTurnNumber;
+    const stage = aiLaunchSession?.stage || null;
+    const activeSessionCanProceed = stage === "targeting" || stage === "pull" || stage === "oscillate";
+
+    if(samePlane && sameTurn && activeSessionCanProceed){
+      logAiDecision("ai_launch_session_duplicate_coalesced", {
+        existingSessionId: aiLaunchSession?.id ?? null,
+        requestedPlaneId: plane?.id ?? null,
+        planeId: aiLaunchSession?.plane?.id ?? null,
+        stage,
+        turnNumber: requestedTurnNumber,
+      });
+      return {
+        ok: true,
+        reason: "ai_launch_session_already_active_same_turn",
+      };
+    }
+
     logAiDecision("ai_launch_session_duplicate_blocked", {
       existingSessionId: aiLaunchSession?.id ?? null,
       requestedPlaneId: plane?.id ?? null,
       planeId: aiLaunchSession?.plane?.id ?? null,
+      activeStage: stage,
+      samePlane,
+      sameTurn,
+      requestedTurnNumber,
+      activeTurnNumber,
     });
     return {
       ok: false,


### PR DESCRIPTION
### Motivation
- Устранить причину бесконечного переприцеливания, когда повторные запросы на запуск хода приводили к рестарту прицеливания и цепочке ретраев вместо продолжения уже начатой сессии. 
- Сделать поведение запуска ИИ детерминированным относительно номера хода и служебного номера коммита, чтобы легко различать дубликаты и действительно новые запросы.

### Description
- Добавлена привязка метаданных хода в `aiLaunchSession`: поля `turnNumber` и `turnCommitSequence` при создании сессии (`buildAiLaunchSession`).
- В `issueAIMove` дубликатный запрос теперь коалесцируется (возвращается `ok: true`), если он относится к тому же самолёту и тому же номеру хода, а существующая сессия находится в рабочей стадии (`targeting`/`pull`/`oscillate`), чтобы не запускать повторное прицеливание; в противном случае остаётся строгая блокировка с обогащённой диагностикой. 
- Добавлена защита в `runAiLaunchSessionTick`: обнаружение неизвестной/некорректной стадии с переводом сессии в путь обработки аномалий через `resolveAiLaunchSessionAnomaly`, чтобы избежать висячих/бесконечных состояний.
- Все изменения сосредоточены в `script.js` и логируют дополнительные диагностические поля для упрощённой отладки (см. `ai_launch_session_duplicate_coalesced` / `ai_launch_session_duplicate_blocked`).

### Testing
- Запущен smoke-тест `node scripts/smoke-ai-launch-coarse-pull.js` — успешно прошёл. 
- Запущены smoke-тесты `node scripts/smoke-ai-launch-watchdog-failsafe.js` и `node scripts/smoke-ai-fallback-retry-budget.js` — упали в тестовом окружении из‑за отсутствующей переменной окружения/заглушки `failSafeAdvanceTurnInProgress` в текущем harness, не связанных с логикой внесённых правок. 
- Локально проверены основные сценарии создания/коалесации сессий и срабатывания защиты от неизвестных стадий (логирование диагностических записей присутствует).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db44555798832d877898e16b99fba3)