### PR TITLE
Add dedicated TURN glow layer under transfer banner

### DIFF
--- a/script.js
+++ b/script.js
@@ -879,6 +879,7 @@ const TRANSFER_FRAME_HIDE_DURATION_MS = 160;
 // Z-index policy: transfer/system notifications must always be above all gameplay FX hosts (cargo/explosions/nuclear).
 const TRANSFER_SYSTEM_HOST_ID = "transferSystemHost";
 const TRANSFER_SYSTEM_HOST_Z_INDEX = 320;
+const TRANSFER_GLOW_LAYER_Z_INDEX = 320;
 const TRANSFER_FRAME_LAYER_Z_INDEX = 321;
 const TRANSFER_FRAME_ASSETS = Object.freeze({
   back: "ui_gamescreen/gs_transfer/gs_transfer_back.png",
@@ -887,6 +888,7 @@ const TRANSFER_FRAME_ASSETS = Object.freeze({
 });
 const transferFrameState = {
   host: null,
+  glowLayer: null,
   layer: null,
   panel: null,
   backImage: null,
@@ -898,6 +900,28 @@ const transferFrameState = {
   hideAnimationId: 0,
   panelAnimation: null,
 };
+
+function stopTransferTurnGlow() {
+  const glowLayer = transferFrameState.glowLayer;
+  if (!(glowLayer instanceof HTMLElement)) return;
+  glowLayer.classList.remove(
+    "is-visible",
+    "is-pulsing",
+    "transfer-turn-glow-layer--blue",
+    "transfer-turn-glow-layer--green"
+  );
+}
+
+function playTransferTurnGlow(player) {
+  const glowLayer = transferFrameState.glowLayer;
+  if (!(glowLayer instanceof HTMLElement)) return;
+  const isGreen = player === "green";
+  glowLayer.classList.remove("transfer-turn-glow-layer--blue", "transfer-turn-glow-layer--green", "is-pulsing");
+  glowLayer.classList.add("is-visible");
+  glowLayer.classList.add(isGreen ? "transfer-turn-glow-layer--green" : "transfer-turn-glow-layer--blue");
+  void glowLayer.offsetWidth;
+  glowLayer.classList.add("is-pulsing");
+}
 
 function ensureTransferSystemHost() {
   const hostParent = gsFrameLayer instanceof HTMLElement
@@ -936,6 +960,16 @@ function ensureTransferFrameElements() {
   if (!(transferHost instanceof HTMLElement)) return null;
 
   let layer = transferFrameState.layer;
+  let glowLayer = transferFrameState.glowLayer;
+  if (!(glowLayer instanceof HTMLElement) || glowLayer.parentElement !== transferHost) {
+    glowLayer = document.createElement("div");
+    glowLayer.className = "transfer-turn-glow-layer";
+    glowLayer.setAttribute("aria-hidden", "true");
+    glowLayer.style.zIndex = String(TRANSFER_GLOW_LAYER_Z_INDEX);
+    transferHost.appendChild(glowLayer);
+    transferFrameState.glowLayer = glowLayer;
+  }
+
   if (!(layer instanceof HTMLElement) || layer.parentElement !== transferHost) {
     layer = document.createElement("div");
     layer.className = "transfer-frame-layer";
@@ -1023,6 +1057,7 @@ function stopTransferPanelAnimation() {
 }
 
 function clearTransferFrameContent() {
+  stopTransferTurnGlow();
   if (transferFrameState.backImage instanceof HTMLImageElement) {
     transferFrameState.backImage.src = "";
   }
@@ -1112,9 +1147,11 @@ function showTransferFrame(options = {}) {
     if (mode === "turn") {
       transferState.colorImage.src = player === "green" ? TRANSFER_FRAME_ASSETS.green : TRANSFER_FRAME_ASSETS.blue;
       transferState.colorImage.classList.add("is-visible");
+      playTransferTurnGlow(player);
     } else {
       transferState.colorImage.src = "";
       transferState.colorImage.classList.remove("is-visible");
+      stopTransferTurnGlow();
     }
   }
 

--- a/styles.css
+++ b/styles.css
@@ -537,6 +537,49 @@ body, button {
     display: flex;
   }
 
+  .transfer-turn-glow-layer {
+    position: absolute;
+    inset: 0;
+    display: none;
+    pointer-events: none;
+    z-index: 320;
+  }
+
+  .transfer-turn-glow-layer::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    pointer-events: none;
+    background: transparent;
+  }
+
+  .transfer-turn-glow-layer.is-visible {
+    display: block;
+  }
+
+  .transfer-turn-glow-layer.is-pulsing::before {
+    animation: tgPulse2 1.7s ease-in-out 1;
+  }
+
+  .transfer-turn-glow-layer.transfer-turn-glow-layer--blue::before {
+    background: linear-gradient(to bottom, rgba(80,140,255,.48) 0 50%, rgba(80,140,255,0) 50% 100%);
+  }
+
+  .transfer-turn-glow-layer.transfer-turn-glow-layer--green::before {
+    background: linear-gradient(to bottom, rgba(80,200,120,0) 0 50%, rgba(80,200,120,.48) 50% 100%);
+  }
+
+  @keyframes tgPulse2 {
+    0%   { opacity: 0; }
+    14%  { opacity: .24; }
+    32%  { opacity: .42; }
+    50%  { opacity: .24; }
+    68%  { opacity: .42; }
+    86%  { opacity: .24; }
+    100% { opacity: 0; }
+  }
+
   .transfer-frame-panel {
     /*
       Geometry tokens are mapped to the Figma text containers:


### PR DESCRIPTION
### Motivation
- Внедрить фоновую пульсацию активной половины поля при показе TURN баннера как отдельный слой в игре, без таймерных хаков и без покрытия самой плашки (рамки/фона/текста).
- Требовались точные градиенты и ключевые кадры (ртим пульсации), однократное воспроизведение (не бесконечная петля) и надёжная интеграция в существующую логику показа transfer banner.

### Description
- Добавлены файлы/фрагменты: изменение в `script.js` и `styles.css` для нового слоя `transfer-turn-glow-layer` и его анимации.
- В `script.js` создано состояние `transferFrameState.glowLayer`, реализованы функции `playTransferTurnGlow(player)` и `stopTransferTurnGlow()`, и новый DOM-элемент создаётся в `ensureTransferFrameElements()` под host; анимация запускается строго в ветке `showTransferFrame(..., mode: 'turn')` и выключается для `mode: 'win'` и при очистке (`clearTransferFrameContent()`).
- В `styles.css` добавлены стили для `.transfer-turn-glow-layer` и псевдоэлемента `::before`, точные градиенты для BLUE и GREEN (`linear-gradient(...)`) и `@keyframes tgPulse2` с заданными кадрами, длительностью `1.7s`, easing `ease-in-out` и `1` итерацией, а также класс для переключения пульсации (`.is-pulsing`).
- Технические параметры и привязки: цвета и половины заданы в CSS-градиентах (BLUE — верхняя половина, GREEN — нижняя половина), z-index: glow = `320`, transfer frame layer = `321`, запуск происходит из `showTransferFrame`, layer располагается ниже transfer-frame-layer, при этом не меняется layout и не перекрываются рамка/фон/текст.

### Testing
- Запуск автоматической проверки синтаксиса: `node --check script.js` — прошло успешно.
- Локальная проверка сборки/коммитов выполнена (изменены `script.js` и `styles.css`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca63b9cac832d8ac7faf8c6ba48fe)