### PR TITLE
Fix Safari mobile viewport clipping by anchoring wrapper and frame centering

### DIFF
--- a/script.js
+++ b/script.js
@@ -42004,18 +42004,14 @@ function syncWrapperToVisualViewport() {
   const viewport = typeof window !== "undefined" ? window.visualViewport : null;
   const width = viewport && Number.isFinite(viewport.width) ? viewport.width : (window.innerWidth || 0);
   const height = viewport && Number.isFinite(viewport.height) ? viewport.height : (window.innerHeight || 0);
-  const offsetLeft = viewport && Number.isFinite(viewport.offsetLeft) ? viewport.offsetLeft : 0;
-  const offsetTop = viewport && Number.isFinite(viewport.offsetTop) ? viewport.offsetTop : 0;
-
-wrapperEl.style.position = 'fixed';
-wrapperEl.style.inset = 'auto';
-wrapperEl.style.right = 'auto';
-wrapperEl.style.bottom = 'auto';
-
-wrapperEl.style.left = `${offsetLeft}px`;
-wrapperEl.style.top = `${offsetTop}px`;
-wrapperEl.style.width = `${width}px`;
-wrapperEl.style.height = `${height}px`;
+  wrapperEl.style.position = 'fixed';
+  wrapperEl.style.inset = 'auto';
+  wrapperEl.style.right = 'auto';
+  wrapperEl.style.bottom = 'auto';
+  wrapperEl.style.left = '0px';
+  wrapperEl.style.top = '0px';
+  wrapperEl.style.width = `${width}px`;
+  wrapperEl.style.height = `${height}px`;
 
 
   if (DEBUG_WRAPPER_SYNC && !wrapperSyncDebugState.logged) {

--- a/styles.css
+++ b/styles.css
@@ -102,8 +102,8 @@ body, button {
 
 #uiFrame {
   position: relative;
-  left: 50vw;
-  top: 50vh;
+  left: 50%;
+  top: 50%;
   margin: 0;
   transform: translate(-50%, -50%) scale(var(--ui-scale));
   transform-origin: 50% 50%;


### PR DESCRIPTION
### Motivation
- Mobile Safari can report a shifted visual viewport (offsetTop/offsetLeft) when UI chrome shows/hides, which caused the game wrapper to move and the bottom of the game to be clipped while the top letterboxed. 
- Centering the UI frame using viewport-relative units (`50vw/50vh`) can misalign when the wrapper size differs from the layout viewport. 

### Description
- In `script.js`, `syncWrapperToVisualViewport()` now anchors `#screenWrapper` at top-left (`left: 0px; top: 0px`) and continues to size it to the visual viewport width/height, avoiding applying `visualViewport.offsetLeft/offsetTop` which produced unstable shifts on Safari. 
- In `styles.css`, `#uiFrame` centering was changed from `left: 50vw; top: 50vh;` to `left: 50%; top: 50%;` so the frame is centered relative to the wrapper box rather than the layout viewport. 
- These changes only adjust positioning/centering logic and do not alter canvas sizes, scaling algorithm, or game rendering logic. 

### Testing
- Ran `node --check script.js` and the file passed syntax check (success). 
- Ran `node --check settings.js` and the file passed syntax check (success). 
- Verified repository changes were recorded (`git show --stat` / commit created) (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5020c7848832d9325745a14356bfd)