### PR TITLE
Полировка двойного контура индикатора захваченного флага

### DIFF
--- a/script.js
+++ b/script.js
@@ -8478,11 +8478,11 @@ function colorWithAlpha(color, alpha){
 
 const CAPTURED_FLAG_RING_STYLE = {
   innerRadiusOffset: 7,
-  outerRadiusOffset: 0.9,
-  outerStrokeColor: "rgba(10, 14, 22, 0.9)",
-  outerStrokeWidth: 0.8,
-  innerStrokeWidth: 2.4,
-  innerStrokeAlpha: 0.98
+  outerRadiusOffset: 1.1,
+  outerStrokeColor: "rgba(24, 29, 38, 0.84)",
+  outerStrokeWidth: 1.05,
+  innerStrokeWidth: 2.2,
+  innerStrokeAlpha: 1
 };
 
 let brickFrameBorderPxX = FIELD_BORDER_THICKNESS;


### PR DESCRIPTION
### Motivation
- Сохранить текущую концепцию индикатора — нейтральный внешний контур и цветной внутренний контур по цвету захваченного вражеского флага — и аккуратно её отполировать, не делая редизайн.
- Устранить визуальную «шумность» и сделать контуры более благородными и читаемыми на поле при минимальных изменениях геометрии и логики.

### Description
- Подправлены параметры в объекте `CAPTURED_FLAG_RING_STYLE` в `script.js`, чтобы слегка увеличить расстояние между кольцами, смягчить тон внешнего контура и чуть подправить толщины линий; логика выбора цвета внутреннего кольца не менялась.
- Конкретные изменения: `outerRadiusOffset: 0.9 → 1.1`, `outerStrokeColor: rgba(10,14,22,0.9) → rgba(24,29,38,0.84)`, `outerStrokeWidth: 0.8 → 1.05`, `innerStrokeWidth: 2.4 → 2.2`, `innerStrokeAlpha: 0.98 → 1`.
- Все параметры управления находятся в `CAPTURED_FLAG_RING_STYLE` (`script.js`), а место отрисовки двойного контура — блок `if(p.flagColor && !isPlaneFullyHiddenByInvisibility)` в том же файле, где сначала рисуется внешний нейтральный круг, затем внутренний цветной.
- Изменения сохраняют текущую цветовую логику (внутренний контур берётся из `p.flagColor`), не добавляют glow, пульсацию, тени или дополнительные декоративные элементы и не меняют общую геометрию существенно.

### Testing
- Выполнена синтаксическая проверка: `node --check script.js` — успешно.
- Собран и зафиксирован коммит с изменениями (статус репозитория после коммита — чистый).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1df608ac832d9c8a1673bb017403)