### PR TITLE
Polish captured-flag ring contour styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -8476,6 +8476,15 @@ function colorWithAlpha(color, alpha){
   return `rgba(${r},${g},${b},${alpha})`;
 }
 
+const CAPTURED_FLAG_RING_STYLE = {
+  innerRadiusOffset: 7,
+  outerRadiusOffset: 0.9,
+  outerStrokeColor: "rgba(10, 14, 22, 0.9)",
+  outerStrokeWidth: 0.8,
+  innerStrokeWidth: 2.4,
+  innerStrokeAlpha: 0.98
+};
+
 let brickFrameBorderPxX = FIELD_BORDER_THICKNESS;
   let brickFrameBorderPxY = FIELD_BORDER_THICKNESS;
 function processBrickFrameImage() {
@@ -38982,20 +38991,20 @@ function drawPlanesAndTrajectories(){
     const isPlaneFullyHiddenByInvisibility = invisibilityAlpha <= 0.01;
     if(p.flagColor && !isPlaneFullyHiddenByInvisibility){
       targetCtx.save();
-      const ringColor = colorFor(p.flagColor);
+      const ringColor = colorWithAlpha(p.flagColor, CAPTURED_FLAG_RING_STYLE.innerStrokeAlpha);
 
       // Captured-flag ring: fully closed and visibly double-stroked.
-      const innerRingRadius = POINT_RADIUS + 7;
-      const outerRingRadius = innerRingRadius + 1;
+      const innerRingRadius = POINT_RADIUS + CAPTURED_FLAG_RING_STYLE.innerRadiusOffset;
+      const outerRingRadius = innerRingRadius + CAPTURED_FLAG_RING_STYLE.outerRadiusOffset;
 
-      targetCtx.strokeStyle = "rgba(14, 18, 28, 0.82)";
-      targetCtx.lineWidth = 1;
+      targetCtx.strokeStyle = CAPTURED_FLAG_RING_STYLE.outerStrokeColor;
+      targetCtx.lineWidth = CAPTURED_FLAG_RING_STYLE.outerStrokeWidth;
       targetCtx.beginPath();
       targetCtx.arc(p.x, p.y, outerRingRadius, 0, Math.PI * 2, false);
       targetCtx.stroke();
 
       targetCtx.strokeStyle = ringColor;
-      targetCtx.lineWidth = 2.6;
+      targetCtx.lineWidth = CAPTURED_FLAG_RING_STYLE.innerStrokeWidth;
       targetCtx.beginPath();
       targetCtx.arc(p.x, p.y, innerRingRadius, 0, Math.PI * 2, false);
       targetCtx.stroke();


### PR DESCRIPTION
### Motivation
- Improve the visual quality of the existing captured-flag ring around a plane without redesigning it, keeping the indicator minimal and without adding decorative effects. 
- Make the outer contour slightly darker and thinner and make the inner colored ring a touch cleaner and more contrastive so it reads better on the field. 

### Description
- Introduced a single tuning object `CAPTURED_FLAG_RING_STYLE` in `script.js` to centralize ring parameters (`innerRadiusOffset`, `outerRadiusOffset`, `outerStrokeColor`, `outerStrokeWidth`, `innerStrokeWidth`, `innerStrokeAlpha`).
- Replaced hardcoded values in the captured-flag drawing code with the new constants so the outer ring is slightly darker (`rgba(10,14,22,0.9)`) and thinner (`0.8`), the inner colored ring is slightly thinner (`2.4`) and uses a controlled alpha (`0.98`) via `colorWithAlpha(...)`, and the outer radius offset was reduced from `+1` to `0.9` for a gentler edge.
- Kept the original geometry and color logic intact: the inner ring color is still derived from `p.flagColor` so existing color inversion (green plane → blue indicator / blue plane → green indicator) remains unchanged.

### Testing
- Ran the syntax/check command `node --check script.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd17da621c832d848e63379a335d35)