### PR TITLE
Add unified forced non-skip AI fallback path

### DIFF
--- a/script.js
+++ b/script.js
@@ -14206,13 +14206,8 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       if(!isPlaneLaunchStateReady(plane)) return false;
       return !flyingPoints.some((fp) => fp.plane === plane);
     });
-
-    if(!launchReadyPlanes.length){
-      aiMoveScheduled = false;
-      advanceTurn();
-      return;
-    }
     const enemyPlanes = points.filter((plane) => plane?.color === "green" && isPlaneTargetable(plane));
+
     const readyCargo = cargoState.filter((cargo) => cargo?.state === "ready");
     const aiExecutionContext = {
       aiPlanes: launchReadyPlanes,
@@ -14314,6 +14309,78 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       }
       return null;
     };
+
+    const runForcedNonSkipLastChance = (reasonSuffix, options = {}) => {
+      const reasonCode = `forced_non_skip_last_chance_${reasonSuffix || "unknown"}`;
+      const candidatePlanes = Array.isArray(options?.candidatePlanes)
+        ? options.candidatePlanes.filter(Boolean)
+        : launchReadyPlanes.filter(Boolean);
+      const guaranteedMove = candidatePlanes
+        .map((plane) => buildGuaranteedAdvanceMove(plane))
+        .find(Boolean);
+
+      if(guaranteedMove){
+        const guaranteedLaunchResult = tryIssueAiMoveWithInventory({
+          plane: guaranteedMove.plane,
+          landingX: guaranteedMove.landingX,
+          landingY: guaranteedMove.landingY,
+          goalName: guaranteedMove.goalName || "simple_step2_guaranteed_advance",
+          decisionReason: guaranteedMove.decisionReason || "simple_step2_guaranteed_advance",
+          whyChosen: guaranteedMove.whyChosen || "forced_non_skip_last_chance_guaranteed_move",
+          routeClass: guaranteedMove.routeClass || "direct",
+        }, "simple_step2_selector_forced_non_skip_last_chance");
+        if(guaranteedLaunchResult?.ok){
+          aiMoveScheduled = false;
+          logAiDecision("simple_step2_forced_non_skip_last_chance_success", {
+            reasonCode,
+            strategy: "guaranteed_advance",
+            planeId: guaranteedMove?.plane?.id ?? null,
+          });
+          return { ok: true, reasonCode };
+        }
+      }
+
+      const mandatoryMove = getMandatoryTurnMove({
+        aiPlanes: candidatePlanes,
+        enemies: enemyPlanes,
+      });
+      if(mandatoryMove && mandatoryMove.plane && Number.isFinite(mandatoryMove.vx) && Number.isFinite(mandatoryMove.vy)){
+        const mandatoryDurationSec = Number.isFinite(FIELD_FLIGHT_DURATION_SEC) && FIELD_FLIGHT_DURATION_SEC > 0
+          ? FIELD_FLIGHT_DURATION_SEC
+          : 1;
+        const mandatoryLaunchResult = tryIssueAiMoveWithInventory({
+          plane: mandatoryMove.plane,
+          landingX: mandatoryMove.plane.x + mandatoryMove.vx * mandatoryDurationSec,
+          landingY: mandatoryMove.plane.y + mandatoryMove.vy * mandatoryDurationSec,
+          goalName: mandatoryMove.goalName || "simple_step2_mandatory_move",
+          decisionReason: mandatoryMove.decisionReason || "simple_step2_mandatory_move",
+          whyChosen: "forced_non_skip_last_chance_mandatory_move",
+          routeClass: mandatoryMove.routeClass || "direct",
+        }, "simple_step2_selector_forced_non_skip_last_chance_mandatory");
+        if(mandatoryLaunchResult?.ok){
+          aiMoveScheduled = false;
+          logAiDecision("simple_step2_forced_non_skip_last_chance_success", {
+            reasonCode,
+            strategy: "mandatory_turn_move",
+            planeId: mandatoryMove?.plane?.id ?? null,
+          });
+          return { ok: true, reasonCode };
+        }
+      }
+
+      aiMoveScheduled = false;
+      logAiDecision("simple_step2_forced_non_skip_last_chance_failed", {
+        reasonCode,
+        candidatePlaneIds: candidatePlanes.map((plane) => plane?.id ?? null),
+      });
+      advanceTurn();
+      return { ok: false, reasonCode };
+    };
+
+    if(!launchReadyPlanes.length){
+      runForcedNonSkipLastChance("no_launch_ready_planes", { candidatePlanes: launchReadyPlanes });
+      return;
+    }
 
     const scoredPlans = [];
     for(const launchReadyPlane of launchReadyPlanes){
@@ -14422,38 +14489,13 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
     }
 
     if(!selectedPlan){
-      const mandatoryMove = getMandatoryTurnMove({
-        aiPlanes: launchReadyPlanes,
-        enemies: enemyPlanes,
-      });
-      if(mandatoryMove && mandatoryMove.plane && Number.isFinite(mandatoryMove.vx) && Number.isFinite(mandatoryMove.vy)){
-        const emergencyDurationSec = Number.isFinite(FIELD_FLIGHT_DURATION_SEC) && FIELD_FLIGHT_DURATION_SEC > 0
-          ? FIELD_FLIGHT_DURATION_SEC
-          : 1;
-        const emergencyLaunchResult = tryIssueAiMoveWithInventory({
-          plane: mandatoryMove.plane,
-          landingX: mandatoryMove.plane.x + mandatoryMove.vx * emergencyDurationSec,
-          landingY: mandatoryMove.plane.y + mandatoryMove.vy * emergencyDurationSec,
-          goalName: mandatoryMove.goalName || "simple_step2_mandatory_move",
-          decisionReason: mandatoryMove.decisionReason || "simple_step2_mandatory_move",
-          whyChosen: "mandatory_non_skip_fallback",
-          routeClass: mandatoryMove.routeClass || "direct",
-        }, "simple_step2_selector_mandatory");
-        aiMoveScheduled = false;
-        if(!emergencyLaunchResult?.ok){
-          advanceTurn();
-        }
-        return;
-      }
-      aiMoveScheduled = false;
-      advanceTurn();
+      runForcedNonSkipLastChance("no_selected_plan");
       return;
     }
 
     const launchReadyPlane = selectedPlan.plane;
     if(!launchReadyPlane){
-      aiMoveScheduled = false;
-      advanceTurn();
+      runForcedNonSkipLastChance("selected_plan_without_plane");
       return;
     }
 
