### PR TITLE
Add AI fallback reporting and download utilities; prioritize special routes when direct path is blocked

### DIFF
--- a/script.js
+++ b/script.js
@@ -13577,6 +13577,83 @@ function exportPathCandidatePassportLogs(limit = 20){
   return json;
 }
 
+function getAiFallbackReportEntries(limit = 400){
+  const safeLimit = Math.max(1, Math.min(1200, Math.floor(Number(limit) || 400)));
+  const events = getBufferedAiDecisionEvents(1200);
+  const filtered = events.filter((entry) => {
+    const reason = `${entry?.reason || ""}`.toLowerCase();
+    const payload = entry?.payload && typeof entry.payload === "object" ? entry.payload : {};
+    const reasonCode = `${payload?.reasonCode || ""}`.toLowerCase();
+    const decisionReason = `${payload?.decisionReason || ""}`.toLowerCase();
+    const goalName = `${payload?.goalName || ""}`.toLowerCase();
+    if(reason.includes("fallback_")) return true;
+    if(reason === "path_candidate_passport") return true;
+    if(reasonCode.includes("fallback")) return true;
+    if(decisionReason.includes("fallback")) return true;
+    return goalName.includes("fallback");
+  });
+  return filtered.slice(-safeLimit);
+}
+
+function exportAiFallbackReport(limit = 400){
+  const logs = getAiFallbackReportEntries(limit);
+  const json = JSON.stringify(logs, null, 2);
+  console.info("[AI_DEBUG] fallback-report-json", json);
+  return json;
+}
+
+function downloadTextAsFile(content, fileName){
+  const safeText = typeof content === "string" ? content : `${content ?? ""}`;
+  const safeFileName = typeof fileName === "string" && fileName.trim().length > 0
+    ? fileName.trim()
+    : `ai-report-${new Date().toISOString().replace(/[:.]/g, "-")}.txt`;
+  if(typeof window === "undefined" || typeof document === "undefined"){
+    return {
+      ok: false,
+      reason: "dom_unavailable",
+      fileName: safeFileName,
+      bytes: safeText.length,
+      content: safeText,
+    };
+  }
+
+  const blob = new Blob([safeText], { type: "application/json;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = safeFileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+
+  return {
+    ok: true,
+    fileName: safeFileName,
+    bytes: safeText.length,
+  };
+}
+
+function downloadPathCandidatePassportLogs(limit = 200, fileName = ""){
+  const json = exportPathCandidatePassportLogs(limit);
+  const normalizedFileName = (typeof fileName === "string" && fileName.trim().length > 0)
+    ? fileName.trim()
+    : `ai-path-passport-${new Date().toISOString().replace(/[:.]/g, "-")}.json`;
+  const result = downloadTextAsFile(json, normalizedFileName);
+  console.info("[AI_DEBUG] path-candidate-passport-download", result);
+  return result;
+}
+
+function downloadAiFallbackReport(limit = 400, fileName = ""){
+  const json = exportAiFallbackReport(limit);
+  const normalizedFileName = (typeof fileName === "string" && fileName.trim().length > 0)
+    ? fileName.trim()
+    : `ai-fallback-report-${new Date().toISOString().replace(/[:.]/g, "-")}.json`;
+  const result = downloadTextAsFile(json, normalizedFileName);
+  console.info("[AI_DEBUG] fallback-report-download", result);
+  return result;
+}
+
 function forceResetCargoNow(){
   const beforeCount = Array.isArray(cargoState) ? cargoState.length : 0;
   const cargoEnabled = Boolean(settings?.addCargo);
@@ -13602,6 +13679,9 @@ if(typeof window !== "undefined"){
   window.RESET_CARGO = forceResetCargoNow;
   window.AI_PRINT_PATH_PASSPORT_LOGS = printPathCandidatePassportLogs;
   window.AI_EXPORT_PATH_PASSPORT_LOGS = exportPathCandidatePassportLogs;
+  window.AI_DOWNLOAD_PATH_PASSPORT_LOGS = downloadPathCandidatePassportLogs;
+  window.AI_EXPORT_FALLBACK_REPORT = exportAiFallbackReport;
+  window.AI_DOWNLOAD_FALLBACK_REPORT = downloadAiFallbackReport;
 }
 
 
@@ -32311,13 +32391,32 @@ function getFallbackAiMove(context){
 
     for(const enemy of targetEnemies){
       const directPathClear = isPathClear(plane.x, plane.y, enemy.x, enemy.y);
+      const fallbackGoalText = `${aiRoundState?.currentGoal || ""}`.toLowerCase();
+      const isEmergencyGoal = fallbackGoalText.includes("critical_base_threat")
+        || fallbackGoalText.includes("emergency_base_defense");
+      const blockedDirectSpecialPriorityActive = !directPathClear && !isEmergencyGoal;
+      const specialRouteClasses = blockedDirectSpecialPriorityActive
+        ? ["ricochet", "gap"]
+        : ["gap", "ricochet"];
+      if(blockedDirectSpecialPriorityActive){
+        logAiDecision("fallback_blocked_direct_special_priority_enabled", {
+          source: "fallback_attack",
+          planeId: plane?.id ?? null,
+          enemyId: enemy?.id ?? null,
+          directPathClear,
+          emergencyGoal: isEmergencyGoal,
+          priorityOrder: specialRouteClasses,
+        });
+      }
       const routeProbeMove = planPathWithSpecialRouteProbe(plane, enemy.x, enemy.y, {
         goalName: "attack_enemy_plane",
-        decisionReason: directPathClear ? "fallback_attack_competitive_route_probe" : "fallback_attack_blocked_route_probe",
+        decisionReason: blockedDirectSpecialPriorityActive
+          ? "fallback_attack_blocked_route_probe_special_first"
+          : (directPathClear ? "fallback_attack_competitive_route_probe" : "fallback_attack_blocked_route_probe"),
         targetEnemy: enemy,
         enemy,
         context,
-        specialRouteClasses: ["ricochet", "gap"],
+        specialRouteClasses,
         specialAttemptBudget: 2,
         compareLabel: ["fallback_attack_route_probe", plane?.id ?? "", enemy?.id ?? ""],
       });


### PR DESCRIPTION
### Motivation
- Provide tools to inspect and export AI fallback-related decision events and path-candidate passport logs for debugging and post-mortem analysis. 
- Prefer selecting special route types (`ricochet`, `gap`) earlier when a direct path is blocked unless an emergency goal is active, to improve fallback attack routing choices. 

### Description
- Added `getAiFallbackReportEntries` and `exportAiFallbackReport` to collect and JSON-export filtered AI decision events that indicate fallback behavior. 
- Implemented `downloadTextAsFile`, `downloadPathCandidatePassportLogs`, and `downloadAiFallbackReport` to enable saving exported JSON to disk, and exposed them on `window` as `AI_DOWNLOAD_PATH_PASSPORT_LOGS`, `AI_EXPORT_FALLBACK_REPORT`, and `AI_DOWNLOAD_FALLBACK_REPORT`. 
- Adjusted fallback attack routing logic in `getFallbackAiMove` to detect emergency goals, compute `blockedDirectSpecialPriorityActive`, change `specialRouteClasses` ordering accordingly, and log when the special-first priority is enabled; also update the `decisionReason` passed to `planPathWithSpecialRouteProbe`. 

### Testing
- Ran the test suite with `npm test` and code quality checks with `npm run lint`, both of which completed successfully. 
- Built the project with `npm run build` to validate there are no bundling/runtime syntax errors, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7570c8d10832d95748071b8897844)