### PR TITLE
Prioritize ricochet/gap probing for blocked direct fallback attacks

### DIFF
--- a/script.js
+++ b/script.js
@@ -32311,13 +32311,32 @@ function getFallbackAiMove(context){
 
     for(const enemy of targetEnemies){
       const directPathClear = isPathClear(plane.x, plane.y, enemy.x, enemy.y);
+      const fallbackGoalText = `${aiRoundState?.currentGoal || ""}`.toLowerCase();
+      const isEmergencyGoal = fallbackGoalText.includes("critical_base_threat")
+        || fallbackGoalText.includes("emergency_base_defense");
+      const blockedDirectSpecialPriorityActive = !directPathClear && !isEmergencyGoal;
+      const specialRouteClasses = blockedDirectSpecialPriorityActive
+        ? ["ricochet", "gap"]
+        : ["gap", "ricochet"];
+      if(blockedDirectSpecialPriorityActive){
+        logAiDecision("fallback_blocked_direct_special_priority_enabled", {
+          source: "fallback_attack",
+          planeId: plane?.id ?? null,
+          enemyId: enemy?.id ?? null,
+          directPathClear,
+          emergencyGoal: isEmergencyGoal,
+          priorityOrder: specialRouteClasses,
+        });
+      }
       const routeProbeMove = planPathWithSpecialRouteProbe(plane, enemy.x, enemy.y, {
         goalName: "attack_enemy_plane",
-        decisionReason: directPathClear ? "fallback_attack_competitive_route_probe" : "fallback_attack_blocked_route_probe",
+        decisionReason: blockedDirectSpecialPriorityActive
+          ? "fallback_attack_blocked_route_probe_special_first"
+          : (directPathClear ? "fallback_attack_competitive_route_probe" : "fallback_attack_blocked_route_probe"),
         targetEnemy: enemy,
         enemy,
         context,
-        specialRouteClasses: ["ricochet", "gap"],
+        specialRouteClasses,
         specialAttemptBudget: 2,
         compareLabel: ["fallback_attack_route_probe", plane?.id ?? "", enemy?.id ?? ""],
       });


### PR DESCRIPTION
### Motivation
- Увеличить шанс того, что ИИ попробует рикошет/обход раньше в ситуациях, когда прямая линия до цели закрыта, чтобы не терялись хорошие специальные маршруты из‑за «раннего» выбора прямого варианта. 
- Сохранить осторожное поведение для критических целей (emergency), чтобы не нарушать защитную логику в экстренных сценариях. 

### Description
- Проверка ситуации: добавлено вычисление `blockedDirectSpecialPriorityActive` на основе `isPathClear(...)` и текущей цели `aiRoundState.currentGoal`, при котором режим приоритета активен только если прямая линия закрыта и цель не является emergency (`critical_base_threat` / `emergency_base_defense`).
- Порядок попыток: формируется `specialRouteClasses` как `["ricochet","gap"]` при активном приоритете и как `["gap","ricochet"]` в остальных случаях, и этот массив передаётся в `planPathWithSpecialRouteProbe` вместо жёстко зашитого порядка. 
- Диагностика: добавлен лог-эвент `fallback_blocked_direct_special_priority_enabled` для явной записи в логах, когда новый приоритет включился. 
- Причина решения: подставляется изменённое значение `decisionReason` (`fallback_attack_blocked_route_probe_special_first`) при вызове `planPathWithSpecialRouteProbe`, чтобы поведение было трассируемым в экспортируемых событиях. 
- Файл изменён: `script.js` (внесены вставки рядом с логикой строительства probe-маршрута в `getFallbackAiMove`).

### Testing
- Запущена статическая проверка синтаксиса `node --check script.js`, результат: успешно. 
- Проверен рабочий статус рабочего дерева через `git status --short`, результат: ожидаемо чисто/изменения отмечены (файл `script.js` модифицирован).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7570c8d10832d95748071b8897844)