### PR TITLE
Fix AI launch blocker by implementing registerAiInventoryUsageAfterMove

### DIFF
--- a/script.js
+++ b/script.js
@@ -18288,6 +18288,29 @@ function createInitialAiRoundState(){
   };
 }
 
+function registerAiInventoryUsageAfterMove(itemWasUsed){
+  if(!aiRoundState || typeof aiRoundState !== "object"){
+    return;
+  }
+
+  const usedInventoryItem = itemWasUsed === true;
+  const nextIdleTurns = usedInventoryItem
+    ? 0
+    : Math.max(0, Number.isFinite(aiRoundState.inventoryIdleTurns)
+      ? Math.trunc(aiRoundState.inventoryIdleTurns) + 1
+      : 1);
+
+  aiRoundState.inventoryIdleTurns = nextIdleTurns;
+  aiRoundState.lastInventorySoftFallbackUsed = usedInventoryItem;
+  aiRoundState.inventorySoftFallbackCooldown = usedInventoryItem
+    ? Math.max(0, Number.isFinite(aiRoundState.inventorySoftFallbackCooldown)
+      ? Math.trunc(aiRoundState.inventorySoftFallbackCooldown)
+      : 0)
+    : Math.max(0, (Number.isFinite(aiRoundState.inventorySoftFallbackCooldown)
+      ? Math.trunc(aiRoundState.inventorySoftFallbackCooldown)
+      : 0) - 1);
+}
+
 function clampAiAllowedMoveRisk(rawRisk){
   if(!Number.isFinite(rawRisk)) return 0.7;
   return Math.max(0.2, Math.min(0.95, rawRisk));


### PR DESCRIPTION
### Motivation
- A missing function caused a `ReferenceError` during AI move finalization, which prevented the AI from completing its turn and produced cascade errors like `base_launch_execution_exception` and `inventory_recovery_finalize_exception`.
- Implementing a safe handler for inventory usage updates ensures the AI does not crash at the finalization/recovery stage and can proceed to attempt launches and fail-safe logic.

### Description
- Added `registerAiInventoryUsageAfterMove(itemWasUsed)` to `script.js` to safely update `aiRoundState.inventoryIdleTurns`, `aiRoundState.lastInventorySoftFallbackUsed`, and `aiRoundState.inventorySoftFallbackCooldown` when inventory usage is finalized.
- The function is defensive: it no-ops if `aiRoundState` is missing and normalizes numeric fields with `Number.isFinite` and `Math.trunc` to avoid throwing.
- The new function is inserted immediately after `createInitialAiRoundState()` so callers in finalization and recovery flows (e.g. post-inventory launch paths) now resolve without raising `ReferenceError`.

### Testing
- Ran static syntax check with `node --check /workspace/p-p-online/script.js`, which succeeded.
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e47afcc1a0832dbce1fd24e3e80bde)