### PR TITLE
Disable forced pre-launch inventory spending to prevent AI stalls

### DIFF
--- a/script.js
+++ b/script.js
@@ -25704,12 +25704,14 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
     }
   }
 
+  const allowForcedInventorySpend = options?.allowForcedInventorySpend === true;
+
   if(filteredCandidates.length === 0){
     logPreLaunchItemDecision("inventory_prelaunch_no_allowed_items", {
       reason: "no_step5_items_selected",
       selectedCandidateType: selectedInventoryCandidate?.itemType || null,
       selectedSequence: selectedInventorySequence.map((entry) => entry.itemType),
-      fallbackMode: "forced_inventory_spend_enabled",
+      fallbackMode: allowForcedInventorySpend ? "forced_inventory_spend_enabled" : "forced_inventory_spend_disabled",
     });
   }
 
@@ -25718,10 +25720,10 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
   const skippedItems = [];
   const primaryCandidates = filteredCandidates.length > 0
     ? filteredCandidates
-    : buildForcedInventoryFallbackCandidates(new Set());
+    : (allowForcedInventorySpend ? buildForcedInventoryFallbackCandidates(new Set()) : []);
   tryApplyCandidates(primaryCandidates, appliedItemTypes, appliedReasonCodes, skippedItems);
 
-  if(appliedItemTypes.length === 0){
+  if(appliedItemTypes.length === 0 && allowForcedInventorySpend){
     const excludedItemTypes = new Set(primaryCandidates.map((candidate) => candidate?.itemType).filter(Boolean));
     const forcedFallbackCandidates = buildForcedInventoryFallbackCandidates(excludedItemTypes);
     if(forcedFallbackCandidates.length > 0){
@@ -26370,6 +26372,7 @@ function issueAIMoveWithInventoryUsage(context, plannedMove){
 
   let actionUsed = false;
   const actionBeforeState = beforeInventoryState;
+  const allowHardForceInventorySpend = false;
   function forceUseAnyInventoryItemNow(){
     const counts = evaluateBlueInventoryState()?.counts || {};
     const plane = plannedMove?.plane || null;
@@ -26447,7 +26450,7 @@ function issueAIMoveWithInventoryUsage(context, plannedMove){
     inventoryStopReason = "inventory_selector_exception_handled";
   }
 
-  if(!actionUsed && Number(actionBeforeState?.total ?? 0) > 0){
+  if(allowHardForceInventorySpend && !actionUsed && Number(actionBeforeState?.total ?? 0) > 0){
     const hardForceResult = forceUseAnyInventoryItemNow();
     if(hardForceResult.used){
       actionUsed = true;


### PR DESCRIPTION
### Motivation
- Recent behavior caused the AI to stall or appear to hang by attempting to forcibly spend inventory items when normal candidate selection failed. 
- The goal is to avoid unnecessary forced inventory fallback and hard-force spending paths that delay or block launch flow.

### Description
- Added an `options.allowForcedInventorySpend` flag to `maybeUseInventoryBeforeLaunch` and changed the fallback path so forced inventory candidates are used only when this flag is explicitly true. 
- Updated the prelaunch diagnostic `fallbackMode` to report whether forced fallback is enabled or disabled. 
- Prevented the hard-force emergency spend path by introducing `allowHardForceInventorySpend = false` in `issueAIMoveWithInventoryUsage`, so the last-resort automatic spending branch is disabled by default. 
- Adjusted the primary candidate building logic so it returns an empty fallback candidate list when forced spend is not allowed.

### Testing
- Ran `node --check script.js` to verify there are no syntax errors and it passed. 
- Attempted `node scripts/smoke-mine-segment-hit-large-step.js`, which failed due to an existing `SyntaxError` in the harness unrelated to this change. 
- Attempted `node scripts/smoke-shield-immediate-rehit.js`, which failed in the smoke harness due to an undefined helper (`dropActiveFlagFromPlane`) and is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3820dc3f4832d8e40035ff5ae1a7b)