### PR TITLE
Не сбрасывать sticky-aim сразу после первого тапа

### DIFF
--- a/script.js
+++ b/script.js
@@ -17493,12 +17493,7 @@ function onCanvasPointerDown(e){
   } else if(pendingInventoryUse) {
     handleStart(e);
   } else {
-    const { x: designX, y: designY } = getPointerDesignCoords(e);
-    const { x, y } = designToBoardCoords(designX, designY);
     handleStart(e);
-    if(shouldUseStickyAimForPointerEvent(e)){
-      beginStickyAimHoldTracking(e, x, y);
-    }
   }
 }
 


### PR DESCRIPTION
### Motivation

- Исправить баг, при котором режим «липкого прицеливания» (sticky aim) сразу сбрасывался после первого касания из‑за преждевременного запуска отслеживания удержания. 

### Description

- В `script.js` в обработчике `onCanvasPointerDown` удалён предварительный вызов `beginStickyAimHoldTracking` в ветке, когда прицел ещё не активен, чтобы первый тап только активировал сессию прицеливания через `handleStart` и не начинал трекать удержание.
- Удалено лишнее получение координат в этой ветке (`getPointerDesignCoords` / `designToBoardCoords`), так как эти значения больше не используются после правки.
- Изменение ограничивает запуск логики удержания только для уже активной сессии (`handleCircle.active`), сохраняя существующее поведение для второго касания/держания и для глобальных обработчиков.

### Testing

- Запущена проверка синтаксиса: `cd /workspace/p-p-online && node --check script.js` — успешно (без ошибок).
- UI-скриншот не приложен, так как в окружении нет инструмента для снятия скриншотов (интерактивное тестирование вручную не выполнялось).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9cc1b5a34832db99c25975bc96d71)