### PR TITLE
Update transfer banner asset paths to gs_transfer_2

### DIFF
--- a/script.js
+++ b/script.js
@@ -882,9 +882,9 @@ const TRANSFER_SYSTEM_HOST_Z_INDEX = 320;
 const TRANSFER_GLOW_LAYER_Z_INDEX = 320;
 const TRANSFER_FRAME_LAYER_Z_INDEX = 321;
 const TRANSFER_FRAME_ASSETS = Object.freeze({
-  back: "ui_gamescreen/gs_transfer/gs_transfer_back.png",
-  blue: "ui_gamescreen/gs_transfer/gs_transfer_blue.png",
-  green: "ui_gamescreen/gs_transfer/gs_transfer_green.png",
+  back: "ui_gamescreen/gs_transfer_2/gs_transfer_back.png",
+  blue: "ui_gamescreen/gs_transfer_2/gs_transfer_blue.png",
+  green: "ui_gamescreen/gs_transfer_2/gs_transfer_green.png",
 });
 const transferFrameState = {
   host: null,


### PR DESCRIPTION
### Motivation
- Switch the end-turn / new-round banner backgrounds to the new asset set located in `ui_gamescreen/gs_transfer_2` while keeping filenames and behavior unchanged.

### Description
- Updated the three image paths in `TRANSFER_FRAME_ASSETS` inside `script.js` from `ui_gamescreen/gs_transfer/...` to `ui_gamescreen/gs_transfer_2/...` for `gs_transfer_back.png`, `gs_transfer_blue.png`, and `gs_transfer_green.png` and made no other code or logic changes.

### Testing
- Verified the replacements with `rg -n "ui_gamescreen/gs_transfer"` and `rg -n "ui_gamescreen/gs_transfer_2"` and confirmed `script.js` now references the `_2` folder; ran `git status` to confirm the file was modified and created a commit for the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf67331bc832dad6235e69a2da639)