### PR TITLE
Улучшение кольца индикатора захваченного флага — двойной замкнутый контур

### DIFF
--- a/script.js
+++ b/script.js
@@ -39038,21 +39038,21 @@ function drawPlanesAndTrajectories(){
     if(p.flagColor && !isPlaneFullyHiddenByInvisibility){
       targetCtx.save();
       const ringColor = colorFor(p.flagColor);
-      const ringRadius = POINT_RADIUS + 6;
-      const ringGapAngle = Math.PI / 18;
-      const ringStart = -Math.PI / 2 + ringGapAngle * 0.5;
-      const ringEnd = (Math.PI * 3) / 2 - ringGapAngle * 0.5;
 
-      targetCtx.strokeStyle = "rgba(14, 18, 28, 0.7)";
-      targetCtx.lineWidth = 1.2;
+      // Captured-flag ring: fully closed and visibly double-stroked.
+      const innerRingRadius = POINT_RADIUS + 7;
+      const outerRingRadius = innerRingRadius + 1;
+
+      targetCtx.strokeStyle = "rgba(14, 18, 28, 0.82)";
+      targetCtx.lineWidth = 1;
       targetCtx.beginPath();
-      targetCtx.arc(p.x, p.y, ringRadius + 0.6, ringStart, ringEnd, false);
+      targetCtx.arc(p.x, p.y, outerRingRadius, 0, Math.PI * 2, false);
       targetCtx.stroke();
 
       targetCtx.strokeStyle = ringColor;
-      targetCtx.lineWidth = 2.2;
+      targetCtx.lineWidth = 2.6;
       targetCtx.beginPath();
-      targetCtx.arc(p.x, p.y, ringRadius, ringStart, ringEnd, false);
+      targetCtx.arc(p.x, p.y, innerRingRadius, 0, Math.PI * 2, false);
       targetCtx.stroke();
       targetCtx.restore();
     }


### PR DESCRIPTION
### Motivation
- Индикатор флага выглядел как декоративный разрыв в кольце и воспринимался как случайный штрих, поэтому нужно было сделать его более явным, сохранив минимализм и без эффектов.

### Description
- Заменён участок рисования индикатора в `script.js` в блоке `if(p.flagColor && !isPlaneFullyHiddenByInvisibility){ ... }` (примерно около `L39038`) на полностью замкнутый двойной контур: наружный тонкий нейтральный и внутренний — цвет флага; декоративный разрыв убран и рисуется полный круг (`0 .. Math.PI * 2`).
- Итоговые размеры и толщины заданы как: внутренний радиус `POINT_RADIUS + 7`, внешний радиус `innerRingRadius + 1`, толщина внешнего контура `1`, толщина внутреннего цветного контура `2.6`, цвет внутреннего контура по-прежнему берётся через `colorFor(p.flagColor)` (логика цветов не менялась).

### Testing
- Запущена автоматическая синтаксическая проверка командой `node --check script.js`, проверка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0cc2ae40832db000cae02d919af7)