### PR TITLE
Enable automatic ricochet probe when direct path fails

### DIFF
--- a/script.js
+++ b/script.js
@@ -35286,7 +35286,25 @@ function planPathToPoint(plane, tx, ty, options = {}){
   const candidateBasket = [];
   const emergencyBaseDefenseGoal = activeGoalName.includes("emergency_base_defense");
   const allowGapCandidates = requestedRouteClass === "gap";
-  const allowExperimentalRicochet = shouldForceNonDirectBranch || options?.enableExperimentalRicochet === true;
+  const explicitRicochetProbeRequested = shouldForceNonDirectBranch || options?.enableExperimentalRicochet === true;
+  const routeBehaviorHint = `${options?.goalName || ""} ${options?.decisionReason || ""}`.toLowerCase();
+  const isAttackOrPressureBehavior = isAttackContext(routeBehaviorHint) || routeBehaviorHint.includes("pressure");
+  const allowAutoRicochetFallback = !explicitRicochetProbeRequested
+    && !strictSpecialPathRejectStage
+    && !isCriticalOrEmergencyStage
+    && !emergencyBaseDefenseGoal
+    && isAttackOrPressureBehavior;
+  let autoRicochetProbeReason = null;
+  if(allowAutoRicochetFallback && !hasDirectLine){
+    autoRicochetProbeReason = "direct_blocked_auto_ricochet_probe";
+    logAiDecision("auto_ricochet_probe_enabled", {
+      planeId: plane?.id ?? null,
+      goalName: options?.goalName || null,
+      reason: autoRicochetProbeReason,
+      hasDirectLine,
+    });
+  }
+  let allowExperimentalRicochet = explicitRicochetProbeRequested || Boolean(autoRicochetProbeReason);
 
   function registerCandidate(move){
     if(move?.specialPromotionApplied === true && (move?.candidateClass === "gap" || move?.candidateClass === "ricochet")){
@@ -35471,6 +35489,23 @@ function planPathToPoint(plane, tx, ty, options = {}){
     }
   }
 
+  if(!allowExperimentalRicochet
+    && allowAutoRicochetFallback
+    && hasDirectLine
+    && !shouldForceNonDirectBranch){
+    const hasValidDirectCandidate = candidateBasket.some(candidate => candidate?.candidateClass === "direct");
+    if(!hasValidDirectCandidate){
+      autoRicochetProbeReason = "direct_candidates_rejected_auto_ricochet_probe";
+      allowExperimentalRicochet = true;
+      logAiDecision("auto_ricochet_probe_enabled", {
+        planeId: plane?.id ?? null,
+        goalName: options?.goalName || null,
+        reason: autoRicochetProbeReason,
+        hasDirectLine,
+      });
+    }
+  }
+
   let mirrorRejectCode = null;
   if(allowExperimentalRicochet){
     const mirrorPressureBoost = isMirrorPressureTarget(options?.targetEnemy || { x: tx, y: ty }, { ...options, plane })
@@ -35503,7 +35538,7 @@ function planPathToPoint(plane, tx, ty, options = {}){
       });
       logAiDecision("mirror_selected_reason", {
         source: "plan_path_to_point",
-        reason: hasDirectLine ? "mirror_competing_with_direct" : "direct_path_blocked",
+        reason: autoRicochetProbeReason || (hasDirectLine ? "mirror_competing_with_direct" : "direct_path_blocked"),
         planeId: plane?.id ?? null,
         targetEnemyId: options?.targetEnemy?.id ?? options?.targetEnemyId ?? null,
         pressureBoost: Number(mirrorPressureBoost.toFixed(2)),
@@ -35581,6 +35616,7 @@ function planPathToPoint(plane, tx, ty, options = {}){
     planeId: plane?.id ?? null,
     goalName: options?.goalName || aiRoundState?.currentGoal || null,
     routeStrictnessMode,
+    ricochetProbeReason: autoRicochetProbeReason || null,
   });
   return null;
   } finally {


### PR DESCRIPTION
### Motivation
- Раньше рикошет (experimental ricochet) включался только по явному запросу (`routeClass: "ricochet"` или `enableExperimentalRicochet: true`), из‑за чего в обычных атакующих сценариях система могла сдаваться слишком рано при заблокированном прямом пути.
- Нужно дать боту возможность автоматически сделать «попытку рикошета» в не‑критичных attack/pressure сценариях до окончательного отказа, чтобы уменьшить ложные отказы. 
- При этом критические defensive/emergency ветки нельзя ломать, поэтому авто‑включение должно быть отключено в строгих/экстренных режимах.
- Для удобства аналитики требуется фиксированный reason‑code при авто‑включении, чтобы отличать ручные запросы рикошета от авто‑fallback'а.

### Description
- Добавлены локальные флаги: `explicitRicochetProbeRequested`, `allowAutoRicochetFallback` и `autoRicochetProbeReason`, и логика, которая выставляет `allowExperimentalRicochet` если явно запрошено или сработал авто‑fallback. 
- Авто‑fallback включается в двух случаях: когда `hasDirectLine === false` (прямой путь заблокирован), либо когда прямые кандидаты присутствуют по проверке, но не дали валидного хода (после первого прохода кандидатов). 
- Авто‑включение запрещено в строгих/критических режимах (`strictSpecialPathRejectStage`, `isCriticalOrEmergencyStage`, `emergencyBaseDefenseGoal`) и сработает только для обычного attack/pressure поведения, при этом поведение emergency/defense не меняется. 
- Добавлены диагностические точки: `logAiDecision("auto_ricochet_probe_enabled", ...)`, новые reason‑codes `direct_blocked_auto_ricochet_probe` и `direct_candidates_rejected_auto_ricochet_probe`, и проброс `ricochetProbeReason` в финальную телеметрию `recordAiPrimaryTurnstileBlocker` на стадии `candidate_basket_exhausted`; также причина привязывается к `mirror_selected_reason` если рикошет выбран. 

### Testing
- Выполнена синтаксическая проверка: `node --check script.js` — успешно. 
- Изменения зафиксированы в репозитории (`git commit`) после правок. 
- Примечание: модульных/интеграционных тестов в этом патче не запускалось, проверка ограничена статическим синтаксисом и ручным просмотром изменений.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67076b574832d89024030aa5c17fa)