### PR TITLE
Prevent AI from soft-passing through its own mines

### DIFF
--- a/script.js
+++ b/script.js
@@ -25958,6 +25958,33 @@ function getFinalAiLaunchMineThreatCheck(plannedMove){
     landingPoint.y,
     plane,
   );
+  const ownMineThreatMeta = plane?.color
+    ? getMineThreatMetaForSegment(
+        startPoint.x,
+        startPoint.y,
+        landingPoint.x,
+        landingPoint.y,
+        plane,
+        { mineOwner: plane.color },
+      )
+    : null;
+  const blockedByOwnMine = Boolean(ownMineThreatMeta?.pathHit || ownMineThreatMeta?.landingThreat);
+  if(blockedByOwnMine){
+    return {
+      ok: false,
+      reason: "path_crosses_own_mine",
+      reasonCode: "final_mine_check_rejected_own_mine",
+      threatClass: "critical_self_mine",
+      ownMineThreat: true,
+      threatMeta: {
+        ...(threatMeta || {}),
+        ownMineThreatMeta,
+      },
+      startPoint,
+      landingPoint,
+      message: "Launch path intersects own mine danger zone.",
+    };
+  }
   const blocked = Boolean(threatMeta?.pathHit || threatMeta?.landingThreat);
   if(blocked){
     return {
@@ -25965,6 +25992,7 @@ function getFinalAiLaunchMineThreatCheck(plannedMove){
       reason: "path_crosses_mine",
       reasonCode: "final_mine_check_rejected_stale_route",
       threatClass: "critical_forbidden",
+      ownMineThreat: false,
       threatMeta,
       startPoint,
       landingPoint,
@@ -25976,6 +26004,7 @@ function getFinalAiLaunchMineThreatCheck(plannedMove){
     ok: true,
     reasonCode: "final_mine_check_clear",
     threatClass: "clear",
+    ownMineThreat: false,
     threatMeta,
     startPoint,
     landingPoint,
@@ -26065,6 +26094,7 @@ function resolveFinalAiLaunchMoveWithMineGate(plannedMove, context = {}, options
     && gateResult?.threatMeta?.pathHit
   );
   const canSoftPassModerateRisk = !clearlyLethalCrossing
+    && gateResult?.ownMineThreat !== true
     && gateResult?.threatClass === "critical_forbidden"
     && mineGateRiskScore <= allowedMoveRisk
     && progressToGoalMeta.hasProgress === true;


### PR DESCRIPTION
### Motivation
- The AI could occasionally place a mine and then accept a launch that passed through that same mine because the final mine-gate check did not distinguish own vs enemy mines, and a moderate-risk "soft-pass" path could still be allowed.
- This change hardens the final launch validation so that a route intersecting the plane's own mine is treated as a hard rejection rather than eligible for soft-pass heuristics.

### Description
- Added an explicit own-mine probe in `getFinalAiLaunchMineThreatCheck` by calling `getMineThreatMetaForSegment(..., { mineOwner: plane.color })` and detecting `pathHit`/`landingThreat` for the plane's own mines.
- When an own-mine threat is found the gate now returns a dedicated failure with `reason: "path_crosses_own_mine"`, `reasonCode: "final_mine_check_rejected_own_mine"`, `threatClass: "critical_self_mine"` and `ownMineThreat: true`, and includes the own-mine meta in the `threatMeta` payload.
- Existing enemy/neutral mine handling is preserved and other gate results include `ownMineThreat: false` for clarity.
- Updated `resolveFinalAiLaunchMoveWithMineGate` soft-pass logic to explicitly block moderate-risk soft-passes when `gateResult.ownMineThreat === true` so the AI will not accept a move that crosses its own mine.

### Testing
- Ran static syntax check `node --check script.js`, which passed successfully.
- Verified basic commit; no additional automated unit tests exist for this flow in the repository, so behavioral validation should be performed in runtime scenarios (AI placing a mine then attempting launch) during integration testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4fde77554832daacc85ee9a84fc4a)