### PR TITLE
Refine enemy flag carrier ring rendering

### DIFF
--- a/script.js
+++ b/script.js
@@ -39280,10 +39280,22 @@ function drawPlanesAndTrajectories(){
     const isPlaneFullyHiddenByInvisibility = invisibilityAlpha <= 0.01;
     if(p.flagColor && !isPlaneFullyHiddenByInvisibility){
       targetCtx.save();
-      targetCtx.strokeStyle = colorFor(p.flagColor);
-      targetCtx.lineWidth = 3;
+      const ringColor = colorFor(p.flagColor);
+      const ringRadius = POINT_RADIUS + 6;
+      const ringGapAngle = Math.PI / 18;
+      const ringStart = -Math.PI / 2 + ringGapAngle * 0.5;
+      const ringEnd = (Math.PI * 3) / 2 - ringGapAngle * 0.5;
+
+      targetCtx.strokeStyle = "rgba(14, 18, 28, 0.7)";
+      targetCtx.lineWidth = 1.2;
       targetCtx.beginPath();
-      targetCtx.arc(p.x, p.y, POINT_RADIUS + 5, 0, Math.PI*2);
+      targetCtx.arc(p.x, p.y, ringRadius + 0.6, ringStart, ringEnd, false);
+      targetCtx.stroke();
+
+      targetCtx.strokeStyle = ringColor;
+      targetCtx.lineWidth = 2.2;
+      targetCtx.beginPath();
+      targetCtx.arc(p.x, p.y, ringRadius, ringStart, ringEnd, false);
       targetCtx.stroke();
       targetCtx.restore();
     }


### PR DESCRIPTION
### Motivation
- Упростить и сделать эстетичнее индикатор самолёта, несущего вражеский флаг, сохранив минимализм и текущую логику цвета.
- Текущий один «голый» stroke выглядел как дефолтная векторная обводка и терялся на некоторых фонах.

### Description
- Заменил один круговой `stroke` на аккуратное кольцо из двух контуров: тонкая тёмная внешняя подложка и цветной внутренний контур, при этом цвет остаётся равен цвету захваченного флага (`colorFor(p.flagColor)`).
- Немного увеличил радиус маркера (примерно на 1px) для лучшей читаемости без визуального утяжеления.
- Ввёл небольшой фиксированный разрыв дуги (малый `ringGapAngle`), чтобы кольцо выглядело менее «идеально редакторным», оставаясь ненавязчивым.
- Изменения внесены в `script.js` внутри блока отрисовки индикатора флага: условие `if(p.flagColor && !isPlaneFullyHiddenByInvisibility){ ... }` (примерно `script.js` строки `39281-39299`).

### Testing
- Запуск `node --check script.js` прошёл успешно (без синтаксических ошибок).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd001352c0832d937abfb2121ba95f)