### PR TITLE
Плавный сброс зума с лёгким overshoot-анимированием

### DIFF
--- a/script.js
+++ b/script.js
@@ -42570,8 +42570,12 @@ let pinchScale = 1;
 let pinchPanX = 0;
 let pinchPanY = 0;
 let pinchResetTimer = null;
+let pinchResetAnimationFrame = null;
+let pinchResetAnimationToken = 0;
 const PINCH_MIN = 1;
 const PINCH_MAX = 8;
+const PINCH_RESET_ANIMATION_MS = 460;
+const PINCH_RESET_OVERSHOOT = 1.1;
 if (typeof window !== 'undefined') {
   window.PINCH_ACTIVE = pinchActive;
 }
@@ -42592,26 +42596,80 @@ function applyPinchTransform() {
   uiFrameInner.style.transform = `translate(${pinchPanX}px, ${pinchPanY}px) scale(${pinchScale})`;
 }
 
-function resetPinchState() {
+function clearPinchResetAnimation() {
+  pinchResetAnimationToken += 1;
+  if (pinchResetAnimationFrame) {
+    cancelAnimationFrame(pinchResetAnimationFrame);
+    pinchResetAnimationFrame = null;
+  }
+}
+
+function pinchResetEaseOutBack(t, overshoot = PINCH_RESET_OVERSHOOT) {
+  const clamped = clamp(t, 0, 1);
+  const inv = clamped - 1;
+  return 1 + (overshoot + 1) * inv * inv * inv + overshoot * inv * inv;
+}
+
+function resetPinchState({ animated = true } = {}) {
   if (typeof window !== 'undefined') {
     window.PINCH_ACTIVE = false;
   }
   pinchActive = false;
+  clearPinchResetAnimation();
   if (pinchResetTimer) {
     clearTimeout(pinchResetTimer);
     pinchResetTimer = null;
   }
-  pinchScale = 1;
-  pinchPanX = 0;
-  pinchPanY = 0;
-  if (uiFrameInner instanceof HTMLElement) {
+  const startScale = pinchScale;
+  const startPanX = pinchPanX;
+  const startPanY = pinchPanY;
+  const isNearNeutral = Math.abs(startScale - 1) < 0.001
+    && Math.abs(startPanX) < 0.1
+    && Math.abs(startPanY) < 0.1;
+  if (!animated || isNearNeutral || !(uiFrameInner instanceof HTMLElement)) {
+    pinchScale = 1;
+    pinchPanX = 0;
+    pinchPanY = 0;
     applyPinchTransform();
-    uiFrameInner.style.transformOrigin = "50% 50%";
+    if (uiFrameInner instanceof HTMLElement) {
+      uiFrameInner.style.transformOrigin = "50% 50%";
+    }
+    return;
   }
+
+  const token = ++pinchResetAnimationToken;
+  const startTime = performance.now();
+  const animateStep = (now) => {
+    if (token !== pinchResetAnimationToken) {
+      return;
+    }
+    const elapsed = now - startTime;
+    const t = clamp(elapsed / PINCH_RESET_ANIMATION_MS, 0, 1);
+    const eased = pinchResetEaseOutBack(t);
+    pinchScale = startScale + (1 - startScale) * eased;
+    pinchPanX = startPanX + (0 - startPanX) * eased;
+    pinchPanY = startPanY + (0 - startPanY) * eased;
+    applyPinchTransform();
+
+    if (t >= 1) {
+      pinchScale = 1;
+      pinchPanX = 0;
+      pinchPanY = 0;
+      applyPinchTransform();
+      if (uiFrameInner instanceof HTMLElement) {
+        uiFrameInner.style.transformOrigin = "50% 50%";
+      }
+      pinchResetAnimationFrame = null;
+      return;
+    }
+    pinchResetAnimationFrame = requestAnimationFrame(animateStep);
+  };
+  pinchResetAnimationFrame = requestAnimationFrame(animateStep);
 }
 
 
 window.addEventListener('gesturestart', () => {
+  clearPinchResetAnimation();
   pinchActive = true;
   window.PINCH_ACTIVE = true;
 }, { capture: true });
@@ -42628,6 +42686,7 @@ window.addEventListener('gestureend', () => {
 window.addEventListener('wheel', (event) => {
   if (pinchActive && event.ctrlKey !== true) {
     if (pinchScale > PINCH_MIN) {
+      clearPinchResetAnimation();
       pinchPanX = pinchPanX - event.deltaX;
       pinchPanY = pinchPanY - event.deltaY;
       applyPinchTransform();
@@ -42721,6 +42780,7 @@ function installTouchPinchZoom() {
       clearTimeout(pinchResetTimer);
       pinchResetTimer = null;
     }
+    clearPinchResetAnimation();
 
     if (event.touches.length >= 2) {
       const touchA = event.touches[0];
@@ -42851,6 +42911,7 @@ window.addEventListener('wheel', (event) => {
   }
   uiFrameInner.style.transformOrigin = `${originX}% ${originY}%`;
   const step = Math.exp(-event.deltaY * 0.01);
+  clearPinchResetAnimation();
   pinchScale = clamp(pinchScale * step, PINCH_MIN, PINCH_MAX);
   if (pinchScale <= PINCH_MIN) {
     pinchPanX = 0;

--- a/settings.js
+++ b/settings.js
@@ -67,9 +67,13 @@ let pinchScale = 1;
 let pinchPanX = 0;
 let pinchPanY = 0;
 let pinchResetTimer = null;
+let pinchResetAnimationFrame = null;
+let pinchResetAnimationToken = 0;
 const PINCH_RESET_MS = 4000;
 const PINCH_MIN = 1;
 const PINCH_MAX = 8;
+const PINCH_RESET_ANIMATION_MS = 460;
+const PINCH_RESET_OVERSHOOT = 1.1;
 if (typeof window !== 'undefined') {
   window.PINCH_ACTIVE = pinchActive;
 }
@@ -87,7 +91,22 @@ function applyPinchTransform() {
   uiFrameInner.style.transform = `translate(${pinchPanX}px, ${pinchPanY}px) scale(${pinchScale})`;
 }
 
-function resetPinchState() {
+function clearPinchResetAnimation() {
+  pinchResetAnimationToken += 1;
+  if (pinchResetAnimationFrame) {
+    cancelAnimationFrame(pinchResetAnimationFrame);
+    pinchResetAnimationFrame = null;
+  }
+}
+
+function pinchResetEaseOutBack(t, overshoot = PINCH_RESET_OVERSHOOT) {
+  const clamped = clamp(t, 0, 1);
+  const inv = clamped - 1;
+  return 1 + (overshoot + 1) * inv * inv * inv + overshoot * inv * inv;
+}
+
+function resetPinchState({ animated = true } = {}) {
+  clearPinchResetAnimation();
   pinchActive = false;
   if (typeof window !== 'undefined') {
     window.PINCH_ACTIVE = false;
@@ -96,13 +115,51 @@ function resetPinchState() {
     clearTimeout(pinchResetTimer);
     pinchResetTimer = null;
   }
-  pinchScale = 1;
-  pinchPanX = 0;
-  pinchPanY = 0;
-  if (uiFrameInner instanceof HTMLElement) {
+  const startScale = pinchScale;
+  const startPanX = pinchPanX;
+  const startPanY = pinchPanY;
+  const isNearNeutral = Math.abs(startScale - 1) < 0.001
+    && Math.abs(startPanX) < 0.1
+    && Math.abs(startPanY) < 0.1;
+  if (!animated || isNearNeutral || !(uiFrameInner instanceof HTMLElement)) {
+    pinchScale = 1;
+    pinchPanX = 0;
+    pinchPanY = 0;
     applyPinchTransform();
-    uiFrameInner.style.transformOrigin = '50% 50%';
+    if (uiFrameInner instanceof HTMLElement) {
+      uiFrameInner.style.transformOrigin = '50% 50%';
+    }
+    return;
   }
+
+  const token = ++pinchResetAnimationToken;
+  const startTime = performance.now();
+  const animateStep = (now) => {
+    if (token !== pinchResetAnimationToken) {
+      return;
+    }
+    const elapsed = now - startTime;
+    const t = clamp(elapsed / PINCH_RESET_ANIMATION_MS, 0, 1);
+    const eased = pinchResetEaseOutBack(t);
+    pinchScale = startScale + (1 - startScale) * eased;
+    pinchPanX = startPanX + (0 - startPanX) * eased;
+    pinchPanY = startPanY + (0 - startPanY) * eased;
+    applyPinchTransform();
+
+    if (t >= 1) {
+      pinchScale = 1;
+      pinchPanX = 0;
+      pinchPanY = 0;
+      applyPinchTransform();
+      if (uiFrameInner instanceof HTMLElement) {
+        uiFrameInner.style.transformOrigin = '50% 50%';
+      }
+      pinchResetAnimationFrame = null;
+      return;
+    }
+    pinchResetAnimationFrame = requestAnimationFrame(animateStep);
+  };
+  pinchResetAnimationFrame = requestAnimationFrame(animateStep);
 }
 
 function schedulePinchReset() {
@@ -115,6 +172,7 @@ function schedulePinchReset() {
 }
 
 window.addEventListener('gesturestart', () => {
+  clearPinchResetAnimation();
   pinchActive = true;
   window.PINCH_ACTIVE = true;
 }, { capture: true });
@@ -124,6 +182,7 @@ window.addEventListener('gestureend', () => schedulePinchReset(), { capture: tru
 window.addEventListener('wheel', (event) => {
   if (pinchActive && event.ctrlKey !== true) {
     if (pinchScale > PINCH_MIN) {
+      clearPinchResetAnimation();
       pinchPanX = pinchPanX - event.deltaX;
       pinchPanY = pinchPanY - event.deltaY;
       applyPinchTransform();
@@ -198,6 +257,7 @@ function installTouchPinchZoom() {
   const onTouchStart = (event) => {
     if (!(uiFrameEl instanceof HTMLElement) || !(uiFrameInner instanceof HTMLElement)) return;
     if (!isZoomExitTarget(event.target)) return;
+    clearPinchResetAnimation();
     if (event.touches.length < 2) return;
     const touchA = event.touches[0];
     const touchB = event.touches[1];
@@ -281,6 +341,7 @@ window.addEventListener('wheel', (event) => {
   }
   uiFrameInner.style.transformOrigin = `${originX}% ${originY}%`;
   const step = Math.exp(-event.deltaY * 0.01);
+  clearPinchResetAnimation();
   pinchScale = clamp(pinchScale * step, PINCH_MIN, PINCH_MAX);
   if (pinchScale <= PINCH_MIN) {
     pinchPanX = 0;


### PR DESCRIPTION
### Motivation
- Сброс приближения происходил мгновенно и резко, что давало неприятный «прыжок» интерфейса при отпускании щипка/колеса; нужно было сделать возврат более плавным и естественным для десктопа и жестовых интерфейсов. 

### Description
- В `script.js` и `settings.js` добавлена анимированная логика сброса зума: введены тайминги и токен для управления анимацией (`PINCH_RESET_ANIMATION_MS = 460`, `PINCH_RESET_OVERSHOOT = 1.1`).
- Реализована функция плавного easing-а `pinchResetEaseOutBack` и цикл кадров на `requestAnimationFrame`, который интерполирует `pinchScale`, `pinchPanX` и `pinchPanY` до нейтральных значений с лёгким overshoot.
- Добавлена отмена текущей анимации при новом вводе пользователя (`clearPinchResetAnimation`) и вызовы отмены в местах начала жеста/колеса, чтобы действия пользователя всегда прерывали автосброс.
- Изменения применены ко всем входным путям: gesture/touch/pointer/wheel, а также в логике отложенного автосброса, чтобы поведение совпадало в игровом коде и в настройках (`script.js`, `settings.js`).

### Testing
- Выполнена синтаксическая проверка JavaScript: `node --check script.js` — успешно.
- Выполнена синтаксическая проверка JavaScript: `node --check settings.js` — успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f8c1dd5c832dac6ef9ee1d21faa1)