### PR TITLE
Вернуть практичное использование инвентаря ИИ: выполнимые кандидаты для мины/динамита и лёгкий плюс к баффам

### DIFF
--- a/script.js
+++ b/script.js
@@ -25723,19 +25723,35 @@ function buildAiInventoryCandidatePlans(context, plannedMove){
     const mineExpectedBenefit = hasEnemyPressure ? 0.42 : 0.27;
     const mineRisk = hasEnemyPressure ? 0.1 : 0.08;
 
-    pushCandidate({
-      itemType: INVENTORY_ITEM_TYPES.MINE,
-      target: priorityEnemy || enemyBase || landingPoint || null,
-      expectedBenefit: mineExpectedBenefit,
-      risk: mineRisk,
-      reason: hasEnemyPressure ? "mine_pressure_control" : "mine_area_control",
-      whyBetter: hasEnemyPressure
-        ? "enemy is already close, so a mine now quickly creates denial space and makes the immediate response harder"
-        : "even without a perfect trap, an early mine gives stable area control and is cheap enough to spend",
-      usageTier: hasEnemyPressure ? "strong" : "moderate",
-      mineDecisionLabel: hasEnemyPressure ? "pressure_control" : "area_control",
-      reasonCode: hasEnemyPressure ? "mine_pressure_control" : "mine_area_control",
-    });
+    const defensiveMineProbe = typeof tryPlaceBlueDefensiveMine === "function"
+      ? tryPlaceBlueDefensiveMine(context, plannedMove, { evaluateOnly: true })
+      : null;
+    const baseMineProbe = typeof tryPlaceBlueMineNearEnemyBase === "function"
+      ? tryPlaceBlueMineNearEnemyBase(context, plannedMove, { evaluateOnly: true })
+      : null;
+    const minePlan = defensiveMineProbe || baseMineProbe || null;
+
+    if(minePlan?.placement){
+      pushCandidate({
+        itemType: INVENTORY_ITEM_TYPES.MINE,
+        target: priorityEnemy || enemyBase || landingPoint || null,
+        expectedBenefit: mineExpectedBenefit,
+        risk: mineRisk,
+        reason: hasEnemyPressure ? "mine_pressure_control" : "mine_area_control",
+        whyBetter: hasEnemyPressure
+          ? "enemy is already close, so a mine now quickly creates denial space and makes the immediate response harder"
+          : "even without a perfect trap, an early mine gives stable area control and is cheap enough to spend",
+        usageTier: hasEnemyPressure ? "strong" : "moderate",
+        mineDecisionLabel: hasEnemyPressure ? "pressure_control" : "area_control",
+        reasonCode: hasEnemyPressure ? "mine_pressure_control" : "mine_area_control",
+        minePlan,
+        placementMode: minePlan?.scenario?.includes("defensive") ? "defensive" : "base",
+      });
+    } else {
+      rejectCandidate(INVENTORY_ITEM_TYPES.MINE, "mine_no_fast_placement", {
+        whyWaiting: "no quick safe mine placement found for current route context",
+      });
+    }
   }
 
   if(allowTacticalItems && inventory.counts?.[INVENTORY_ITEM_TYPES.DYNAMITE] > 0){
@@ -25746,15 +25762,31 @@ function buildAiInventoryCandidatePlans(context, plannedMove){
           .sort((a, b) => a.d - b.d)[0] || null
       : null;
 
-    if(simpleDynamiteTarget){
-      const isNearObstacle = simpleDynamiteTarget.d <= CELL_SIZE * 10;
+    const tacticalDynamiteDecision = typeof evaluateAiDynamiteTacticalTarget === "function"
+      ? evaluateAiDynamiteTacticalTarget(context, plannedMove, { allowStrategicProbeWhenRouteAware: true })
+      : null;
+    const tacticalFallbackTarget = tacticalDynamiteDecision?.fallbackTarget || null;
+    const resolvedDynamiteTarget = simpleDynamiteTarget
+      ? {
+        x: simpleDynamiteTarget.collider.cx,
+        y: simpleDynamiteTarget.collider.cy,
+        colliderId: simpleDynamiteTarget.collider?.id ?? null,
+      }
+      : (Number.isFinite(tacticalFallbackTarget?.cx) && Number.isFinite(tacticalFallbackTarget?.cy)
+        ? {
+          x: tacticalFallbackTarget.cx,
+          y: tacticalFallbackTarget.cy,
+          colliderId: tacticalFallbackTarget?.collider?.id ?? null,
+          spriteId: tacticalFallbackTarget?.id ?? null,
+        }
+        : null);
+
+    if(resolvedDynamiteTarget){
+      const resolvedDist = dist(plannedMove.plane, resolvedDynamiteTarget);
+      const isNearObstacle = resolvedDist <= CELL_SIZE * 10;
       pushCandidate({
         itemType: INVENTORY_ITEM_TYPES.DYNAMITE,
-        target: {
-          x: simpleDynamiteTarget.collider.cx,
-          y: simpleDynamiteTarget.collider.cy,
-          colliderId: simpleDynamiteTarget.collider?.id ?? null,
-        },
+        target: resolvedDynamiteTarget,
         expectedBenefit: isNearObstacle ? 0.36 : 0.24,
         risk: isNearObstacle ? 0.09 : 0.07,
         reason: isNearObstacle ? "dynamite_open_near_obstacle" : "dynamite_open_map",
@@ -25849,6 +25881,13 @@ function buildAiInventoryCandidatePlans(context, plannedMove){
     candidate.directUtility = Number(directUtility.toFixed(3));
     candidate.adjustedComparableScore = candidate.directUtility;
     candidate.releaseReady = true;
+    if(candidate.itemType === INVENTORY_ITEM_TYPES.FUEL
+      || candidate.itemType === INVENTORY_ITEM_TYPES.CROSSHAIR
+      || candidate.itemType === INVENTORY_ITEM_TYPES.WINGS
+      || candidate.itemType === INVENTORY_ITEM_TYPES.INVISIBILITY){
+      candidate.directUtility = Number((candidate.directUtility + 0.035).toFixed(3));
+      candidate.adjustedComparableScore = candidate.directUtility;
+    }
   }
 
   let selectedCandidate = null;


### PR DESCRIPTION
### Motivation
- После упрощения эвристик генерации кандидатов ИИ стал редко применять предметы из инвентаря, что было вызвано тем, что для некоторых тактических предметов (особенно мина) создавались кандидаты без валидной точки установки, из‑за чего применение проваливалось.
- Нужно вернуть частое и быстрое использование инвентаря без возвращения «тяжёлых» просчётов, чтобы не возникали фризы при принятии решения перед ходом.
- Цель — обеспечить, чтобы кандидаты были выполнимыми и лёгкие баффы тратились проще, сохранив низкую вычислительную нагрузку.

### Description
- При генерации кандидатов для мины добавлены быстрые evaluate-only пробы `tryPlaceBlueDefensiveMine` / `tryPlaceBlueMineNearEnemyBase`, и кандидат создаётся только если найден `minePlan`; в противном случае кандидат явно отклоняется с причиной `mine_no_fast_placement`.
- Для динамита добавлена более надёжная резолюция цели: сначала простой ближайший коллайдер, а если его нет — используется резерв из `evaluateAiDynamiteTacticalTarget` (если доступен), чтобы увеличить шанс реального применения.
- В результатах кандидатов к лёгким бафф‑предметам (`FUEL`, `CROSSHAIR`, `WINGS`, `INVISIBILITY`) при финальном сравнении добавлен небольшой мягкий бонус полезности (+0.035) для повышения частоты их использования без тяжёлых симуляций.
- Логика выбора последовательностей и финальная часть сравнения кандидатов оставлены прежними, чтобы не менять общую структуру принятия решения и сохранить быстрые эвристики.

### Testing
- Запущена быстрая синтаксическая проверка: `node --check script.js`, проверка прошла успешно.
- Изменения протестированы на предмет отсутствия синтаксических ошибок и совмещены с существующей логикой выбора кандидатов (без медленных веток оценки).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb129312d4832db1fa71510db15d75)