### PR TITLE
Improve Step 2 AI enemy attack selection using simulated shots

### DIFF
--- a/script.js
+++ b/script.js
@@ -14717,26 +14717,62 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
         }
       }
 
-      const directEnemyCandidate = enemyPlanes
+      const buildSimulatedEnemyCandidate = (enemy) => {
+        if(!enemy) return null;
+        const simulated = findBestSimulatedShot(launchReadyPlane, enemy, { maxBounces: 3 });
+        const sim = simulated?.sim;
+        if(!sim || !sim.hitTarget) return null;
+        const launchScale = Math.max(0.1, Math.min(1, Number.isFinite(sim.launchVector?.scale) ? sim.launchVector.scale : 1));
+        const launchDx = Number(sim.launchVector?.dx);
+        const launchDy = Number(sim.launchVector?.dy);
+        if(!Number.isFinite(launchDx) || !Number.isFinite(launchDy)) return null;
+        const dirLen = Math.hypot(launchDx, launchDy);
+        if(!(dirLen > 0)) return null;
+        const normDx = launchDx / dirLen;
+        const normDy = launchDy / dirLen;
+        const effectiveRangePx = getPlaneEffectiveRangePx(launchReadyPlane);
+        const travelPx = Math.max(1, effectiveRangePx * launchScale);
+        const landingX = launchReadyPlane.x + normDx * travelPx;
+        const landingY = launchReadyPlane.y + normDy * travelPx;
+        if(!Number.isFinite(landingX) || !Number.isFinite(landingY)) return null;
+        const bouncedShot = sim.bounceCount > 0;
+        return {
+          plane: launchReadyPlane,
+          landingX,
+          landingY,
+          targetPoint: { x: enemy.x, y: enemy.y },
+          decisionReason: bouncedShot ? "simple_step2_ricochet_enemy" : "simple_step2_direct_enemy",
+          goalName: "simple_step2_attack_enemy",
+          whyChosen: `simulated_hit_enemy_id_${enemy.id || "unknown"}_bounces_${sim.bounceCount}`,
+          routeClass: bouncedShot ? "ricochet" : "direct",
+          bounceCount: sim.bounceCount,
+          simulatedScore: simulated.score,
+          predictedOutcome: sim.predictedOutcome,
+        };
+      };
+
+      const attackCandidates = enemyPlanes
         .map((enemy) => {
           const enemyDistance = dist(launchReadyPlane, enemy);
           const inRange = enemyDistance <= maxFlightDistancePx * 1.05;
           const directPath = isPathClear(launchReadyPlane.x, launchReadyPlane.y, enemy.x, enemy.y);
           if(!inRange || directPath !== true) return null;
-          const move = buildMoveTowardTarget(launchReadyPlane, enemy, maxFlightDistancePx, {
-            decisionReason: "simple_step2_direct_enemy",
-            goalName: "simple_step2_attack_enemy",
-            whyChosen: `direct_enemy_hit_enemy_id_${enemy.id || "unknown"}`,
-          });
+          // Симулятор сам ограничивает дальность scale-ом; здесь — sanity-лимит, ослабленный для рикошета.
+          if(!(enemyDistance <= maxFlightDistancePx * 1.8)) return null;
+          const move = buildSimulatedEnemyCandidate(enemy);
           if(!move) return null;
-          return { enemy, move, enemyDistance };
+          return { enemy, move, enemyDistance, score: move.simulatedScore };
         })
         .filter(Boolean)
-        .sort((a, b) => a.enemyDistance - b.enemyDistance)[0] || null;
+        .sort((a, b) => {
+          if(Math.abs((a.score ?? 0) - (b.score ?? 0)) > 0.0001) return (b.score ?? 0) - (a.score ?? 0);
+          return a.enemyDistance - b.enemyDistance;
+        });
+      const bestAttackCandidate = attackCandidates[0] || null;
 
-      let selectedPlan = directEnemyCandidate?.move || null;
+      let selectedPlan = bestAttackCandidate?.move || null;
       let planTier = 1;
-      let planDistance = Number.isFinite(directEnemyCandidate?.enemyDistance) ? directEnemyCandidate.enemyDistance : Number.POSITIVE_INFINITY;
+      let planDistance = Number.isFinite(bestAttackCandidate?.enemyDistance) ? bestAttackCandidate.enemyDistance : Number.POSITIVE_INFINITY;
 
       if(!selectedPlan){
         selectedPlan = buildMoveTowardTarget(launchReadyPlane, centerTarget, maxFlightDistancePx, {
@@ -14748,7 +14784,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
         planDistance = selectedPlan ? Math.hypot(selectedPlan.landingX - launchReadyPlane.x, selectedPlan.landingY - launchReadyPlane.y) : Number.POSITIVE_INFINITY;
       }
 
-      if(selectedPlan && nearestCargo && !directEnemyCandidate){
+      if(selectedPlan && nearestCargo && !bestAttackCandidate){
         const cargoMove = buildMoveTowardTarget(launchReadyPlane, nearestCargo.center, maxFlightDistancePx, {
           decisionReason: "simple_step2_pickup_cargo",
           goalName: "simple_step2_cargo",
@@ -14774,7 +14810,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
           ...selectedPlan,
           planTier,
           planDistance,
-          hasDirectEnemy: Boolean(directEnemyCandidate),
+          hasDirectEnemy: Boolean(bestAttackCandidate),
           readyCargoCount: readyCargo.length,
         });
       }
@@ -14839,6 +14875,10 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       },
       directEnemyCandidate: Boolean(selectedPlan.hasDirectEnemy),
       readyCargoCount: selectedPlan.readyCargoCount ?? readyCargo.length,
+      routeClass: selectedPlan.routeClass || "direct",
+      bounceCount: Number.isFinite(selectedPlan.bounceCount) ? selectedPlan.bounceCount : 0,
+      simulatedScore: Number.isFinite(selectedPlan.simulatedScore) ? Number(selectedPlan.simulatedScore.toFixed(2)) : null,
+      predictedOutcome: selectedPlan.predictedOutcome || null,
     });
 
     let launchResult = tryIssueAiMoveWithInventory({


### PR DESCRIPTION
### Motivation
- Заменить простую выборку «прямого» врага на более надёжный выбор, основанный на прогоне симуляции выстрела (включая рикошеты), чтобы ИИ не выбирал мимо при более хитрых траекториях. 
- Добавить телеметрию (метаданные симуляции) в логи для упрощения отладки и понимания решений ИИ.

### Description
- Добавлен `buildSimulatedEnemyCandidate` который для каждого врага прогоняет `findBestSimulatedShot` и строит кандидат-ход с учётом направления, дальности, числа отскоков и оценки симуляции. 
- Вместо прежнего `directEnemyCandidate` собраны `attackCandidates`, которые сортируются по `simulatedScore` (с учётом дистанции как вторичного критерия) и выбирается `bestAttackCandidate`. 
- Обновлена логика выбора плана: используются симулированные ходы, при отсутствии подходящих кандидатов сохраняются прежние fallback-стратегии (центр/груз), а флаг `hasDirectEnemy` теперь отражает наличие `bestAttackCandidate`. 
- Расширены поля в `logAiDecision` и в итоговом запуске хода: добавлены `routeClass`, `bounceCount`, `simulatedScore` и `predictedOutcome` для облегчения диагностики.

### Testing
- Синтаксическая проверка `node --check script.js` выполнена успешно. 
- Изменения закоммичены в репозиторий и готовы для дальнейшего тестирования в рантайме.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e887816dc8832da59c3de23cdebc3f)