### PR TITLE
Use DOM offsets and CSS --ui-scale for menu plane positioning; refine pinch-state handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -15376,28 +15376,26 @@ function updateModePlanesPosition(activeButton){
   const btnRect = resolvedButton.getBoundingClientRect();
   const rootRect = modeMenuDiv.getBoundingClientRect();
   if(!btnRect || !rootRect) return;
-
-  const btnLeftD = toDesignCoords(btnRect.left, btnRect.top).x;
-  const btnTopD = toDesignCoords(btnRect.left, btnRect.top).y;
-  const rootLeftD = toDesignCoords(rootRect.left, rootRect.top).x;
-  const rootTopD = toDesignCoords(rootRect.left, rootRect.top).y;
-  const designOrigin = toDesignCoords(rootRect.left, rootRect.top);
-  const uiScale = Number.isFinite(designOrigin.uiScale) ? designOrigin.uiScale : 1;
-  if(!hasValidMenuPlaneGeometry(btnRect, rootRect, uiScale)){
+  const rootStyle = window.getComputedStyle(document.documentElement);
+  const uiScaleRaw = rootStyle.getPropertyValue('--ui-scale');
+  const uiScaleValue = uiScaleRaw ? parseFloat(uiScaleRaw) : 1;
+  const fallbackUiScale = Number.isFinite(uiScaleValue) && uiScaleValue > 0
+    ? uiScaleValue
+    : 1;
+  if(!hasValidMenuPlaneGeometry(btnRect, rootRect, fallbackUiScale)){
     leftModePlane.style.opacity = "0";
     rightModePlane.style.opacity = "0";
     return;
   }
-  const btnW_D = btnRect.width / uiScale;
-  const btnH_D = btnRect.height / uiScale;
-  const rootX_D = btnLeftD - rootLeftD;
-  const rootY_D = btnTopD - rootTopD;
+  const btnW_D = resolvedButton.offsetWidth || 0;
+  const btnH_D = resolvedButton.offsetHeight || 0;
+  const rootX_D = resolvedButton.offsetLeft || 0;
+  const rootY_D = resolvedButton.offsetTop || 0;
   const leftOffset = 36 + 12;
   const rightOffset = 12;
 
   const updatePlane = (plane, targetX_D) => {
-    const planeRect = plane.getBoundingClientRect();
-    const planeHeight_D = (planeRect.height || plane.offsetHeight || 0) / uiScale;
+    const planeHeight_D = plane.offsetHeight || plane.clientHeight || 0;
     const targetY_D = rootY_D + btnH_D / 2 - planeHeight_D / 2;
     plane.style.transform = `translate(${targetX_D}px, ${targetY_D}px)`;
     return targetY_D;
@@ -15447,28 +15445,26 @@ function updateRulesPlanesPosition(activeButton){
   const btnRect = resolvedButton.getBoundingClientRect();
   const rootRect = modeMenuDiv.getBoundingClientRect();
   if(!btnRect || !rootRect) return;
-
-  const btnLeftD = toDesignCoords(btnRect.left, btnRect.top).x;
-  const btnTopD = toDesignCoords(btnRect.left, btnRect.top).y;
-  const rootLeftD = toDesignCoords(rootRect.left, rootRect.top).x;
-  const rootTopD = toDesignCoords(rootRect.left, rootRect.top).y;
-  const designOrigin = toDesignCoords(rootRect.left, rootRect.top);
-  const uiScale = Number.isFinite(designOrigin.uiScale) ? designOrigin.uiScale : 1;
-  if(!hasValidMenuPlaneGeometry(btnRect, rootRect, uiScale)){
+  const rootStyle = window.getComputedStyle(document.documentElement);
+  const uiScaleRaw = rootStyle.getPropertyValue('--ui-scale');
+  const uiScaleValue = uiScaleRaw ? parseFloat(uiScaleRaw) : 1;
+  const fallbackUiScale = Number.isFinite(uiScaleValue) && uiScaleValue > 0
+    ? uiScaleValue
+    : 1;
+  if(!hasValidMenuPlaneGeometry(btnRect, rootRect, fallbackUiScale)){
     leftRulesPlane.style.opacity = "0";
     rightRulesPlane.style.opacity = "0";
     return;
   }
-  const btnW_D = btnRect.width / uiScale;
-  const btnH_D = btnRect.height / uiScale;
-  const rootX_D = btnLeftD - rootLeftD;
-  const rootY_D = btnTopD - rootTopD;
+  const btnW_D = resolvedButton.offsetWidth || 0;
+  const btnH_D = resolvedButton.offsetHeight || 0;
+  const rootX_D = resolvedButton.offsetLeft || 0;
+  const rootY_D = resolvedButton.offsetTop || 0;
   const leftOffset = 36 + 12;
   const rightOffset = 12;
 
   const updatePlane = (plane, targetX_D) => {
-    const planeRect = plane.getBoundingClientRect();
-    const planeHeight_D = (planeRect.height || plane.offsetHeight || 0) / uiScale;
+    const planeHeight_D = plane.offsetHeight || plane.clientHeight || 0;
     const targetY_D = rootY_D + btnH_D / 2 - planeHeight_D / 2;
     plane.style.transform = `translate(${targetX_D}px, ${targetY_D}px)`;
     return targetY_D;
@@ -42441,7 +42437,7 @@ function resizeCanvasFixedForGameBoard() {
   }
 }
 
-let lastResizeMetrics = {
+var lastResizeMetrics = {
   cssW: 0,
   cssH: 0,
   scale: 0,
@@ -42450,6 +42446,12 @@ let lastResizeMetrics = {
 
 async function syncLayoutAndField(reason = "sync") {
   if (typeof window !== 'undefined' && window.PINCH_ACTIVE) {
+    const wasNeutralPinch = reconcileNeutralPinchState();
+    if (!wasNeutralPinch && isPinchTransformEffectivelyActive()) {
+      return;
+    }
+  }
+  if (isPinchTransformEffectivelyActive()) {
     return;
   }
   logResizeDebug('resizeCanvas');
@@ -42608,6 +42610,22 @@ function clamp(value, min, max) {
 function applyPinchTransform() {
   if (!(uiFrameInner instanceof HTMLElement)) return;
   uiFrameInner.style.transform = `translate(${pinchPanX}px, ${pinchPanY}px) scale(${pinchScale})`;
+}
+
+function isPinchTransformEffectivelyActive() {
+  const resolvedScale = getEffectivePinchScale();
+  const runtimeScale = Number.isFinite(pinchScale) ? pinchScale : 1;
+  const maxScale = Math.max(resolvedScale, runtimeScale);
+  const hasZoom = maxScale > (PINCH_MIN + 0.001);
+  const hasPan = Math.abs(pinchPanX) > 0.1 || Math.abs(pinchPanY) > 0.1;
+  return hasZoom || hasPan;
+}
+
+function reconcileNeutralPinchState() {
+  if (typeof window === 'undefined' || window.PINCH_ACTIVE !== true) return false;
+  if (isPinchTransformEffectivelyActive()) return false;
+  resetPinchState({ animated: false });
+  return true;
 }
 
 function clearPinchResetAnimation() {


### PR DESCRIPTION
### Motivation
- Simplify and stabilize menu plane positioning by avoiding fragile design-coordinate conversions and relying on actual DOM offsets and CSS scaling.
- Prevent incorrect or stuck pinch state behavior during layout syncs by detecting effectively active pinch transforms and reconciling neutral pinch state.

### Description
- Replace `toDesignCoords`-based conversions and `getBoundingClientRect`/derived uiScale math in `updateModePlanesPosition` and `updateRulesPlanesPosition` with a CSS `--ui-scale` lookup and fallbacks, and use `resolvedButton.offsetWidth`, `offsetHeight`, `offsetLeft`, and `offsetTop` for positioning.
- Compute plane heights from `plane.offsetHeight`/`plane.clientHeight` instead of dividing `getBoundingClientRect()` by a uiScale factor.
- Add `isPinchTransformEffectivelyActive` and `reconcileNeutralPinchState` helpers and incorporate them into `syncLayoutAndField` to avoid unnecessary early exits or persistent `PINCH_ACTIVE` when the transform is effectively neutral.
- Minor change: `lastResizeMetrics` declaration changed from `let` to `var`.

### Testing
- Ran the repository's automated test suite via `npm test` and the linter via `npm run lint`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6018a6168832daa44d1ad6c8866fb)