### PR TITLE
Add two-finger pan support for pinch zoom (touch and trackpad)

### DIFF
--- a/script.js
+++ b/script.js
@@ -42417,6 +42417,8 @@ function logLayoutMetrics(reason) {
 
 let pinchActive = false;
 let pinchScale = 1;
+let pinchPanX = 0;
+let pinchPanY = 0;
 let pinchResetTimer = null;
 const PINCH_RESET_MS = 4000;
 const PINCH_MIN = 1;
@@ -42436,6 +42438,11 @@ function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
 
+function applyPinchTransform() {
+  if (!(uiFrameInner instanceof HTMLElement)) return;
+  uiFrameInner.style.transform = `translate(${pinchPanX}px, ${pinchPanY}px) scale(${pinchScale})`;
+}
+
 function resetPinchState() {
   if (typeof window !== 'undefined') {
     window.PINCH_ACTIVE = false;
@@ -42446,8 +42453,10 @@ function resetPinchState() {
     pinchResetTimer = null;
   }
   pinchScale = 1;
+  pinchPanX = 0;
+  pinchPanY = 0;
   if (uiFrameInner instanceof HTMLElement) {
-    uiFrameInner.style.transform = "scale(1)";
+    applyPinchTransform();
     uiFrameInner.style.transformOrigin = "50% 50%";
   }
 }
@@ -42470,6 +42479,14 @@ window.addEventListener('gestureend', () => schedulePinchReset(), { capture: tru
 
 window.addEventListener('wheel', (event) => {
   if (pinchActive && event.ctrlKey !== true) {
+    if (pinchScale > PINCH_MIN) {
+      pinchPanX = pinchPanX - event.deltaX;
+      pinchPanY = pinchPanY - event.deltaY;
+      applyPinchTransform();
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
     resetPinchState();
   }
 }, { capture: true });
@@ -42503,7 +42520,11 @@ installPinchExitOnGameplayInput();
 const touchPinchState = {
   active: false,
   startDistance: 0,
-  startScale: 1
+  startScale: 1,
+  startCenterX: 0,
+  startCenterY: 0,
+  startPanX: 0,
+  startPanY: 0
 };
 
 function getTouchDistance(touchA, touchB) {
@@ -42522,6 +42543,13 @@ function getTouchCenterInPercents(touchA, touchB, rect) {
   return { originX, originY };
 }
 
+function getTouchCenterClient(touchA, touchB) {
+  return {
+    x: (touchA.clientX + touchB.clientX) / 2,
+    y: (touchA.clientY + touchB.clientY) / 2
+  };
+}
+
 function installTouchPinchZoom() {
   const onTouchStart = (event) => {
     if (!(uiFrameEl instanceof HTMLElement) || !(uiFrameInner instanceof HTMLElement)) return;
@@ -42534,6 +42562,11 @@ function installTouchPinchZoom() {
     touchPinchState.active = true;
     touchPinchState.startDistance = startDistance;
     touchPinchState.startScale = pinchScale;
+    const center = getTouchCenterClient(touchA, touchB);
+    touchPinchState.startCenterX = center.x;
+    touchPinchState.startCenterY = center.y;
+    touchPinchState.startPanX = pinchPanX;
+    touchPinchState.startPanY = pinchPanY;
     pinchActive = true;
     window.PINCH_ACTIVE = true;
   };
@@ -42551,7 +42584,15 @@ function installTouchPinchZoom() {
     uiFrameInner.style.transformOrigin = `${originX}% ${originY}%`;
     const ratio = distance / touchPinchState.startDistance;
     pinchScale = clamp(touchPinchState.startScale * ratio, PINCH_MIN, PINCH_MAX);
-    uiFrameInner.style.transform = `scale(${pinchScale})`;
+    const center = getTouchCenterClient(touchA, touchB);
+    if (pinchScale > PINCH_MIN) {
+      pinchPanX = touchPinchState.startPanX + (center.x - touchPinchState.startCenterX);
+      pinchPanY = touchPinchState.startPanY + (center.y - touchPinchState.startCenterY);
+    } else {
+      pinchPanX = 0;
+      pinchPanY = 0;
+    }
+    applyPinchTransform();
     event.preventDefault();
     event.stopImmediatePropagation();
   };
@@ -42597,7 +42638,11 @@ window.addEventListener('wheel', (event) => {
   uiFrameInner.style.transformOrigin = `${originX}% ${originY}%`;
   const step = Math.exp(-event.deltaY * 0.01);
   pinchScale = clamp(pinchScale * step, PINCH_MIN, PINCH_MAX);
-  uiFrameInner.style.transform = `scale(${pinchScale})`;
+  if (pinchScale <= PINCH_MIN) {
+    pinchPanX = 0;
+    pinchPanY = 0;
+  }
+  applyPinchTransform();
 }, { passive: false, capture: true });
 
 window.addEventListener('resize', async () => {

--- a/settings.js
+++ b/settings.js
@@ -64,6 +64,8 @@ const DEBUG_FIELD_MARKER = false;
 const FIELD_DEBUG_MARKER_QUERY_FLAG = 'field_debug_marker';
 let pinchActive = false;
 let pinchScale = 1;
+let pinchPanX = 0;
+let pinchPanY = 0;
 let pinchResetTimer = null;
 const PINCH_RESET_MS = 4000;
 const PINCH_MIN = 1;
@@ -80,6 +82,11 @@ function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
 
+function applyPinchTransform() {
+  if (!(uiFrameInner instanceof HTMLElement)) return;
+  uiFrameInner.style.transform = `translate(${pinchPanX}px, ${pinchPanY}px) scale(${pinchScale})`;
+}
+
 function resetPinchState() {
   pinchActive = false;
   if (typeof window !== 'undefined') {
@@ -90,8 +97,10 @@ function resetPinchState() {
     pinchResetTimer = null;
   }
   pinchScale = 1;
+  pinchPanX = 0;
+  pinchPanY = 0;
   if (uiFrameInner instanceof HTMLElement) {
-    uiFrameInner.style.transform = 'scale(1)';
+    applyPinchTransform();
     uiFrameInner.style.transformOrigin = '50% 50%';
   }
 }
@@ -114,6 +123,14 @@ window.addEventListener('gestureend', () => schedulePinchReset(), { capture: tru
 
 window.addEventListener('wheel', (event) => {
   if (pinchActive && event.ctrlKey !== true) {
+    if (pinchScale > PINCH_MIN) {
+      pinchPanX = pinchPanX - event.deltaX;
+      pinchPanY = pinchPanY - event.deltaY;
+      applyPinchTransform();
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
     resetPinchState();
   }
 }, { capture: true });
@@ -147,7 +164,11 @@ installPinchExitOnGameplayInput();
 const touchPinchState = {
   active: false,
   startDistance: 0,
-  startScale: 1
+  startScale: 1,
+  startCenterX: 0,
+  startCenterY: 0,
+  startPanX: 0,
+  startPanY: 0
 };
 
 function getTouchDistance(touchA, touchB) {
@@ -166,6 +187,13 @@ function getTouchCenterInPercents(touchA, touchB, rect) {
   return { originX, originY };
 }
 
+function getTouchCenterClient(touchA, touchB) {
+  return {
+    x: (touchA.clientX + touchB.clientX) / 2,
+    y: (touchA.clientY + touchB.clientY) / 2
+  };
+}
+
 function installTouchPinchZoom() {
   const onTouchStart = (event) => {
     if (!(uiFrameEl instanceof HTMLElement) || !(uiFrameInner instanceof HTMLElement)) return;
@@ -178,6 +206,11 @@ function installTouchPinchZoom() {
     touchPinchState.active = true;
     touchPinchState.startDistance = startDistance;
     touchPinchState.startScale = pinchScale;
+    const center = getTouchCenterClient(touchA, touchB);
+    touchPinchState.startCenterX = center.x;
+    touchPinchState.startCenterY = center.y;
+    touchPinchState.startPanX = pinchPanX;
+    touchPinchState.startPanY = pinchPanY;
     pinchActive = true;
     window.PINCH_ACTIVE = true;
   };
@@ -195,7 +228,15 @@ function installTouchPinchZoom() {
     uiFrameInner.style.transformOrigin = `${originX}% ${originY}%`;
     const ratio = distance / touchPinchState.startDistance;
     pinchScale = clamp(touchPinchState.startScale * ratio, PINCH_MIN, PINCH_MAX);
-    uiFrameInner.style.transform = `scale(${pinchScale})`;
+    const center = getTouchCenterClient(touchA, touchB);
+    if (pinchScale > PINCH_MIN) {
+      pinchPanX = touchPinchState.startPanX + (center.x - touchPinchState.startCenterX);
+      pinchPanY = touchPinchState.startPanY + (center.y - touchPinchState.startCenterY);
+    } else {
+      pinchPanX = 0;
+      pinchPanY = 0;
+    }
+    applyPinchTransform();
     event.preventDefault();
     event.stopImmediatePropagation();
   };
@@ -241,7 +282,11 @@ window.addEventListener('wheel', (event) => {
   uiFrameInner.style.transformOrigin = `${originX}% ${originY}%`;
   const step = Math.exp(-event.deltaY * 0.01);
   pinchScale = clamp(pinchScale * step, PINCH_MIN, PINCH_MAX);
-  uiFrameInner.style.transform = `scale(${pinchScale})`;
+  if (pinchScale <= PINCH_MIN) {
+    pinchPanX = 0;
+    pinchPanY = 0;
+  }
+  applyPinchTransform();
 }, { passive: false, capture: true });
 
 function getVisualViewportState() {


### PR DESCRIPTION
### Motivation
- Improve UX so that when the UI is pinched-in, moving two fingers should pan the zoomed content instead of resetting the zoom, matching standard touch/trackpad behavior. 
- Keep existing reset-by-tap/click and single-finger gestures unchanged while making two-finger movement intuitive on both mobile and desktop.

### Description
- Added persistent pan offsets `pinchPanX` and `pinchPanY` and a centralized `applyPinchTransform()` helper to apply `translate(...) scale(...)` consistently. 
- For touch pinch: track the two-finger center and starting pan in `touchPinchState`, and during `touchmove` update `pinchPanX/Y` so two-finger movement drags the zoomed content when `pinchScale > PINCH_MIN`. 
- For wheel/trackpad: when pinch is active, non-`Ctrl` wheel deltas now pan while zoomed (`pinchScale > PINCH_MIN`) instead of immediately resetting zoom. `Ctrl + wheel` continues to change zoom origin/scale. 
- Mirrored the same logic in both `settings.js` and `script.js` so runtime and built script stay consistent.

### Testing
- Ran `node --check settings.js` and the check passed. 
- Ran `node --check script.js` and the check passed. 
- No additional automated tests exist for runtime gestures in this repo; manual browser verification is recommended to validate touch and trackpad behavior on target devices.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c5835070832d83b219fd124af6a8)