### PR TITLE
Improve AI ricochet fallback when direct path is blocked

### DIFF
--- a/script.js
+++ b/script.js
@@ -35560,12 +35560,12 @@ function planPathToPoint(plane, tx, ty, options = {}){
   const allowGapCandidates = requestedRouteClass === "gap";
   const explicitRicochetProbeRequested = shouldForceNonDirectBranch || options?.enableExperimentalRicochet === true;
   const routeBehaviorHint = `${options?.goalName || ""} ${options?.decisionReason || ""}`.toLowerCase();
-  const isAttackOrPressureBehavior = isAttackContext(routeBehaviorHint) || routeBehaviorHint.includes("pressure");
+  const isDefenseOrRetreatBehavior = isDefenseOrRetreatContext(routeBehaviorHint);
   const allowAutoRicochetFallback = !explicitRicochetProbeRequested
     && !strictSpecialPathRejectStage
     && !isCriticalOrEmergencyStage
     && !emergencyBaseDefenseGoal
-    && isAttackOrPressureBehavior;
+    && !isDefenseOrRetreatBehavior;
   let autoRicochetProbeReason = null;
   if(allowAutoRicochetFallback && !hasDirectLine){
     autoRicochetProbeReason = "direct_blocked_auto_ricochet_probe";


### PR DESCRIPTION
### Motivation
- Исправить поведение ИИ: при закрытом прямом пути он должен активнее пробовать рикошет, а не зацикливаться на нерабочем прямом варианте, потому что ранее авто-рикошет запускался только для attack/pressure-контекстов и в ряде разгёрнутых ситуаций ИИ «дубасил в стену». 

### Description
- В `script.js` в функции `planPathToPoint` заменено условие активации авто-рикошета: вместо зависимости от `isAttackOrPressureBehavior` введена проверка `isDefenseOrRetreatContext` и логика теперь использует `!isDefenseOrRetreatBehavior`, при этом сохраняются прежние защиты `strictSpecialPathRejectStage`, `isCriticalOrEmergencyStage` и `emergencyBaseDefenseGoal`.

### Testing
- Запущены базовые проверки: `node --check script.js` — успешно, и дымовой тест `node scripts/smoke-ai-forced-non-skip-last-chance.js` — успешно пройден.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e70db55730832da8646d9d40d7f4d3)