### PR TITLE
Tune ROUND label size and vertical position in transfer frame

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -624,6 +624,9 @@ body, button {
     font-family: "Inter", "Roboto", "Arial", sans-serif;
     font-weight: 600;
     font-variant-numeric: lining-nums;
+    font-size: 1.08em;
+    line-height: 1.08;
+    transform: translateY(1px);
   }
 
   .transfer-frame-text--turn-bottom {


### PR DESCRIPTION
### Motivation
- The `ROUND N` label inside the transfer frame appeared visually too small and slightly shifted upward, reducing legibility; this change corrects the visual balance without touching timing or sequence logic.

### Description
- In `styles.css` updated `.transfer-round-label` to add `font-size: 1.08em;`, `line-height: 1.08;` and `transform: translateY(1px);` to increase size and nudge the label downward for better optical centering.

### Testing
- Verified the style change with `git diff -- styles.css` and inspected the file contents (`nl -ba styles.css`), then committed the update with `git commit -m "Increase and vertically balance transfer round label"`; these commands completed successfully, and no automated UI tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6178a3e8832d9b8630fcbd2939a3)