### PR TITLE
Отмена "липкого" прицеливания при коротком втором тапе

### DIFF
--- a/script.js
+++ b/script.js
@@ -17638,6 +17638,7 @@ function onCanvasPointerUp(e){
     const launchY = holdResult.moved ? y : handleCircle.pointerDownStartY;
     const tapDistanceFromPlane = Math.hypot(launchX - plane.x, launchY - plane.y);
     if(!holdResult.moved && tapDistanceFromPlane < CELL_SIZE){
+      cancelAimSessionWithoutLaunch();
       e.preventDefault();
       return;
     }
@@ -17699,6 +17700,7 @@ function onGlobalStickyAimPointerUpOrCancel(e){
   const launchY = holdResult.moved ? y : handleCircle.pointerDownStartY;
   const tapDistanceFromPlane = Math.hypot(launchX - plane.x, launchY - plane.y);
   if(!holdResult.moved && tapDistanceFromPlane < CELL_SIZE){
+    cancelAimSessionWithoutLaunch();
     return;
   }
 
@@ -17976,6 +17978,18 @@ function onHandleUp(){
   cleanupHandle();
   updateBoardCursorForHover(baseX, baseY);
 }
+
+function cancelAimSessionWithoutLaunch(){
+  if(!isAimSessionActive()) return;
+  const { baseX, baseY } = aimSession;
+  const plane = aimSession.planeRef;
+  if(plane){
+    plane.angle = aimSession.origAngle;
+  }
+  cleanupHandle();
+  updateBoardCursorForHover(baseX, baseY);
+}
+
 function cleanupHandle(){
   handleCircle.active= false;
   handleCircle.controllerType = null;


### PR DESCRIPTION
### Motivation
- В sticky-режиме (схватил самолёт одним тапом, запускаешь вторым) короткий второй тап раньше не отменял прицеливание и игрок оставался «залипшим», что мешало выбрать другой самолёт.

### Description
- Добавлена функция `cancelAimSessionWithoutLaunch()` которая корректно закрывает активную сессию прицеливания, восстанавливает угол самолёта и обновляет курсор/интерфейс.
- В обработчиках отпуска для sticky-режима (`onCanvasPointerUp` и `onGlobalStickyAimPointerUpOrCancel`) при распознавании короткого второго тапа (расстояние < `CELL_SIZE` и без движения) теперь вызывается новая функция вместо игнорирования события.
- Изменения находятся в `script.js` и затрагивают логику завершения/отмены прицеливания в sticky-сценариях, поведение запуска при обычном отпуске не изменено.

### Testing
- Выполнена статическая проверка синтаксиса: `cd /workspace/p-p-online && node --check script.js` — успешно.
- Тестов UI в автоматическом окружении не запускалось (изменение поведение UI-обработчиков), ручная проверка в браузере рекомендуется для подтверждения UX-поведения при коротком тапе.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9bf10f0b4832daec2b69a4aeea920)