### PR TITLE
Introduce AI behavior contract and reference it in docs and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ How to interpret:
 
 Decision events are capped (last N entries kept) to prevent JSON from growing too much during long sessions.
 
+
+## AI behavior contract
+
+The canonical AI behavior profile is documented in:
+
+- `docs/AI_BEHAVIOR_CONTRACT.md`
+
+Before changing AI goal selection, inventory usage, fallback logic, or launch planning, read this contract first and keep behavior aligned with it.
+
+If a PR intentionally changes AI style, update the contract in the same PR.
+
 ## Game modes
 
 - **Hot Seat** – two players share the same computer.

--- a/docs/AI_BEHAVIOR_CONTRACT.md
+++ b/docs/AI_BEHAVIOR_CONTRACT.md
@@ -1,0 +1,122 @@
+# AI Behavior Contract
+
+Version: 1.0  
+Owner: gameplay-ai  
+Last updated: 2026-04-13
+
+## Purpose
+
+This document defines the target behavior style for Computer-mode AI and is the single source of truth for future AI rewrites.
+
+Primary objective: AI must play proactive, bold, resource-driven matches and avoid passive base camping.
+
+## Style profile
+
+AI should feel:
+
+- smart,
+- unexpected,
+- bold,
+- active every turn.
+
+AI must avoid:
+
+- passive “stay safe at base” behavior,
+- empty trick shots with no tactical objective,
+- conservative item hoarding.
+
+## Priority model (high → low)
+
+1. Eliminate enemy planes with reasonably safe attacks.
+2. Maintain and contest center control.
+3. Collect resources/items in center lanes.
+4. Capture/move flags when delivery potential is realistic.
+
+Notes:
+
+- Flag pickup by itself is not valuable unless AI can keep delivery chances alive.
+- If direct enemy elimination is available with acceptable risk, elimination has priority.
+
+## Inventory policy
+
+Use inventory actively (do not hoard).
+
+Preferred baseline value order:
+
+1. crosshair,
+2. fuel,
+3. wings,
+4. dynamite (situationally can be best),
+5. mine,
+6. invisibility.
+
+Combinations of the first three items are explicitly encouraged, including full triple-combo use before launch when advantageous.
+
+### Dynamite rules
+
+- If a profitable action is blocked by a wall, that wall is considered conditionally breakable.
+- Dynamite should be used on the current turn when it directly enables elimination, flag progress, or resource swing.
+- Special defensive exception: removing selected wall segments behind own base is allowed when it reduces enemy flag-steal ricochet escape options.
+
+### Mine rules
+
+Mines are not “rare emergency only” tools.
+Use them actively to:
+
+- control center routes,
+- block enemy response trajectories,
+- lock enemy movement options,
+- protect own follow-up attack lines,
+- defend key approach vectors to base.
+
+## Exchange and sacrifice policy
+
+Favorable exchanges are acceptable:
+
+- destroy 2 and lose 1 → good,
+- secure resource + elimination and then lose 1 → acceptable.
+
+In extreme score-preservation scenarios, deliberate self-sacrifice is allowed if it prevents a significantly worse round outcome.
+
+## Flag policy details
+
+- Do not panic-return by default.
+- Intercept enemy flag carrier when realistically possible.
+- If interception is unrealistic, continue pressure/value play instead of forced retreat.
+
+## Endgame behavior
+
+As plane counts drop, AI may become even more assertive (not more passive), because tempo and initiative become more decisive.
+
+## Strict anti-patterns (must not happen)
+
+- Base camping for “safety” while yielding center resources.
+- Repeated 1-for-1 suicidal trades at enemy base with no strategic upside.
+- Decorative high-risk shots with no clear objective.
+- Turn resolutions that intentionally avoid making progress when progress options exist.
+
+## Decision tie behavior
+
+When options are close in value:
+
+- allow controlled variety,
+- prefer the more aggressive option,
+- but execute clearly superior actions deterministically.
+
+## Acceptance checklist for future AI changes
+
+Any AI change should preserve all of the following:
+
+1. AI keeps moving game state forward (no passive loops).
+2. Center/resource pressure remains core behavior.
+3. Inventory is spent actively, not hoarded.
+4. Flag logic remains delivery-aware (not pickup-only).
+5. Aggressive style is preserved in low-plane and high-pressure states.
+6. Mines and dynamite remain first-class tactical tools.
+7. “Clearly best” actions are stable; close actions may vary.
+8. AI does not regress into base-stall safety play.
+
+## Implementation note for maintainers
+
+Before editing AI selection/planning/launch code, read this file first.
+If behavior changes intentionally, update this contract in the same PR.

--- a/script.js
+++ b/script.js
@@ -33141,6 +33141,7 @@ function setNoReadyAiPlanesStreak(value){
   return normalizedValue;
 }
 
+// AI CONTRACT: before changing turn-level AI behavior, align with docs/AI_BEHAVIOR_CONTRACT.md
 function runAiTurnV2(context = {}){
   if (gameMode!=="computer" || isGameOver) return;
 
@@ -34181,6 +34182,7 @@ if(typeof window !== "undefined"){
   window.runAiTurnV2 = runAiTurnV2;
 }
 
+// AI CONTRACT: dispatcher behavior should remain consistent with docs/AI_BEHAVIOR_CONTRACT.md
 function doComputerMove(){
   const getFailSafeCounts = () => ({
     aiPlanes: points.filter((plane) => plane?.color === "blue" && plane?.isAlive && !plane?.burning).length,


### PR DESCRIPTION
### Motivation

- Provide a single source of truth for Computer-mode AI style and decision expectations to avoid regressions when editing AI logic.
- Ensure contributors read and keep AI goal selection, inventory usage, fallback logic, and launch planning aligned with a documented contract.

### Description

- Add `docs/AI_BEHAVIOR_CONTRACT.md` detailing AI style, priority model, inventory policy, dynamite/mine rules, flag/endgame behavior, anti-patterns, and an acceptance checklist for future changes.
- Update `README.md` to reference the new contract and instruct contributors to update the contract when intentionally changing AI style.
- Add inline `// AI CONTRACT:` annotations in `script.js` near `runAiTurnV2` and `doComputerMove` to remind maintainers to consult `docs/AI_BEHAVIOR_CONTRACT.md` before changing turn-level or dispatcher behavior.

### Testing

- Ran the project linter with `npm run lint` and existing test suite with `npm test`, and both completed successfully.
- No runtime AI logic changes were made by this PR, so existing AI behavior tests and smoke checks remained unchanged and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcaa9a0a64832d9c61ad23c991128a)