### PR TITLE
Enable ricochet/gap probing for direct and preparation attack pathing

### DIFF
--- a/script.js
+++ b/script.js
@@ -20648,7 +20648,8 @@ function findSafePreparationMoveForAttack(plane, enemy, options = {}){
         goalName: preparationGoalName,
         decisionReason: preparationGoalName,
         targetEnemy: enemy,
-        specialAttemptBudget: 0,
+        specialRouteClasses: ["ricochet", "gap"],
+        specialAttemptBudget: 2,
         compareLabel: [preparationGoalName, plane?.id ?? "", enemy?.id ?? ""],
       });
       if(!move) continue;
@@ -20686,7 +20687,8 @@ function planDirectAttackOrPreparationMove(plane, enemy, options = {}){
     targetEnemy: enemy,
     enemy,
     context: options?.context,
-    specialAttemptBudget: 0,
+    specialRouteClasses: ["ricochet", "gap"],
+    specialAttemptBudget: 2,
     compareLabel,
     prioritizeDirectFinisher: options?.prioritizeDirectFinisher === true,
     allowFinisherSafetyBypass: options?.allowFinisherSafetyBypass === true,


### PR DESCRIPTION
### Motivation
- В текущей логике в двух ключевых местах (`planDirectAttackOrPreparationMove` и `findSafePreparationMoveForAttack`) явно запрещалась проба специальных типов маршрутов, установив `specialAttemptBudget: 0`, из‑за чего планировщик мог упираться только в прямой путь и пропускать обходные варианты.
- Цель изменения — разрешить проверку безопасных альтернатив (рикогшет/щель) при планировании атаки, не ломая существующую аварийную (emergency) логику, где по‑прежнему должен оставаться direct‑only.

### Description
- В `findSafePreparationMoveForAttack` заменён аргумент вызова `planPathWithSpecialRouteProbe`: добавлено `specialRouteClasses: ["ricochet", "gap"]` и `specialAttemptBudget: 2` вместо `0` для возможности двух спец‑попыток при подготовительных позициях.
- В `planDirectAttackOrPreparationMove` аналогично обновлён вызов `planPathWithSpecialRouteProbe`, добавив `specialRouteClasses: ["ricochet", "gap"]` и `specialAttemptBudget: 2` при планировании прямой атаки.
- Логика внутри `planPathWithSpecialRouteProbe` не менялась и по‑прежнему формирует последовательность попыток как `direct` сначала, а затем спец‑классы (`ricochet`, `gap`) когда цель не является emergency, следовательно порядок попыток сохранён.

### Testing
- Поисковые проверки кода выполнены: `rg -n "planDirectAttackOrPreparationMove|findSafePreparationMoveForAttack|specialAttemptBudget: 0|planPathWithSpecialRouteProbe" script.js`, и найдены обновлённые места (успешно).
- Просмотр изменённых фрагментов и подтверждение замены выполнены через `sed`/`nl` и `git diff -- script.js`, подтверждающие добавление `specialRouteClasses` и изменение бюджета на `2` (успешно).
- Файл сохранён и зафиксирован в репозитории с сообщением коммита; автоматизированный коммит выполнен (`git commit`) и PR-описание сгенерировано (успешно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66f5ec504832da29a502c0bd78271)