### PR TITLE
Skip redundant inventory planning and gate noisy AI debug events

### DIFF
--- a/script.js
+++ b/script.js
@@ -17610,11 +17610,15 @@ const AI_DECISION_DEBUG_EVENT_FLAGS = Object.freeze({
   fallback_safe_angle_candidate_scored: "candidateScoring",
   fallback_attack_candidate_scored: "candidateScoring",
   final_compared: "candidateScoring",
+  inventory_candidate_generated: "candidateScoring",
+  inventory_candidate_rejected: "candidateScoring",
   fallback_replan_candidate_missing: "fallbackReplan",
   fallback_replan_candidate_invalid: "fallbackReplan",
   fallback_replan_execution_started: "fallbackReplan",
   fallback_replan_execution_committed: "fallbackReplan",
   stale_target_replanned: "fallbackReplan",
+  narrow_corridor_evaluation: "narrowCorridor",
+  detour_angle_selected: "narrowCorridor",
   narrow_corridor_phase_started: "narrowCorridor",
   narrow_corridor_rejected: "narrowCorridor",
   narrow_corridor_selected: "narrowCorridor",
@@ -33156,6 +33160,9 @@ function runInventoryRouteOpeningBeforeFallback(modeContext = {}, chosenGoal = n
   let bestPlan = null;
   for(const seedMove of moveSeeds){
     const baseValidation = validateAiLaunchMoveCandidate(seedMove);
+    if(baseValidation?.ok){
+      continue;
+    }
     const inventoryPlanning = buildAiInventoryCandidatePlans(modeContext, seedMove);
     const selectedInventoryCandidate = inventoryPlanning?.selectedCandidate || null;
     const selectedInventorySequence = Array.isArray(inventoryPlanning?.selectedSequence)


### PR DESCRIPTION
### Motivation

- The inventory route-opening probe was running expensive item-planning for every seed including seeds that were already valid, which produced unnecessary CPU work and caused multi-second turn delays.
- Several high-volume AI decision logs were always-on and flooded the console, making diagnosis harder and adding runtime overhead.

### Description

- In `runInventoryRouteOpeningBeforeFallback` added an early `continue` when `validateAiLaunchMoveCandidate(seedMove).ok` is true to avoid running `buildAiInventoryCandidatePlans` for already-valid seeds (`script.js`).
- Moved high-volume reasons (`inventory_candidate_generated`, `inventory_candidate_rejected`, `narrow_corridor_evaluation`, `detour_angle_selected`) into the `AI_DECISION_DEBUG_EVENT_FLAGS` mapping so these events are gated by debug flags and are off by default (`script.js`).
- Small cleanup to reduce noisy console churn and focus inventory probing on cases that could actually become valid after item usage.

### Testing

- Ran `node --check script.js` to validate syntax and static correctness; the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ebd9370c832db748b18eebffb85c)