@@ -14475,8 +14517,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
     }
 
     if(!selectedPlan || !Number.isFinite(selectedPlan.landingX) || !Number.isFinite(selectedPlan.landingY)){
-      aiMoveScheduled = false;
-      advanceTurn();
+      runForcedNonSkipLastChance("selected_plan_invalid_coordinates");
       return;
     }
 
@@ -14525,7 +14566,9 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
 
     aiMoveScheduled = false;
     if(!launchResult?.ok){
-      advanceTurn();
+      runForcedNonSkipLastChance("launch_result_not_ok", {
+        candidatePlanes: launchReadyPlanes,
+      });
     }
     return;
   }, safeDelayMs);

--- a/scripts/smoke-ai-forced-non-skip-last-chance.js
+++ b/scripts/smoke-ai-forced-non-skip-last-chance.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const vm = require('vm');
+
+function extractFunctionSource(source, fnName){
+  const signature = `function ${fnName}(`;
+  const start = source.indexOf(signature);
+  if(start === -1) throw new Error(`Function not found in script.js: ${fnName}`);
+  const signatureEnd = source.indexOf(')', start);
+  const bodyStart = source.indexOf('{', signatureEnd);
+  let depth = 0;
+  for(let i = bodyStart; i < source.length; i += 1){
+    const ch = source[i];
+    if(ch === '{') depth += 1;
+    if(ch === '}') depth -= 1;
+    if(depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`Function body end not found for: ${fnName}`);
+}
+
+function assert(condition, message){
+  if(!condition) throw new Error(message);
+}
+
+function buildContext(overrides = {}){
+  const aiLogs = [];
+  let advanceTurnCount = 0;
+  const context = {
+    Math,
+    Number,
+    Boolean,
+    Array,
+    JSON,
+    performance: { now: () => 0 },
+    AI_MOVE_INITIAL_DELAY_MS: 0,
+    AI_MOVE_CARGO_RETRY_DELAY_MS: 0,
+    FIELD_FLIGHT_DURATION_SEC: 1,
+    CELL_SIZE: 10,
+    FIELD_TOP: 0,
+    FIELD_HEIGHT: 100,
+    isGameOver: false,
+    gameMode: 'computer',
+    turnColors: ['blue'],
+    turnIndex: 0,
+    aiLaunchSession: null,
+    aiMoveScheduled: false,
+    points: [],
+    flyingPoints: [],
+    cargoState: [],
+    settings: { flagsMode: false },
+    markAiTurnStarted: () => {},
+    hasAnimatingCargo: () => false,
+    getBaseAnchor: () => ({ x: 0, y: 0 }),
+    getAvailableFlagsByColor: () => [],
+    isPlaneLaunchStateReady: () => true,
+    isPlaneTargetable: () => true,
+    getAiFlightRangeProfile: () => ({ flightDistancePx: 30 }),
+    getEffectiveFlightRangeCells: () => 3,
+    getCargoVisualCenter: (cargo) => ({ x: cargo.x || 0, y: cargo.y || 0 }),
+    dist: (a, b) => Math.hypot((a?.x || 0) - (b?.x || 0), (a?.y || 0) - (b?.y || 0)),
+    getNearestPointInCenterControlZone: () => ({ x: 0, y: 60 }),
+    getNearestReachableCenterControlPoint: () => null,
+    isPathClear: () => true,
+    getMandatoryTurnMove: () => null,
+    issueAIMoveFromDoComputerMove: () => ({ selected: true, reason: 'ok' }),
+    get advanceTurnCount(){
+      return advanceTurnCount;
+    },
+    advanceTurn(){
+      advanceTurnCount += 1;
+    },
+    aiLogs,
+    logAiDecision(stage, payload){
+      aiLogs.push({ stage, payload });
+    },
+    setTimeout(fn){ fn(); return 1; },
+    ...overrides,
+  };
+  vm.createContext(context);
+  return context;
+}
+
+const source = fs.readFileSync('script.js', 'utf8');
+const scheduleSrc = extractFunctionSource(source, 'scheduleComputerMoveWithCargoGate');
+
+(function runNoSelectedPlanScenario(){
+  const plane = { id: 'blue-1', color: 'blue', x: 10, y: 10 };
+  const calls = [];
+  const context = buildContext({
+    points: [plane],
+    isPathClear: () => false,
+    getMandatoryTurnMove: ({ aiPlanes }) => ({
+      plane: aiPlanes[0],
+      vx: 2,
+      vy: 0,
+      goalName: 'forced_mandatory',
+      decisionReason: 'forced_mandatory',
+      routeClass: 'direct',
+    }),
+    issueAIMoveFromDoComputerMove: (_ctx, _plannedMove, meta) => {
+      calls.push(meta?.source || null);
+      if((meta?.source || '').includes('forced_non_skip_last_chance_mandatory')){
+        return { selected: true, reason: 'forced_ok' };
+      }
+      return { selected: false, reason: 'blocked' };
+    },
+  });
+
+  vm.runInContext(scheduleSrc, context);
+  context.scheduleComputerMoveWithCargoGate();
+
+  assert(calls.some((sourceName) => sourceName && sourceName.includes('forced_non_skip_last_chance_mandatory')), 'Expected mandatory forced-non-skip source call when no selected plan exists.');
+  assert(context.advanceTurnCount === 0, 'Expected no immediate advanceTurn when mandatory forced fallback succeeds.');
+  assert(
+    context.aiLogs.some((entry) => entry?.payload?.reasonCode === 'forced_non_skip_last_chance_no_selected_plan'),
+    'Expected forced_non_skip_last_chance_no_selected_plan reasonCode in AI logs.'
+  );
+})();
+
+(function runLaunchFailureScenario(){
+  const plane = { id: 'blue-2', color: 'blue', x: 10, y: 10 };
+  const calls = [];
+  const context = buildContext({
+    points: [plane],
+    issueAIMoveFromDoComputerMove: (_ctx, _plannedMove, meta) => {
+      const sourceName = meta?.source || null;
+      calls.push(sourceName);
+      if(sourceName === 'simple_step2_selector'){
+        return { selected: false, reason: 'primary_reject' };
+      }
+      if(sourceName === 'simple_step2_selector_forced_non_skip_last_chance'){
+        return { selected: true, reason: 'forced_guaranteed_ok' };
+      }
+      return { selected: false, reason: 'reject' };
+    },
+  });
+
+  vm.runInContext(scheduleSrc, context);
+  context.scheduleComputerMoveWithCargoGate();
+
+  assert(calls.includes('simple_step2_selector'), 'Expected primary selector launch attempt.');
+  assert(calls.includes('simple_step2_selector_forced_non_skip_last_chance'), 'Expected forced non-skip launch attempt after launch failure.');
+  assert(context.advanceTurnCount === 0, 'Expected no advanceTurn when forced non-skip fallback succeeds after launch failure.');
+  assert(
+    context.aiLogs.some((entry) => entry?.payload?.reasonCode === 'forced_non_skip_last_chance_launch_result_not_ok'),
+    'Expected forced_non_skip_last_chance_launch_result_not_ok reasonCode in AI logs.'
+  );
+})();
+
+console.log('Smoke test passed: scheduleComputerMoveWithCargoGate uses forced non-skip last chance before advanceTurn.');


### PR DESCRIPTION
### Motivation
- Устранить поведение, когда ИИ в ряде неуспешных веток сразу вызывал `advanceTurn()` и пропускал ход без попытки сделать гарантированный минимальный ход. 
- Свести к одному месту логику «последней попытки», чтобы избежать дублирования и обеспечить одинаковую диагностику в логах. 
- Сделать поведение ИИ более предсказуемым и записываемым в логах через понятные `reasonCode` метки.

### Description
- Добавлен общий helper `runForcedNonSkipLastChance(reasonSuffix, options)` внутри `scheduleComputerMoveWithCargoGate`, который последовательно пытает: 1) гарантированный минимальный ход (`buildGuaranteedAdvanceMove`), 2) обязательный ход (`getMandatoryTurnMove` + `tryIssueAiMoveWithInventory`), и только после неудачи вызывает `advanceTurn()` с диагностикой. 
- Вызовы прямого `advanceTurn()` в ветках заменены на единый helper для следующих случаев: нет готовых самолётов, нет выбранного плана, выбран план без самолёта, невалидные координаты плана, и неуспешный результат запуска. 
- Добавлены диагностические `reasonCode` в формате `forced_non_skip_last_chance_*` и логирование успехов/провалов через существующую `logAiDecision`. 
- Добавлен smoke-скрипт `scripts/smoke-ai-forced-non-skip-last-chance.js`, покрывающий сценарии "no selected plan" и "launch failure" и проверяющий, что перед `advanceTurn()` происходит forced-попытка с ожидаемыми источниками запуска.

### Testing
- Запущен новый smoke-тест: `node scripts/smoke-ai-forced-non-skip-last-chance.js`, который прошёл успешно. 
- Локально проверено, что прежние точки вызова `advanceTurn()` теперь делегируют в `runForcedNonSkipLastChance` и что соответствующие `reasonCode` попадают в логи.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4fe657d00832dbbc2b03d372e8d62)