### PR TITLE
Fix TURN_FLASH_DEBUG layer creation and host resolution

### DIFF
--- a/script.js
+++ b/script.js
@@ -905,6 +905,7 @@ const turnFlashDebugState = {
   enabled: false,
   unsubscribe: null,
   layer: null,
+  host: null,
 };
 
 function subscribeTurnAdvance(listener) {
@@ -930,17 +931,40 @@ function normalizeTurnFlashSide(side) {
   return side === "green" ? "green" : "blue";
 }
 
+function resolveTurnFlashDebugHost() {
+  if (turnFlashDebugState.host instanceof HTMLElement && turnFlashDebugState.host.isConnected) {
+    return turnFlashDebugState.host;
+  }
+  const hostCandidates = [
+    overlayContainer,
+    document.getElementById("overlayContainer"),
+    gsFrameEl,
+    document.getElementById("gameContainer"),
+    gsFrameLayer,
+    document.getElementById("gsFrame"),
+  ];
+  const host = hostCandidates.find((candidate) => candidate instanceof HTMLElement) || null;
+  if (!(host instanceof HTMLElement)) {
+    console.warn("[turn-flash-debug] host not found; expected #overlayContainer or #gameContainer.");
+    turnFlashDebugState.host = null;
+    return null;
+  }
+  turnFlashDebugState.host = host;
+  return host;
+}
+
 function ensureTurnFlashDebugLayer() {
   if (turnFlashDebugState.layer instanceof HTMLElement && turnFlashDebugState.layer.isConnected) {
     return turnFlashDebugState.layer;
   }
-  if (!(gameContainer instanceof HTMLElement)) return null;
-  let layer = gameContainer.querySelector(".turn-flash-debug-layer");
+  const host = resolveTurnFlashDebugHost();
+  if (!(host instanceof HTMLElement)) return null;
+  let layer = host.querySelector(".turn-flash-debug-layer");
   if (!(layer instanceof HTMLElement)) {
     layer = document.createElement("div");
     layer.className = "turn-flash-debug-layer";
     layer.setAttribute("aria-hidden", "true");
-    gameContainer.appendChild(layer);
+    host.appendChild(layer);
   }
   turnFlashDebugState.layer = layer;
   return layer;
@@ -958,14 +982,22 @@ function triggerTurnFlashDebugPulse(side) {
 }
 
 function enableTurnFlashDebug() {
-  if (turnFlashDebugState.enabled) {
+  const layer = ensureTurnFlashDebugLayer();
+  if (!(layer instanceof HTMLElement)) {
+    turnFlashDebugState.enabled = false;
+    if (typeof turnFlashDebugState.unsubscribe === "function") {
+      turnFlashDebugState.unsubscribe();
+    }
+    turnFlashDebugState.unsubscribe = null;
     return turnFlashDebugApiState();
   }
-  const unsubscribe = subscribeTurnAdvance(({ nextTurnColor }) => {
-    triggerTurnFlashDebugPulse(nextTurnColor);
-  });
-  turnFlashDebugState.unsubscribe = unsubscribe;
-  turnFlashDebugState.enabled = true;
+  if (!turnFlashDebugState.enabled) {
+    const unsubscribe = subscribeTurnAdvance(({ nextTurnColor }) => {
+      triggerTurnFlashDebugPulse(nextTurnColor);
+    });
+    turnFlashDebugState.unsubscribe = unsubscribe;
+    turnFlashDebugState.enabled = true;
+  }
   return turnFlashDebugApiState();
 }
 
@@ -986,9 +1018,10 @@ function disableTurnFlashDebug() {
 }
 
 function turnFlashDebugApiState() {
+  const hasLayer = turnFlashDebugState.layer instanceof HTMLElement && turnFlashDebugState.layer.isConnected;
   return {
     enabled: turnFlashDebugState.enabled === true,
-    hasLayer: turnFlashDebugState.layer instanceof HTMLElement,
+    hasLayer,
   };
 }
 


### PR DESCRIPTION
### Motivation
- TURN_FLASH_DEBUG often reported `enabled: true` while the visual layer was not created, so `trigger()` produced no visible effect.
- The debug layer was appended to an ambiguous container which could be missing, causing silent failures when the host wasn't present.
- The goal is to make the debug API self-contained: create and attach the layer on `enable()`, reliably show pulses for `trigger(...)`, and log when no host is found.

### Description
- Added `host` to `turnFlashDebugState` and implemented `resolveTurnFlashDebugHost()` which searches and caches a host in the order `#overlayContainer`, `#gameContainer`, `#gsFrame` and logs a clear `console.warn` if none found. (`script.js`)
- `ensureTurnFlashDebugLayer()` now uses the resolved host to query/create the `.turn-flash-debug-layer` element and appends it to that host instead of an ambiguous target. (`script.js`)
- `enableTurnFlashDebug()` now forces layer creation first and only sets the `enabled` subscription if the layer exists; if creation fails the function returns a falsey `hasLayer` and unsubscribes any previous handler. (`script.js`)
- `turnFlashDebugApiState()` computes `hasLayer` by checking that the layer is an `HTMLElement` and `isConnected`, preventing false positives. Visual parameters (gradients, duration 680ms, easing `ease-in-out`, single pulse) remain as defined in `styles.css`.

### Testing
- Ran `node --check script.js` to validate syntax and consistency; the check succeeded.
- No automated UI tests were run in this change set; visual behavior should be verified in-browser using the provided runtime commands (`TURN_FLASH_DEBUG.enable()`, `TURN_FLASH_DEBUG.disable()`, `TURN_FLASH_DEBUG.trigger('blue')`, `TURN_FLASH_DEBUG.trigger('green')`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcdaceb6b4832d83f60bdb321b4c23)