### PR TITLE
Запретить повторное планирование ИИ во время активной сессии прицеливания

### DIFF
--- a/script.js
+++ b/script.js
@@ -14195,6 +14195,9 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
   ){
     return { ok: false, reasonCode: "ai_not_applicable_for_current_turn" };
   }
+  if(aiLaunchSession){
+    return { ok: false, reasonCode: "ai_launch_session_active" };
+  }
   if(aiMoveScheduled){
     return { ok: false, reasonCode: "ai_move_already_scheduled" };
   }
@@ -38320,6 +38323,7 @@ function gameDraw(){
     gameMode === "computer"
     && turnColors?.[turnIndex] === "blue"
     && flyingPoints.length === 0
+    && !aiLaunchSession
     && !aiMoveScheduled
   ){
     scheduleComputerMoveWithCargoGate(performance.now(), AI_MOVE_CARGO_RETRY_DELAY_MS, {


### PR DESCRIPTION
### Motivation
- Исправить визуальный баг, когда ИИ в процессе «человеческого» прицеливания успевал запустить повторное планирование и начать натягивать прицел другим самолётом в том же ходу.
- Нужно гарантировать: один ход = одна последовательность прицеливания → один выстрел, без сторонних перехватов планировщиком.

### Description
- Добавлена проверка в `scheduleComputerMoveWithCargoGate(...)`, которая возвращает `{ ok: false, reasonCode: "ai_launch_session_active" }`, если `aiLaunchSession` уже существует, чтобы не ставить новую задачу планирования поверх активной сессии.
- Добавлен тот же защитный флаг в автозапуске внутри игрового цикла (`gameDraw()`): перед повторным вызовом `scheduleComputerMoveWithCargoGate` теперь также проверяется `!aiLaunchSession`.
- Изменения затронули `script.js` и блокируют повторное планирование в двух точках — при явном планировании и в recovery-пути авто-расписателя, предотвращая двойное прицеливание.

### Testing
- Прогон проверки синтаксиса JavaScript: `node --check script.js` — успешно (без ошибок).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b668a1dc832dae1cb163f4cb8d65)