### PR TITLE
Fix TURN_FLASH_DEBUG trigger to use direct overlay animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -953,44 +953,55 @@ function resolveTurnFlashDebugHost() {
   return host;
 }
 
-function ensureTurnFlashDebugLayer() {
-  if (turnFlashDebugState.layer instanceof HTMLElement && turnFlashDebugState.layer.isConnected) {
-    return turnFlashDebugState.layer;
-  }
-  const host = resolveTurnFlashDebugHost();
-  if (!(host instanceof HTMLElement)) return null;
-  let layer = host.querySelector(".turn-flash-debug-layer");
-  if (!(layer instanceof HTMLElement)) {
-    layer = document.createElement("div");
-    layer.className = "turn-flash-debug-layer";
-    layer.setAttribute("aria-hidden", "true");
-    host.appendChild(layer);
-  }
-  turnFlashDebugState.layer = layer;
-  return layer;
-}
-
 function triggerTurnFlashDebugPulse(side) {
   const safeSide = normalizeTurnFlashSide(side);
-  const layer = ensureTurnFlashDebugLayer();
-  if (!(layer instanceof HTMLElement)) return false;
-  layer.classList.remove("turn-flash-debug-layer--blue", "turn-flash-debug-layer--green", "is-pulsing");
-  layer.classList.add(safeSide === "green" ? "turn-flash-debug-layer--green" : "turn-flash-debug-layer--blue");
-  void layer.offsetWidth;
-  layer.classList.add("is-pulsing");
+  const host = resolveTurnFlashDebugHost();
+  if (!(host instanceof HTMLElement)) {
+    console.warn("[turn-flash-debug] trigger aborted: host/container not found.");
+    return false;
+  }
+  const layer = document.createElement("div");
+  layer.className = "turn-flash-debug-layer";
+  layer.setAttribute("aria-hidden", "true");
+  Object.assign(layer.style, {
+    position: "absolute",
+    inset: "0",
+    pointerEvents: "none",
+    zIndex: "24",
+    opacity: "0",
+    background: safeSide === "green"
+      ? "linear-gradient(to bottom, rgba(80,200,120,0) 0 50%, rgba(80,200,120,.55) 50% 100%)"
+      : "linear-gradient(to bottom, rgba(80,140,255,.55) 0 50%, rgba(80,140,255,0) 50% 100%)",
+  });
+  host.appendChild(layer);
+  turnFlashDebugState.layer = layer;
+  const animation = layer.animate(
+    [
+      { opacity: 0 },
+      { opacity: .24 },
+      { opacity: .42 },
+      { opacity: .24 },
+      { opacity: .42 },
+      { opacity: .24 },
+      { opacity: 0 }
+    ],
+    {
+      duration: 1700,
+      easing: "ease-in-out"
+    }
+  );
+  const cleanup = () => {
+    if (layer.isConnected) layer.remove();
+    if (turnFlashDebugState.layer === layer) {
+      turnFlashDebugState.layer = null;
+    }
+  };
+  animation.onfinish = cleanup;
+  animation.oncancel = cleanup;
   return true;
 }
 
 function enableTurnFlashDebug() {
-  const layer = ensureTurnFlashDebugLayer();
-  if (!(layer instanceof HTMLElement)) {
-    turnFlashDebugState.enabled = false;
-    if (typeof turnFlashDebugState.unsubscribe === "function") {
-      turnFlashDebugState.unsubscribe();
-    }
-    turnFlashDebugState.unsubscribe = null;
-    return turnFlashDebugApiState();
-  }
   if (!turnFlashDebugState.enabled) {
     const unsubscribe = subscribeTurnAdvance(({ nextTurnColor }) => {
       triggerTurnFlashDebugPulse(nextTurnColor);
@@ -1007,18 +1018,19 @@ function disableTurnFlashDebug() {
   }
   turnFlashDebugState.unsubscribe = null;
   turnFlashDebugState.enabled = false;
-  if (turnFlashDebugState.layer instanceof HTMLElement) {
-    turnFlashDebugState.layer.classList.remove(
-      "turn-flash-debug-layer--blue",
-      "turn-flash-debug-layer--green",
-      "is-pulsing"
-    );
+  if (turnFlashDebugState.host instanceof HTMLElement) {
+    turnFlashDebugState.host.querySelectorAll(".turn-flash-debug-layer").forEach((layer) => {
+      if (layer instanceof HTMLElement) layer.remove();
+    });
   }
+  turnFlashDebugState.layer = null;
   return turnFlashDebugApiState();
 }
 
 function turnFlashDebugApiState() {
-  const hasLayer = turnFlashDebugState.layer instanceof HTMLElement && turnFlashDebugState.layer.isConnected;
+  const hasLayer =
+    turnFlashDebugState.layer instanceof HTMLElement
+    && turnFlashDebugState.layer.isConnected;
   return {
     enabled: turnFlashDebugState.enabled === true,
     hasLayer,


### PR DESCRIPTION
### Motivation
- The existing `TURN_FLASH_DEBUG.trigger` relied on CSS classes, a pre-existing layer and keyframes which made the pulse unreliable in runtime edge cases. 
- The goal is a tiny, robust debug entrypoint that always shows the flash when called, independent from `enable()` subscription state.

### Description
- Rewrote `triggerTurnFlashDebugPulse(side)` to create a new overlay `div`, append it to a resolved host, set the side-specific gradient background and `z-index: 24`, run a single `element.animate(...)` and remove the element in `onfinish`/`oncancel`.
- The gradients used are the supplied working patterns for `blue` and `green`, and the animation frames/duration/easing are exactly as requested (`[0, .24, .42, .24, .42, .24, 0]`, `1700ms`, `ease-in-out`).
- `trigger()` now logs a clear `console.warn` and returns `false` if no host/container can be resolved, rather than silently failing or returning invalid values.
- `enable()`/`disable()` are left as subscription controls: `enable()` only subscribes to turn-change events, and `disable()` unsubscribes and also removes any active debug overlays; `trigger()` remains a self-contained manual debug call.
- Host resolution priority remains: `overlayContainer` → `#overlayContainer` → `gsFrameEl` → `#gameContainer` → `gsFrameLayer` → `#gsFrame`.

### Testing
- Ran `node --check script.js` with no syntax errors, which succeeded.
- Performed local sanity checks (script load / static verification) and confirmed `TURN_FLASH_DEBUG.trigger('blue')`, `TURN_FLASH_DEBUG.trigger('green')`, `TURN_FLASH_DEBUG.enable()` and `TURN_FLASH_DEBUG.disable()` are available on `window` for manual verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf89a0f4c832d81a6b01fe717f8fc)