### PR TITLE
Improve ricochet persistence before fallback when direct path is blocked

### DIFF
--- a/script.js
+++ b/script.js
@@ -36063,7 +36063,16 @@ function planPathToPoint(plane, tx, ty, options = {}){
 
   function flushPathCandidatePassportSummary(extra = {}){
     if(pathCandidatePassportEntries.length === 0){
-      return;
+      pushPathCandidatePassportEntry({
+        event: "candidate_rejected",
+        stage: "candidate_generation",
+        candidateClass: requestedRouteClass || "direct",
+        moveType: requestedRouteClass === "ricochet" ? "mirror" : "direct",
+        decisionReason: options?.decisionReason || null,
+        goalName: options?.goalName || aiRoundState?.currentGoal || null,
+        killedAtStage: "candidate_generation",
+        killedByReason: planPathToPoint.lastRejectCode || "no_candidates_generated",
+      });
     }
     logAiDecision("path_candidate_passport", {
       planeId: plane?.id ?? null,
@@ -36384,6 +36393,62 @@ function planPathToPoint(plane, tx, ty, options = {}){
     } else {
       mirrorRejectCode = "v2_simulation_candidate_not_found";
       planPathToPoint.lastRejectMeta = null;
+    }
+  }
+
+  if(allowExperimentalRicochet){
+    const hasRicochetCandidate = candidateBasket.some((candidate) => candidate?.candidateClass === "ricochet");
+    if(!hasRicochetCandidate){
+      const fallbackMirror = findMirrorShot(plane, { x: tx, y: ty }, {
+        logReject: true,
+        pressureBoost: hasDirectLine ? 0 : AI_MIRROR_STUCK_RECOVERY_PRESSURE_BONUS * 0.35,
+        minBounceDistanceScale: hasDirectLine ? 1 : 0.88,
+        maxPathRatioBonus: hasDirectLine ? 0.02 : 0.08,
+        goalName: options?.goalName || "",
+        allowNormalModeFirstSegmentRelaxation: !strictSpecialPathRejectStage,
+        allowGapBeforeBounceGrace: !hasDirectLine,
+        allowGapAfterBounceGrace: !hasDirectLine,
+        allowGapFinalLegRelaxation: !hasDirectLine,
+        allowRicochetBeforeBounceBorderline: !hasDirectLine,
+      });
+      if(fallbackMirror){
+        const dx = fallbackMirror.mirrorTarget.x - plane.x;
+        const dy = fallbackMirror.mirrorTarget.y - plane.y;
+        const baseAngle = Math.atan2(dy, dx);
+        const baseScale = Math.min(fallbackMirror.totalDist / Math.max(1, flightDistancePx), 1);
+        const scale = applyAiMinLaunchScale(baseScale, {
+          source: "plan_path_mirror_fallback_probe",
+          planeId: plane?.id ?? null,
+          goalName: options?.goalName || null,
+          decisionReason: options?.decisionReason || null,
+          moveDistance: fallbackMirror.totalDist,
+          targetX: tx,
+          targetY: ty,
+        });
+        const mirrorMove = buildMoveWithSafeDeviation(baseAngle, fallbackMirror.totalDist, scale, {
+          moveType: "mirror",
+          candidateClass: "ricochet",
+        });
+        if(mirrorMove){
+          mirrorMove.routeQualityScore = Number.isFinite(fallbackMirror.mirrorQualityScore)
+            ? fallbackMirror.mirrorQualityScore
+            : mirrorMove.routeQualityScore;
+          logAiDecision("mirror_selected_reason", {
+            source: "plan_path_to_point",
+            reason: hasDirectLine ? "parallel_ricochet_probe" : "direct_blocked_mirror_fallback_probe",
+            planeId: plane?.id ?? null,
+            targetEnemyId: options?.targetEnemy?.id ?? options?.targetEnemyId ?? null,
+            clearSky: isCurrentMapClearSky(),
+            pathDistance: Number(fallbackMirror.totalDist.toFixed(1)),
+          });
+          registerCandidate(mirrorMove);
+        }
+      } else {
+        mirrorRejectCode = mirrorRejectCode || findMirrorShot.lastRejectCode || "mirror_fallback_probe_not_found";
+        if(!planPathToPoint.lastRejectMeta){
+          planPathToPoint.lastRejectMeta = findMirrorShot.lastRejectMeta || null;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- Diagnostics showed many turns with empty `path_candidate_passport` entries and fast fallback when direct lines were blocked, which hid why ricochet/gap candidates were not attempted or selected. 
- The aim is to make the AI try ricochets more persistently (when direct is blocked or competing) before conceding to fallback, and to make diagnostics informative.

### Description
- Ensure `flushPathCandidatePassportSummary` always logs a minimal `candidate_rejected` entry when no candidates were generated so `path_candidate_passport` never emits an empty `entries: []` payload. 
- Add an extra mirror-based ricochet probe inside `planPathToPoint` when `allowExperimentalRicochet` is true and no ricochet candidate was registered from simulation, using slightly relaxed parameters when the direct line is blocked. 
- When the fallback mirror probe runs, build and `registerCandidate` for a generated mirror move so ricochet candidates get a real chance in final ranking. 
- Preserve and propagate `mirrorRejectCode` / `findMirrorShot.lastRejectMeta` into `planPathToPoint.lastReject*` for improved diagnostics and failure reasons.

### Testing
- Ran syntax check: `node --check script.js` — passed. 
- Ran smoke test: `node scripts/smoke-ai-forced-non-skip-last-chance.js` — passed. 
- Ran `node scripts/smoke-player-vs-ai-gap-export.js` — failed in this environment due to missing expected `window` export wiring (the failure is unrelated to the changes and reflects test bootstrap expectations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8aa427860832d91f0ec7591d87d44)