### PR TITLE
Detect and forbid AI launches that cross own mines; adjust mine-gate and inventory fallback handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -25958,6 +25958,33 @@ function getFinalAiLaunchMineThreatCheck(plannedMove){
     landingPoint.y,
     plane,
   );
+  const ownMineThreatMeta = plane?.color
+    ? getMineThreatMetaForSegment(
+        startPoint.x,
+        startPoint.y,
+        landingPoint.x,
+        landingPoint.y,
+        plane,
+        { mineOwner: plane.color },
+      )
+    : null;
+  const blockedByOwnMine = Boolean(ownMineThreatMeta?.pathHit || ownMineThreatMeta?.landingThreat);
+  if(blockedByOwnMine){
+    return {
+      ok: false,
+      reason: "path_crosses_own_mine",
+      reasonCode: "final_mine_check_rejected_own_mine",
+      threatClass: "critical_self_mine",
+      ownMineThreat: true,
+      threatMeta: {
+        ...(threatMeta || {}),
+        ownMineThreatMeta,
+      },
+      startPoint,
+      landingPoint,
+      message: "Launch path intersects own mine danger zone.",
+    };
+  }
   const blocked = Boolean(threatMeta?.pathHit || threatMeta?.landingThreat);
   if(blocked){
     return {
@@ -25965,6 +25992,7 @@ function getFinalAiLaunchMineThreatCheck(plannedMove){
       reason: "path_crosses_mine",
       reasonCode: "final_mine_check_rejected_stale_route",
       threatClass: "critical_forbidden",
+      ownMineThreat: false,
       threatMeta,
       startPoint,
       landingPoint,
@@ -25976,6 +26004,7 @@ function getFinalAiLaunchMineThreatCheck(plannedMove){
     ok: true,
     reasonCode: "final_mine_check_clear",
     threatClass: "clear",
+    ownMineThreat: false,
     threatMeta,
     startPoint,
     landingPoint,
@@ -26065,6 +26094,7 @@ function resolveFinalAiLaunchMoveWithMineGate(plannedMove, context = {}, options
     && gateResult?.threatMeta?.pathHit
   );
   const canSoftPassModerateRisk = !clearlyLethalCrossing
+    && gateResult?.ownMineThreat !== true
     && gateResult?.threatClass === "critical_forbidden"
     && mineGateRiskScore <= allowedMoveRisk
     && progressToGoalMeta.hasProgress === true;
@@ -26739,7 +26769,9 @@ function issueAIMoveWithInventoryUsage(context, plannedMove){
         const gateRejectReason = finalMoveResolution?.gateResult?.reason || null;
         const gateReasonCode = finalMoveResolution?.reasonCode || null;
         const blockedByMineAfterInventory = gateRejectReason === "path_crosses_mine"
-          || gateReasonCode === "final_mine_check_rejected_stale_route";
+          || gateRejectReason === "path_crosses_own_mine"
+          || gateReasonCode === "final_mine_check_rejected_stale_route"
+          || gateReasonCode === "final_mine_check_rejected_own_mine";
 
         if(blockedByMineAfterInventory){
           const safeAlternatives = [


### PR DESCRIPTION
### Motivation
- Prevent AI from planning or soft-passing launches that would intersect its own mines by detecting own-mine threat zones during final launch validation. 
- Ensure mine-gate soft-pass logic does not allow progress-through risk when the danger is from the AI's own mines. 
- Make inventory/fallback logic respect rejections caused by own-mine intersections so safe alternatives are chosen instead. 

### Description
- In `getFinalAiLaunchMineThreatCheck` compute `ownMineThreatMeta` when `plane.color` is available and reject the move early with `reason: "path_crosses_own_mine"`, `reasonCode: "final_mine_check_rejected_own_mine"`, `threatClass: "critical_self_mine"`, and an `ownMineThreat` flag when the path or landing intersects an own mine. 
- Ensure existing blocked and clear return objects include `ownMineThreat: false` when appropriate. 
- In `resolveFinalAiLaunchMoveWithMineGate` prevent the moderate-risk soft-pass by checking `gateResult?.ownMineThreat !== true` before allowing a soft pass. 
- In `issueAIMoveWithInventoryUsage` include `path_crosses_own_mine` and `final_mine_check_rejected_own_mine` in the blocked-by-mine-after-inventory conditions so inventory usage rollbacks and fallback moves handle own-mine rejections correctly. 

### Testing
- Ran the unit test suite with `npm test` and all tests passed. 
- Ran the linter with `npm run lint` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4fde77554832daacc85ee9a84fc4a)