### PR TITLE
Fix AI fallback rotation choosing blocked wall-collision vectors

### DIFF
--- a/script.js
+++ b/script.js
@@ -32315,7 +32315,35 @@ function getFallbackAiMove(context){
       }
 
       if(Number.isFinite(fallbackCandidate.vx) && Number.isFinite(fallbackCandidate.vy)){
-        return fallbackCandidate;
+        const existingLandingX = fallbackCandidate.plane.x + fallbackCandidate.vx * FIELD_FLIGHT_DURATION_SEC;
+        const existingLandingY = fallbackCandidate.plane.y + fallbackCandidate.vy * FIELD_FLIGHT_DURATION_SEC;
+        if(!isPathClear(fallbackCandidate.plane.x, fallbackCandidate.plane.y, existingLandingX, existingLandingY)){
+          const reroutedMove = planPathToPoint(
+            fallbackCandidate.plane,
+            Number.isFinite(fallbackCandidate?.fallbackTarget?.x) ? fallbackCandidate.fallbackTarget.x : fallbackCandidate.enemy?.x,
+            Number.isFinite(fallbackCandidate?.fallbackTarget?.y) ? fallbackCandidate.fallbackTarget.y : fallbackCandidate.enemy?.y,
+            {
+              goalName: fallbackCandidate.goalName || "fallback_rotation",
+              decisionReason: fallbackCandidate.decisionReason || "fallback_rotation",
+            }
+          );
+          if(reroutedMove){
+            return applyLossCompressionScoreAdjustments({
+              ...fallbackCandidate,
+              ...reroutedMove,
+              totalDist: Number.isFinite(reroutedMove.totalDist)
+                ? reroutedMove.totalDist
+                : Math.hypot(reroutedMove.vx || 0, reroutedMove.vy || 0) * FIELD_FLIGHT_DURATION_SEC,
+            }, context);
+          }
+          logAiDecision("fallback_rotation_blocked_path_skipped", {
+            planeId: fallbackCandidate.plane?.id ?? null,
+            enemyId: fallbackCandidate.enemy?.id ?? null,
+            reason: "existing_vector_blocked_and_no_reroute",
+          });
+        } else {
+          return fallbackCandidate;
+        }
       }
 
       const ang = fallbackCandidate.angleBase
@@ -32335,14 +32363,45 @@ function getFallbackAiMove(context){
         return null;
       }
 
-      best = applyLossCompressionScoreAdjustments({
+      const fallbackMove = {
         plane: fallbackCandidate.plane,
         enemy: fallbackCandidate.enemy,
         decisionReason: "fallback_rotation",
         vx: Math.cos(ang)*scale*speedPxPerSec,
         vy: Math.sin(ang)*scale*speedPxPerSec,
         totalDist: fallbackCandidate.desired,
-      }, context);
+      };
+      const fallbackLandingX = fallbackMove.plane.x + fallbackMove.vx * FIELD_FLIGHT_DURATION_SEC;
+      const fallbackLandingY = fallbackMove.plane.y + fallbackMove.vy * FIELD_FLIGHT_DURATION_SEC;
+      if(!isPathClear(fallbackMove.plane.x, fallbackMove.plane.y, fallbackLandingX, fallbackLandingY)){
+        const reroutedMove = planPathToPoint(
+          fallbackMove.plane,
+          Number.isFinite(fallbackCandidate?.fallbackTarget?.x) ? fallbackCandidate.fallbackTarget.x : fallbackCandidate.enemy?.x,
+          Number.isFinite(fallbackCandidate?.fallbackTarget?.y) ? fallbackCandidate.fallbackTarget.y : fallbackCandidate.enemy?.y,
+          {
+            goalName: fallbackCandidate.goalName || "fallback_rotation",
+            decisionReason: fallbackCandidate.decisionReason || "fallback_rotation",
+          }
+        );
+        if(reroutedMove){
+          best = applyLossCompressionScoreAdjustments({
+            ...fallbackCandidate,
+            ...reroutedMove,
+            totalDist: Number.isFinite(reroutedMove.totalDist)
+              ? reroutedMove.totalDist
+              : Math.hypot(reroutedMove.vx || 0, reroutedMove.vy || 0) * FIELD_FLIGHT_DURATION_SEC,
+          }, context);
+        } else {
+          logAiDecision("fallback_rotation_blocked_path_skipped", {
+            planeId: fallbackMove.plane?.id ?? null,
+            enemyId: fallbackMove.enemy?.id ?? null,
+            reason: "randomized_vector_blocked_and_no_reroute",
+          });
+          best = null;
+        }
+      } else {
+        best = applyLossCompressionScoreAdjustments(fallbackMove, context);
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- Prevent fallback rotation from selecting launch vectors that immediately collide with walls, which caused single-AI-plane tests to repeatedly ‘‘bash the wall’’ instead of using ricochet/dynamite or rerouting. 
- The fallback branch could return precomputed `vx`/`vy` without verifying geometry or using the richer path planner, producing a failsafe that performed poorly in-play.

### Description
- Added path-clear verification (`isPathClear`) before accepting a candidate that already contains `vx`/`vy` and before accepting a synthesized randomized fallback vector in `fallback_rotation`.
- If the direct vector is blocked the code now attempts a reroute via `planPathToPoint(...)` toward the same `fallbackTarget`/`enemy` and accepts that reroute when available.
- When neither direct nor rerouted path is available the code logs a diagnostic event `fallback_rotation_blocked_path_skipped` and avoids returning the blocked move. 
- Changes applied in `script.js` around the fallback rotation / fallback selection logic so fallback moves only proceed when geometrically valid or rerouted.

### Testing
- Ran syntax check: `node --check script.js` (succeeded).
- Executed repository smoke attempts: `node ./scripts/smoke-shield-immediate-rehit.js` and `node ./scripts/smoke-beneficial-wings-cargo.js`, both failed in the baseline harness due to missing global symbols (`ReferenceError: dropActiveFlagFromPlane is not defined` and `ReferenceError: CARGO_SAFE_MAX_DIM_PX is not defined`) unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5fcb88a68832d8cfc1b37c18cc858)