### PR TITLE
Replace game background asset with paperwithred2

### DIFF
--- a/script.js
+++ b/script.js
@@ -5402,7 +5402,7 @@ const GAME_SCREEN_ASSETS = [
   ARCADE_RESPAWN_SHIELD_PATHS.green,
 
   // Game field background
-  "ui_gamescreen/paperwithred.png",
+  "ui_gamescreen/paperwithred2.png",
   "ui_gamescreen/gamescreen_outside/gs_background.png",
   "ui_gamescreen/gamescreen_outside/goat and sparrow.png",
 
@@ -8202,7 +8202,7 @@ function isSpriteReady(img) {
     img.naturalHeight > 0
   );
 }
-const { img: backgroundImg } = loadImageAsset("ui_gamescreen/paperwithred.png", GAME_PRELOAD_LABEL);
+const { img: backgroundImg } = loadImageAsset("ui_gamescreen/paperwithred2.png", GAME_PRELOAD_LABEL);
 backgroundImg?.addEventListener("load", () => {
   console.log("[IMG] load", { label: "backgroundImg", url: backgroundImg.src });
 });
@@ -15158,7 +15158,7 @@ function resetGame(options = {}){
 
   if (shouldShowMenu) {
     menuScreenLocked = false;
-    setBackgroundImage('ui_gamescreen/paperwithred.png');
+    setBackgroundImage('ui_gamescreen/paperwithred2.png');
     hideGameBackgroundForMenu();
   } else {
     restoreGameBackgroundAfterMenu();


### PR DESCRIPTION
### Motivation
- Ensure the game uses the new background image file by replacing references to the old asset name so background loading is consistent.

### Description
- Replaced all references to `ui_gamescreen/paperwithred.png` with `ui_gamescreen/paperwithred2.png` in `script.js`, updating the preload asset list entry, the `loadImageAsset` call, and the `setBackgroundImage` call.

### Testing
- No automated tests were run; the change is a path-only string replacement and was validated by searching for occurrences and reviewing the resulting diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c2e71498832db56ef45e02b873c3)