### PR TITLE
Увеличить лимит pinch-zoom и добавить выход из зума по игровому вводу

### DIFF
--- a/script.js
+++ b/script.js
@@ -42262,7 +42262,7 @@ let pinchScale = 1;
 let pinchResetTimer = null;
 const PINCH_RESET_MS = 4000;
 const PINCH_MIN = 1;
-const PINCH_MAX = 2.2;
+const PINCH_MAX = 8;
 if (typeof window !== 'undefined') {
   window.PINCH_ACTIVE = pinchActive;
 }
@@ -42315,6 +42315,31 @@ window.addEventListener('wheel', (event) => {
     resetPinchState();
   }
 }, { capture: true });
+
+
+function isZoomExitTarget(target) {
+  if (!(target instanceof Element)) return false;
+  if (uiFrameEl instanceof HTMLElement && uiFrameEl.contains(target)) return true;
+  if (uiFrameInner instanceof HTMLElement && uiFrameInner.contains(target)) return true;
+  if (target.closest?.('#gameCanvas, #aimCanvas, #planeCanvas, #hudCanvas, #uiFrame')) return true;
+  return false;
+}
+
+function installPinchExitOnGameplayInput() {
+  const exitZoom = (event) => {
+    if (!isPinchActive()) return;
+    if (!isZoomExitTarget(event.target)) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    resetPinchState();
+  };
+
+  window.addEventListener('pointerdown', exitZoom, { capture: true, passive: false });
+  window.addEventListener('touchstart', exitZoom, { capture: true, passive: false });
+  window.addEventListener('mousedown', exitZoom, { capture: true, passive: false });
+}
+
+installPinchExitOnGameplayInput();
 
 window.addEventListener('wheel', (event) => {
   if (event.ctrlKey !== true) return;

--- a/settings.js
+++ b/settings.js
@@ -67,7 +67,7 @@ let pinchScale = 1;
 let pinchResetTimer = null;
 const PINCH_RESET_MS = 4000;
 const PINCH_MIN = 1;
-const PINCH_MAX = 2.2;
+const PINCH_MAX = 8;
 if (typeof window !== 'undefined') {
   window.PINCH_ACTIVE = pinchActive;
 }
@@ -117,6 +117,31 @@ window.addEventListener('wheel', (event) => {
     resetPinchState();
   }
 }, { capture: true });
+
+
+function isZoomExitTarget(target) {
+  if (!(target instanceof Element)) return false;
+  if (uiFrameEl instanceof HTMLElement && uiFrameEl.contains(target)) return true;
+  if (uiFrameInner instanceof HTMLElement && uiFrameInner.contains(target)) return true;
+  if (target.closest?.('#gameCanvas, #aimCanvas, #planeCanvas, #hudCanvas, #uiFrame')) return true;
+  return false;
+}
+
+function installPinchExitOnGameplayInput() {
+  const exitZoom = (event) => {
+    if (!isPinchActive()) return;
+    if (!isZoomExitTarget(event.target)) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    resetPinchState();
+  };
+
+  window.addEventListener('pointerdown', exitZoom, { capture: true, passive: false });
+  window.addEventListener('touchstart', exitZoom, { capture: true, passive: false });
+  window.addEventListener('mousedown', exitZoom, { capture: true, passive: false });
+}
+
+installPinchExitOnGameplayInput();
 
 window.addEventListener('wheel', (event) => {
   if (event.ctrlKey !== true) return;


### PR DESCRIPTION
### Motivation
- Игроки не могли удобно «подойти» ближе к полю: прежний потолок зума был слишком мал и создавал ощущение «одного приближения». 
- При приближении нежелательно, чтобы первый тап по игровой области сразу выполнял выстрел, поэтому нужен явный выход из зума перед игровым действием.

### Description
- Увеличен максимум масштабирования pinch-zoom с `2.2` до `8` в `script.js` и `settings.js`, чтобы позволить глубже приблизить поле (`PINCH_MAX` = 8). 
- Добавлена функция `isZoomExitTarget(target)` в `script.js` и `settings.js`, которая определяет, является ли цель события областью игры (канвасы / UI-фрейм). 
- Добавлена функция `installPinchExitOnGameplayInput()` и вызов установки слушателей, которая вешает `pointerdown`, `touchstart` и `mousedown` (с `{ capture: true, passive: false }`) и при активном зуме вызывает `resetPinchState()` и `event.preventDefault()` + `event.stopImmediatePropagation()` чтобы тот же тап не прошёл дальше и не стал выстрелом. 
- Изменения применены синхронно в обоих файлах (`script.js` и `settings.js`) для согласованного поведения между игровым кодом и настройками интерфейса.

### Testing
- Проверка синтаксиса: `node --check script.js` — успешно.
- Проверка синтаксиса: `node --check settings.js` — успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5018877a4832d87c6747216d12d48)