### PR TITLE
AI inventory: add fast mine/dynamite placement and improve candidate evaluation

### DIFF
--- a/script.js
+++ b/script.js
@@ -25621,6 +25621,48 @@ function buildAiInventoryCandidatePlans(context, plannedMove){
   const fuelUnlockMeta = compareAiItemUnlockMoveClass(baseUnlockMetrics, fuelUnlockMetrics);
   const wingsUnlockMeta = compareAiItemUnlockMoveClass(baseUnlockMetrics, wingsUnlockMetrics);
   const fuelAndWingsUnlockMeta = compareAiItemUnlockMoveClass(baseUnlockMetrics, fuelAndWingsUnlockMetrics);
+  const quickMinePlacement = (() => {
+    const plane = plannedMove?.plane || null;
+    if(!plane) return null;
+    const localLandingPoint = landingPoint || getAiMoveLandingPoint(plannedMove) || null;
+    const nearestEnemy = Array.isArray(context?.enemies) && context.enemies.length > 0
+      ? context.enemies
+          .map((enemy) => ({ enemy, d: dist(plane, enemy) }))
+          .sort((a, b) => a.d - b.d)[0]?.enemy || null
+      : null;
+    const mineTargets = [priorityEnemy, nearestEnemy, enemyBase, localLandingPoint].filter(Boolean);
+    const pointOffsets = [
+      { ox: 0, oy: 0 },
+      { ox: 0.8, oy: 0.4 },
+      { ox: -0.8, oy: 0.4 },
+      { ox: 0.8, oy: -0.4 },
+      { ox: -0.8, oy: -0.4 },
+      { ox: 0, oy: 0.95 },
+    ];
+    const safeRadius = Math.max(12, MINE_TRIGGER_RADIUS * 1.2);
+    for(const target of mineTargets){
+      if(!Number.isFinite(target?.x) || !Number.isFinite(target?.y)) continue;
+      for(const offset of pointOffsets){
+        const px = target.x + offset.ox * CELL_SIZE;
+        const py = target.y + offset.oy * CELL_SIZE;
+        const placement = {
+          x: px,
+          y: py,
+          cellX: Math.floor((px - FIELD_LEFT) / CELL_SIZE),
+          cellY: Math.floor((py - FIELD_TOP) / CELL_SIZE),
+        };
+        if(!isMinePlacementValid(placement)) continue;
+        if(localLandingPoint && dist(localLandingPoint, placement) <= safeRadius) continue;
+        if(dist(plane, placement) <= safeRadius) continue;
+        return {
+          placement,
+          scenario: "fast_inventory_mine",
+          score: 0.34,
+        };
+      }
+    }
+    return null;
+  })();
   const pushCandidate = (candidate) => {
     const normalizedBenefit = Number.isFinite(candidate?.expectedBenefit) ? candidate.expectedBenefit : 0;
     const normalizedRisk = Number.isFinite(candidate?.risk) ? candidate.risk : 0;
@@ -25723,38 +25765,57 @@ function buildAiInventoryCandidatePlans(context, plannedMove){
     const mineExpectedBenefit = hasEnemyPressure ? 0.42 : 0.27;
     const mineRisk = hasEnemyPressure ? 0.1 : 0.08;
 
-    pushCandidate({
-      itemType: INVENTORY_ITEM_TYPES.MINE,
-      target: priorityEnemy || enemyBase || landingPoint || null,
-      expectedBenefit: mineExpectedBenefit,
-      risk: mineRisk,
-      reason: hasEnemyPressure ? "mine_pressure_control" : "mine_area_control",
-      whyBetter: hasEnemyPressure
-        ? "enemy is already close, so a mine now quickly creates denial space and makes the immediate response harder"
-        : "even without a perfect trap, an early mine gives stable area control and is cheap enough to spend",
-      usageTier: hasEnemyPressure ? "strong" : "moderate",
-      mineDecisionLabel: hasEnemyPressure ? "pressure_control" : "area_control",
-      reasonCode: hasEnemyPressure ? "mine_pressure_control" : "mine_area_control",
-    });
+    const minePlan = quickMinePlacement;
+
+    if(minePlan?.placement){
+      pushCandidate({
+        itemType: INVENTORY_ITEM_TYPES.MINE,
+        target: priorityEnemy || enemyBase || landingPoint || null,
+        expectedBenefit: mineExpectedBenefit,
+        risk: mineRisk,
+        reason: hasEnemyPressure ? "mine_pressure_control" : "mine_area_control",
+        whyBetter: hasEnemyPressure
+          ? "enemy is already close, so a mine now quickly creates denial space and makes the immediate response harder"
+          : "even without a perfect trap, an early mine gives stable area control and is cheap enough to spend",
+        usageTier: hasEnemyPressure ? "strong" : "moderate",
+        mineDecisionLabel: hasEnemyPressure ? "pressure_control" : "area_control",
+        reasonCode: hasEnemyPressure ? "mine_pressure_control" : "mine_area_control",
+        minePlan,
+        placementMode: minePlan?.scenario?.includes("defensive") ? "defensive" : "base",
+      });
+    } else {
+      rejectCandidate(INVENTORY_ITEM_TYPES.MINE, "mine_no_fast_placement", {
+        whyWaiting: "no quick safe mine placement found for current route context",
+      });
+    }
   }
 
   if(allowTacticalItems && inventory.counts?.[INVENTORY_ITEM_TYPES.DYNAMITE] > 0){
-    const simpleDynamiteTarget = Array.isArray(colliders)
-      ? colliders
-          .filter((collider) => Number.isFinite(collider?.cx) && Number.isFinite(collider?.cy))
-          .map((collider) => ({ collider, d: dist(plannedMove.plane, { x: collider.cx, y: collider.cy }) }))
-          .sort((a, b) => a.d - b.d)[0] || null
-      : null;
+    let resolvedDynamiteTarget = null;
+    if(Array.isArray(colliders) && colliders.length > 0){
+      let nearestDist = Number.POSITIVE_INFINITY;
+      const maxColliderChecks = Math.min(colliders.length, 140);
+      for(let i = 0; i < maxColliderChecks; i += 1){
+        const collider = colliders[i];
+        if(!Number.isFinite(collider?.cx) || !Number.isFinite(collider?.cy)) continue;
+        const d = dist(plannedMove.plane, { x: collider.cx, y: collider.cy });
+        if(d < nearestDist){
+          nearestDist = d;
+          resolvedDynamiteTarget = {
+            x: collider.cx,
+            y: collider.cy,
+            colliderId: collider?.id ?? null,
+          };
+        }
+      }
+    }
 
-    if(simpleDynamiteTarget){
-      const isNearObstacle = simpleDynamiteTarget.d <= CELL_SIZE * 10;
+    if(resolvedDynamiteTarget){
+      const resolvedDist = dist(plannedMove.plane, resolvedDynamiteTarget);
+      const isNearObstacle = resolvedDist <= CELL_SIZE * 10;
       pushCandidate({
         itemType: INVENTORY_ITEM_TYPES.DYNAMITE,
-        target: {
-          x: simpleDynamiteTarget.collider.cx,
-          y: simpleDynamiteTarget.collider.cy,
-          colliderId: simpleDynamiteTarget.collider?.id ?? null,
-        },
+        target: resolvedDynamiteTarget,
         expectedBenefit: isNearObstacle ? 0.36 : 0.24,
         risk: isNearObstacle ? 0.09 : 0.07,
         reason: isNearObstacle ? "dynamite_open_near_obstacle" : "dynamite_open_map",
@@ -25849,6 +25910,13 @@ function buildAiInventoryCandidatePlans(context, plannedMove){
     candidate.directUtility = Number(directUtility.toFixed(3));
     candidate.adjustedComparableScore = candidate.directUtility;
     candidate.releaseReady = true;
+    if(candidate.itemType === INVENTORY_ITEM_TYPES.FUEL
+      || candidate.itemType === INVENTORY_ITEM_TYPES.CROSSHAIR
+      || candidate.itemType === INVENTORY_ITEM_TYPES.WINGS
+      || candidate.itemType === INVENTORY_ITEM_TYPES.INVISIBILITY){
+      candidate.directUtility = Number((candidate.directUtility + 0.035).toFixed(3));
+      candidate.adjustedComparableScore = candidate.directUtility;
+    }
   }
 
   let selectedCandidate = null;
@@ -26196,6 +26264,69 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
   const filteredCandidates = uniqueCandidates.filter((candidate) => PRE_LAUNCH_ALLOWED_ITEM_TYPES.has(candidate.itemType));
 
   function buildForcedInventoryFallbackCandidates(excludedItemTypes = new Set()){
+    const quickForcedMinePlan = (() => {
+      const plane = plannedMove?.plane || null;
+      if(!plane) return null;
+      const localLandingPoint = getAiMoveLandingPoint(plannedMove) || null;
+      const enemyBaseAnchor = typeof getBaseAnchor === "function" ? getBaseAnchor("green") : null;
+      const nearestEnemy = Array.isArray(context?.enemies) && context.enemies.length > 0
+        ? context.enemies
+            .map((enemy) => ({ enemy, d: dist(plane, enemy) }))
+            .sort((a, b) => a.d - b.d)[0]?.enemy || null
+        : null;
+      const candidateTargets = [nearestEnemy, enemyBaseAnchor, localLandingPoint].filter(Boolean);
+      const offsetList = [
+        { ox: 0, oy: 0 },
+        { ox: 0.9, oy: 0.35 },
+        { ox: -0.9, oy: 0.35 },
+        { ox: 0.9, oy: -0.35 },
+        { ox: -0.9, oy: -0.35 },
+      ];
+      const safeRadius = Math.max(12, MINE_TRIGGER_RADIUS * 1.15);
+      for(const target of candidateTargets){
+        if(!Number.isFinite(target?.x) || !Number.isFinite(target?.y)) continue;
+        for(const offset of offsetList){
+          const px = target.x + offset.ox * CELL_SIZE;
+          const py = target.y + offset.oy * CELL_SIZE;
+          const placement = {
+            x: px,
+            y: py,
+            cellX: Math.floor((px - FIELD_LEFT) / CELL_SIZE),
+            cellY: Math.floor((py - FIELD_TOP) / CELL_SIZE),
+          };
+          if(!isMinePlacementValid(placement)) continue;
+          if(localLandingPoint && dist(localLandingPoint, placement) <= safeRadius) continue;
+          if(dist(plane, placement) <= safeRadius) continue;
+          return {
+            placement,
+            scenario: "forced_fast_inventory_mine",
+            score: 0.22,
+          };
+        }
+      }
+      return null;
+    })();
+    const quickForcedDynamiteTarget = (() => {
+      if(!Array.isArray(colliders) || colliders.length === 0) return null;
+      let best = null;
+      let bestDist = Number.POSITIVE_INFINITY;
+      const maxChecks = Math.min(colliders.length, 110);
+      for(let i = 0; i < maxChecks; i += 1){
+        const collider = colliders[i];
+        if(!Number.isFinite(collider?.cx) || !Number.isFinite(collider?.cy)) continue;
+        const d = dist(plannedMove.plane, { x: collider.cx, y: collider.cy });
+        if(d < bestDist){
+          bestDist = d;
+          best = collider;
+        }
+      }
+      if(!best) return null;
+      return {
+        x: best.cx,
+        y: best.cy,
+        colliderId: best?.id ?? null,
+      };
+    })();
     const routeAwareFallbackOrder = plannedRouteClass === "gap" || plannedRouteClass === "ricochet"
       ? [
         INVENTORY_ITEM_TYPES.CROSSHAIR,
@@ -26230,13 +26361,7 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
       };
 
       if(itemType === INVENTORY_ITEM_TYPES.MINE){
-        const defensiveProbe = typeof tryPlaceBlueDefensiveMine === "function"
-          ? tryPlaceBlueDefensiveMine(context, plannedMove, { evaluateOnly: true })
-          : null;
-        const baseProbe = typeof tryPlaceBlueMineNearEnemyBase === "function"
-          ? tryPlaceBlueMineNearEnemyBase(context, plannedMove, { evaluateOnly: true })
-          : null;
-        const minePlan = defensiveProbe || baseProbe || null;
+        const minePlan = quickForcedMinePlan;
         if(!minePlan?.placement){
           continue;
         }
@@ -26245,18 +26370,14 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
       }
 
       if(itemType === INVENTORY_ITEM_TYPES.DYNAMITE){
-        const dynamiteDecision = typeof evaluateAiDynamiteTacticalTarget === "function"
-          ? evaluateAiDynamiteTacticalTarget(context, plannedMove, { allowStrategicProbeWhenRouteAware: true })
-          : null;
-        const fallbackTarget = dynamiteDecision?.fallbackTarget || null;
-        if(!(Number.isFinite(fallbackTarget?.cx) && Number.isFinite(fallbackTarget?.cy))){
+        if(!(Number.isFinite(quickForcedDynamiteTarget?.x) && Number.isFinite(quickForcedDynamiteTarget?.y))){
           continue;
         }
         forcedCandidate.target = {
-          x: fallbackTarget.cx,
-          y: fallbackTarget.cy,
-          colliderId: fallbackTarget?.collider?.id ?? null,
-          spriteId: fallbackTarget?.id ?? null,
+          x: quickForcedDynamiteTarget.x,
+          y: quickForcedDynamiteTarget.y,
+          colliderId: quickForcedDynamiteTarget?.colliderId ?? null,
+          spriteId: quickForcedDynamiteTarget?.spriteId ?? null,
         };
       }
 


### PR DESCRIPTION
### Motivation

- Improve the AI's ability to quickly decide on tactical inventory spends (mines and dynamite) for pre-launch and forced fallback scenarios without expensive probing. 
- Reduce missed quick-spend opportunities by providing lightweight heuristics to find nearby placement/target points when a full evaluation probe would be too slow.
- Slightly favor some small-value items so the AI is less likely to hoard `FUEL`, `CROSSHAIR`, `WINGS`, and `INVISIBILITY` in marginal situations.

### Description

- Added a lightweight `quickMinePlacement` heuristic that searches a short list of target anchors (`priorityEnemy`, nearest enemy, `enemyBase`, landing point) with a small set of offsets and `isMinePlacementValid` checks and returns a fast `minePlan` used for immediate candidate creation. 
- Integrated `quickMinePlacement` into the main mine candidate logic so mines are pushed as candidates only if a valid quick placement exists, otherwise the mine is rejected with `mine_no_fast_placement`. 
- Replaced the simple dynamite target lookup with a bounded scan over `colliders` (cap checks to avoid scanning too many entries) to resolve a nearest reachable collider and attach it as the dynamite `target`. 
- Increased direct utility for certain low-cost items by adding a small boost to `directUtility` for `FUEL`, `CROSSHAIR`, `WINGS`, and `INVISIBILITY` to reduce hoarding. 
- Added `quickForcedMinePlan` and `quickForcedDynamiteTarget` inside `buildForcedInventoryFallbackCandidates` to provide fast fallback placements/targets for forced spends without calling heavier strategic probes. 
- Adjusted returned structures to include `minePlan`, `placementMode`, and richer `target` metadata (e.g., `colliderId`) where applicable.

### Testing

- Ran the project's automated unit test suite via `npm test` including AI/inventory-related tests, and they completed successfully. 
- Performed a local smoke test of the pre-launch inventory selection flow to validate quick placement/dynamite heuristics integrate without runtime errors and observed expected candidate/rejection logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb129312d4832db1fa71510db15d75)