### PR TITLE
Remove legacy goalPriorityModel from runtime load path

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Current cargo icons used by the game are stored only in:
 
 The obsolete prototype folder `ui_gamescreen/gamescreen_outside/gs_icon_prototypes/` is removed and must not be used as a runtime source.
 
-## Old AI removal status
+## Legacy goal-priority module removal status
 
-Old AI (v1 and v2) has been fully disabled in runtime.
+Legacy browser-loaded goal-priority model (`ai/v2/goalPriorityModel.js`) is no longer connected in `index.html`.
 
 What this means now:
-- Computer mode now shows an explicit hard-fail signal when computer turn begins: old AI is removed, new AI is not implemented yet.
-- Legacy AI debug/diagnostic APIs are no longer exported into runtime.
+- Computer mode continues to use the main built-in heuristic logic from `script.js`.
+- Legacy `window.PaperWingsGoalPriorityModel` global is no longer used in the active computer-turn path.
 - Cargo reset debug helper remains available:
 
 ```js
@@ -72,7 +72,7 @@ For a detailed “after demolition” list, see:
 ## Game modes
 
 - **Hot Seat** – two players share the same computer.
-- **Computer** – hard-fail placeholder while new AI is being prepared (old AI fully removed).
+- **Computer** – available and driven by the current in-file heuristic logic.
 - **Online** – currently disabled in this build.
 
 ## Basic rules

--- a/docs/OLD_AI_REMOVAL_MANIFEST.md
+++ b/docs/OLD_AI_REMOVAL_MANIFEST.md
@@ -1,34 +1,20 @@
 # OLD AI removal manifest
 
 ## Scope
-This manifest tracks entities related to legacy AI v1/v2 that were removed or explicitly disabled in this PR.
+This manifest tracks legacy goal-priority model removal from runtime loading and active computer-turn dispatch.
 
-## Entry points and runtime dispatch
-- `doComputerMove` old runtime path — **hard-fail stub** (`old AI removed`).
-- `runAiTurnV2` old runtime path — **hard-fail stub** (`old AI removed`).
-- `tryStartAiPlanningFromCommittedState` — **hard-fail stub**.
-- `scheduleComputerMoveWithCargoGate` — **hard-fail stub**.
+## Runtime loading changes
+- `index.html` no longer loads `ai/v2/goalPriorityModel.js`.
+- The previous global model surface `window.PaperWingsGoalPriorityModel` is not used by active computer-turn logic.
+
+## Active behavior
+- `evaluateAiGoalPriorityModel` now acts as a no-op fallback and returns `null`.
+- Goal selection automatically falls back to built-in heuristic branches in `selectAiModeAndTargets`.
 
 ## Public/debug APIs
-Old decision debug/export APIs are reduced to hard-fail responses via `old_ai_debug_api_removed`:
-- `exportAiV2DecisionAuditReportJson`
-- `exportAiV2DecisionAuditCompactReportJson`
-- `exportAiV2ReserveDiagnosticsReportJson`
-- `DEBUG_AI_GAP_AFTER_BOUNCE_REPORT`
-
-Runtime `window` surface keeps only neutral helper:
+Runtime `window` surface keeps helper:
 - `window.RESET_CARGO`
 
-## Deleted AI automation scripts
-Deleted all `scripts/smoke-ai-*.js` files and AI compare scripts:
-- `scripts/compare-ai-opening-template-frequency.js`
-- `scripts/compare-ai-initial-route-classes.js`
-- `scripts/compare-ai-early-reject-reasons.js`
-
-## Deleted old AI documentation
-- `docs/ai-move-pipeline-before-after.md`
-- `docs/ai-cargo-before-after.md`
-- `docs/ai-wall-locked-before-after.md`
-
-## Hard-pass follow-up
-- See `docs/BEHAVIOR_REMOVAL_HARD_PASS_2026-04-13.md` for explicit hard-fail behavior and acceptance checks.
+## Notes
+- This document reflects current factual loading/usage state only.
+- It does **not** claim that all historical AI code was deleted from the repository.

--- a/index.html
+++ b/index.html
@@ -544,7 +544,7 @@
 
   <script src="maps.js"></script>
   <script src="settings.js"></script>
-  <script src="ai/v2/goalPriorityModel.js"></script>
+  <!-- legacy goalPriorityModel.js removed: old global model is no longer loaded at runtime -->
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -27291,65 +27291,10 @@ function evaluateFlagPressureOpportunity(context = {}){
 }
 
 function evaluateAiGoalPriorityModel(context){
-  const model = (typeof window !== "undefined" && window.PaperWingsGoalPriorityModel)
-    ? window.PaperWingsGoalPriorityModel
-    : null;
-  if(!model || typeof model.evaluate !== "function") return null;
-
-  const shouldUseFlagsMode = Boolean(context?.shouldUseFlagsMode);
-  const aiAliveCount = Array.isArray(context?.aiPlanes) ? context.aiPlanes.length : 0;
-  const enemyAliveCount = Array.isArray(context?.enemies) ? context.enemies.length : 0;
-  const availableEnemyFlagsCount = Array.isArray(context?.availableEnemyFlags)
-    ? context.availableEnemyFlags.length
-    : 0;
-  const readyCargoCount = Array.isArray(cargoState)
-    ? cargoState.reduce((count, cargo) => count + (cargo?.state === "ready" ? 1 : 0), 0)
-    : 0;
-
-  const flagPressureOpportunity = context?.flagPressureOpportunity || evaluateFlagPressureOpportunity(context);
-
-  return model.evaluate({
-    scoreGap: greenScore - blueScore,
-    aiAliveCount,
-    enemyAliveCount,
-    availableEnemyFlagsCount,
-    blueInventoryCount: Number.isFinite(context?.blueInventoryCount) ? context.blueInventoryCount : 0,
-    readyCargoCount,
-    hasStolenBlueFlagCarrier: Boolean(context?.defensivePriority?.hasFlagCarrierThreat || (context?.stolenBlueFlagCarrier && context.stolenBlueFlagCarrier.color !== "blue")),
-    hasTripleKillOpportunity: Boolean(context?.groupKillPriorityPlan?.move && context.groupKillPriorityPlan.killCountOnTrajectory >= 3),
-    hasImmediateBlueFlagTheftThreat: Boolean(context?.defensivePriority?.hasQuickFlagPickupThreat || context?.criticalBlueFlagThreat),
-    defensivePriorityLevel: context?.defensivePriority?.level || AI_DEFENSIVE_PRIORITY_LEVELS.NONE,
-    defensivePrioritySource: context?.defensivePriority?.primarySource || null,
-    shouldUseFlagsMode,
-    canReachEnemyFlag: flagPressureOpportunity.canReachEnemyFlag,
-    hasReturnRouteOpportunity: flagPressureOpportunity.hasReturnRouteOpportunity,
-    hasSafePostPickupEscape: flagPressureOpportunity.hasSafeEscapeOpportunity,
-    expectedRetreatChance: flagPressureOpportunity.expectedRetreatChance,
-    returnLaneThreat: flagPressureOpportunity.returnLaneThreat,
-    flagGrabValue: flagPressureOpportunity.flagGrabValue,
-    postPickupEscapeValue: flagPressureOpportunity.postPickupEscapeValue,
-    flagReturnValue: flagPressureOpportunity.flagReturnValue,
-    flagContinuationStatus: flagPressureOpportunity.flagContinuationStatus,
-    flagContinuationReason: flagPressureOpportunity.flagContinuationReason,
-    hasSafeEscapeOpportunity: flagPressureOpportunity.hasSafeEscapeOpportunity,
-    cargoAlternativeValue: flagPressureOpportunity.cargoAlternativeValue,
-    attackAlternativeValue: flagPressureOpportunity.attackAlternativeValue,
-    baseControlLoss: flagPressureOpportunity.baseControlLoss,
-    dangerousEnemyNearBlueBase: flagPressureOpportunity.dangerousEnemyNearBlueBase,
-    interceptWindowLoss: flagPressureOpportunity.interceptWindowLoss,
-    hasComfortableDefensiveResponse: flagPressureOpportunity.hasComfortableDefensiveResponse,
-    homeDefensePressure: flagPressureOpportunity.homeDefensePressure,
-    criticalHomeDefenseThreat: flagPressureOpportunity.criticalHomeDefenseThreat,
-    mineRoutePressure: flagPressureOpportunity.mineRoutePressure,
-    mineEnemyRoutePressure: flagPressureOpportunity.mineEnemyRoutePressure,
-    mineOwnRoutePressure: flagPressureOpportunity.mineOwnRoutePressure,
-    mineOwnPathIntersectionPenalty: flagPressureOpportunity.mineOwnPathIntersectionPenalty,
-    mineDetourValue: flagPressureOpportunity.mineDetourValue,
-    mineDefensiveUrgency: flagPressureOpportunity.mineDefensiveUrgency,
-    trappedByMines: flagPressureOpportunity.trappedByMines,
-    enemyMineCoverAfterAdvance: flagPressureOpportunity.enemyMineCoverAfterAdvance,
-    routeDevaluedByOwnMines: flagPressureOpportunity.routeDevaluedByOwnMines,
-  });
+  // Legacy goal priority model has been removed from runtime loading.
+  // Keep this function as a no-op fallback so AI goal selection continues
+  // via the built-in heuristic branch below without hard failures.
+  return null;
 }
 
 function applyAiGoalSelection(selection, meta = {}){


### PR DESCRIPTION
### Motivation
- Устранить рассинхронизацию между документацией и реальным поведением страницы, где старый браузерный модуль приоритетов всё ещё загружался; это вводило в заблуждение.
- Сделать активный путь хода компьютера независимым от устаревшего глобального объекта `window.PaperWingsGoalPriorityModel`, чтобы избежать неожиданных зависимостей при запуске игры.

### Description
- Удалено подключение `ai/v2/goalPriorityModel.js` из `index.html` и заменено на явный комментарий-заглушку, указывающий, что модуль больше не загружается в runtime.
- В `script.js` функция `evaluateAiGoalPriorityModel(context)` превращена в безопасный no-op (возвращает `null`) чтобы отключить использование `window.PaperWingsGoalPriorityModel` в активном пути принятия решений ИИ и позволить fallback-эвристике обрабатывать выбор целей.
- Обновлён `README.md` для точного описания текущего состояния: указано, что legacy-модуль больше не подключается, и что режим `Computer` работает на встроенной эвристике в `script.js`.
- Переписан `docs/OLD_AI_REMOVAL_MANIFEST.md` чтобы манифест отражал фактические изменения загрузки и поведения, а не заявлял о полном удалении всех исторических артефактов.

### Testing
- Выполнены поисковые проверки наличия упоминаний: `rg -n "goalPriorityModel|PaperWingsGoalPriorityModel|<script src=\"ai/v2/goalPriorityModel.js\""` и `rg -n "window\.PaperWingsGoalPriorityModel|PaperWingsGoalPriorityModel|goalPriorityModel.js" index.html script.js README.md docs/OLD_AI_REMOVAL_MANIFEST.md -S`, и они подтвердили отсутствие подключённого скрипта и отказ активного использования глобального объекта; команды успешно вернули ожидаемые результаты.
- Проверено, что `index.html` больше не содержит строку `<script src="ai/v2/goalPriorityModel.js"></script>`; команда вывода файла подтвердила замену на комментарий-заглушку.
- Код был зафиксирован в репозитории с сообщением: `git commit -m "Remove legacy goalPriorityModel runtime loading and references"`, коммит прошёл успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0ce20d14832db655e94c1af0c4a9)