### PR TITLE
Fix cargo risk gate for ricochet/gap/mirror route candidates

### DIFF
--- a/script.js
+++ b/script.js
@@ -9649,7 +9649,7 @@ function buildAiCargoRouteCandidate(plane, cargo, context, routeTarget, routeCla
     || routeTarget.usedRicochetHint === true
     || move?.candidateClass === "ricochet"
     || move?.moveType === "mirror";
-  const riskInfo = evaluateCargoPickupRisk(plane, cargo, context);
+  const riskInfo = evaluateCargoPickupRisk(plane, cargo, context, move);
   const favorableInfo = evaluateFavorableCargoCandidate(plane, cargo, move, riskInfo);
 
   return {
@@ -29176,7 +29176,7 @@ function tryPlanOpeningCenterControlMove(context){
         markPathRejectCode(planPathToPoint.lastRejectCode);
         continue;
       }
-      const riskInfo = evaluateCargoPickupRisk(plane, cargo, context);
+      const riskInfo = evaluateCargoPickupRisk(plane, cargo, context, move);
       const favorableInfo = evaluateFavorableCargoCandidate(plane, cargo, move, riskInfo);
       const canTakeCargo = riskInfo.isSafePath
         && (riskInfo.totalRisk <= AI_CARGO_RISK_ACCEPTANCE || favorableInfo?.isFavorableCargo);
@@ -29307,14 +29307,18 @@ function estimateCargoInterceptionChance(plane, cargoCenter, enemies){
   return Math.min(1, threateningEnemies / Math.max(1, enemies.length));
 }
 
-function evaluateCargoPickupRisk(plane, cargo, context){
+function evaluateCargoPickupRisk(plane, cargo, context, move = null){
   const cargoCenter = getCargoVisualCenter(cargo);
   const nearestEnemyDistance = Array.isArray(context?.enemies) && context.enemies.length > 0
     ? Math.min(...context.enemies.map((enemy) => dist(enemy, cargoCenter)))
     : Number.POSITIVE_INFINITY;
   const interceptionChance = estimateCargoInterceptionChance(plane, cargoCenter, context?.enemies || []);
   const carryingEnemyFlag = Boolean(plane?.carriedFlagId && getFlagById(plane.carriedFlagId)?.color === "green");
-  const isSafePath = isPathClear(plane.x, plane.y, cargoCenter.x, cargoCenter.y);
+  const isSpecialRouteMove = move?.candidateClass === "ricochet"
+    || move?.candidateClass === "gap"
+    || move?.moveType === "mirror";
+  const isDirectPathSafe = isPathClear(plane.x, plane.y, cargoCenter.x, cargoCenter.y);
+  const isSafePath = isSpecialRouteMove ? true : isDirectPathSafe;
 
   let risk = 0;
   risk += nearestEnemyDistance < ATTACK_RANGE_PX ? 0.55 : nearestEnemyDistance < ATTACK_RANGE_PX * 1.5 ? 0.3 : 0.1;
@@ -29328,6 +29332,8 @@ function evaluateCargoPickupRisk(plane, cargo, context){
     interceptionChance,
     carryingEnemyFlag,
     isSafePath,
+    isDirectPathSafe,
+    isSpecialRouteMove,
     cargoCenter,
   };
 }


### PR DESCRIPTION
### Motivation
- Cargo pickup candidates reachable via special routes (`ricochet`, `gap`, `mirror`) were being rejected because cargo risk used only a direct-line check (`isPathClear`) and marked blocked direct paths as unsafe, causing unnecessary fallbacks.
- Attack logic already accepts non-direct routes (mirror/ricochet), so cargo logic needed to be aligned to avoid asymmetry where planes attack by ricochet but cargo pickups fall back.

### Description
- Updated `evaluateCargoPickupRisk` to accept an optional `move` parameter (`evaluateCargoPickupRisk(plane, cargo, context, move = null)`) and added detection of special-route moves via `move?.candidateClass` / `move?.moveType`.
- Treats special-route moves (`ricochet`, `gap`, `mirror`) as path-safe for cargo gating (sets `isSafePath = true` for these), while keeping direct-path safety available as `isDirectPathSafe` for diagnostics.
- Propagated the planned `move` into cargo-planning call sites (`buildAiCargoRouteCandidate` and opening-center cargo probe) so the risk function can consider the chosen route.
- Exposed new diagnostic fields in the returned risk object: `isDirectPathSafe` and `isSpecialRouteMove` to preserve observability of the decision.

### Testing
- Ran syntax check with `node --check script.js`, which completed successfully.
- Changes were committed (`git commit`) with message: "Fix cargo risk gate for ricochet route candidates".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb13402830832da9d63d24f6ace3b3)