### PR TITLE
Защитить объявление lastResizeMetrics от раннего доступа

### DIFF
--- a/script.js
+++ b/script.js
@@ -42490,7 +42490,7 @@ function resizeCanvasFixedForGameBoard() {
   }
 }
 
-let lastResizeMetrics = {
+var lastResizeMetrics = {
   cssW: 0,
   cssH: 0,
   scale: 0,


### PR DESCRIPTION
### Motivation
- Предотвратить критический крах на старте, когда раннее обращение к служебной переменной `lastResizeMetrics` могло приводить к «белому экрану» и невозможности запустить приложение.

### Description
- В `script.js` заменено объявление `let lastResizeMetrics = {...}` на `var lastResizeMetrics = {...}` (около строк L42493–L42498), чтобы переменная была доступна заранее и не вызывала ошибку при неверном порядке инициализации.

### Testing
- Выполнена синтаксическая проверка командой `node --check script.js`, проверка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e605c757f4832dbc167c03525f005a)