### PR TITLE
AI: relax inventory placement and collider scan limits to improve mine/dynamite usage

### DIFF
--- a/script.js
+++ b/script.js
@@ -25698,6 +25698,13 @@ function buildAiInventoryCandidatePlans(context, plannedMove){
       { ox: 0.8, oy: -0.4 },
       { ox: -0.8, oy: -0.4 },
       { ox: 0, oy: 0.95 },
+      { ox: 1.2, oy: 0 },
+      { ox: -1.2, oy: 0 },
+      { ox: 0, oy: -0.95 },
+      { ox: 1.5, oy: 0.65 },
+      { ox: -1.5, oy: 0.65 },
+      { ox: 1.5, oy: -0.65 },
+      { ox: -1.5, oy: -0.65 },
     ];
     const safeRadius = Math.max(12, MINE_TRIGGER_RADIUS * 1.2);
     for(const target of mineTargets){
@@ -25718,6 +25725,25 @@ function buildAiInventoryCandidatePlans(context, plannedMove){
           placement,
           scenario: "fast_inventory_mine",
           score: 0.34,
+        };
+      }
+    }
+    const fallbackScanStep = Math.max(10, CELL_SIZE * 0.75);
+    for(let y = FIELD_TOP + CELL_SIZE * 0.5; y <= FIELD_BOTTOM - CELL_SIZE * 0.5; y += fallbackScanStep){
+      for(let x = FIELD_LEFT + CELL_SIZE * 0.5; x <= FIELD_RIGHT - CELL_SIZE * 0.5; x += fallbackScanStep){
+        const placement = {
+          x,
+          y,
+          cellX: Math.floor((x - FIELD_LEFT) / CELL_SIZE),
+          cellY: Math.floor((y - FIELD_TOP) / CELL_SIZE),
+        };
+        if(!isMinePlacementValid(placement)) continue;
+        if(localLandingPoint && dist(localLandingPoint, placement) <= safeRadius) continue;
+        if(dist(plane, placement) <= safeRadius) continue;
+        return {
+          placement,
+          scenario: "fast_inventory_mine_fallback_scan",
+          score: 0.26,
         };
       }
     }
@@ -25854,7 +25880,7 @@ function buildAiInventoryCandidatePlans(context, plannedMove){
     let resolvedDynamiteTarget = null;
     if(Array.isArray(colliders) && colliders.length > 0){
       let nearestDist = Number.POSITIVE_INFINITY;
-      const maxColliderChecks = Math.min(colliders.length, 140);
+      const maxColliderChecks = colliders.length;
       for(let i = 0; i < maxColliderChecks; i += 1){
         const collider = colliders[i];
         if(!Number.isFinite(collider?.cx) || !Number.isFinite(collider?.cy)) continue;
@@ -26341,6 +26367,14 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
         { ox: -0.9, oy: 0.35 },
         { ox: 0.9, oy: -0.35 },
         { ox: -0.9, oy: -0.35 },
+        { ox: 1.3, oy: 0 },
+        { ox: -1.3, oy: 0 },
+        { ox: 0, oy: 0.9 },
+        { ox: 0, oy: -0.9 },
+        { ox: 1.7, oy: 0.7 },
+        { ox: -1.7, oy: 0.7 },
+        { ox: 1.7, oy: -0.7 },
+        { ox: -1.7, oy: -0.7 },
       ];
       const safeRadius = Math.max(12, MINE_TRIGGER_RADIUS * 1.15);
       for(const target of candidateTargets){
@@ -26364,13 +26398,32 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
           };
         }
       }
+      const fallbackScanStep = Math.max(10, CELL_SIZE * 0.75);
+      for(let y = FIELD_TOP + CELL_SIZE * 0.5; y <= FIELD_BOTTOM - CELL_SIZE * 0.5; y += fallbackScanStep){
+        for(let x = FIELD_LEFT + CELL_SIZE * 0.5; x <= FIELD_RIGHT - CELL_SIZE * 0.5; x += fallbackScanStep){
+          const placement = {
+            x,
+            y,
+            cellX: Math.floor((x - FIELD_LEFT) / CELL_SIZE),
+            cellY: Math.floor((y - FIELD_TOP) / CELL_SIZE),
+          };
+          if(!isMinePlacementValid(placement)) continue;
+          if(localLandingPoint && dist(localLandingPoint, placement) <= safeRadius) continue;
+          if(dist(plane, placement) <= safeRadius) continue;
+          return {
+            placement,
+            scenario: "forced_fast_inventory_mine_fallback_scan",
+            score: 0.18,
+          };
+        }
+      }
       return null;
     })();
     const quickForcedDynamiteTarget = (() => {
       if(!Array.isArray(colliders) || colliders.length === 0) return null;
       let best = null;
       let bestDist = Number.POSITIVE_INFINITY;
-      const maxChecks = Math.min(colliders.length, 110);
+      const maxChecks = colliders.length;
       for(let i = 0; i < maxChecks; i += 1){
         const collider = colliders[i];
         if(!Number.isFinite(collider?.cx) || !Number.isFinite(collider?.cy)) continue;


### PR DESCRIPTION
### Motivation
- AI sometimes didn’t spend inventory (mine/dynamite) because local probe windows and capped scans failed to find any valid target on cluttered or large maps. 
- The change aims to reduce those artificial failures so the AI can actually apply tactical items when available.

### Description
- Expanded mine placement probe offsets used by `buildAiInventoryCandidatePlans` so the AI tries a wider set of nearby candidate points when building `quickMinePlacement` and forced fallback plans. 
- Added a field-scan fallback that scans the playfield in a coarse grid when local candidate offsets don’t yield a valid mine placement (returns a `fast_inventory_mine_fallback_scan` / `forced_fast_inventory_mine_fallback_scan`).
- Removed collider scan caps for dynamite target search by replacing `Math.min(colliders.length, ...)` with full `colliders.length` checks so the AI examines the whole collider list when resolving dynamite targets.
- Small tuning: added additional probe offsets for forced-mine fallback and adjusted scoring for fallback scan results (all changes in `script.js`).

### Testing
- Syntax check: `node -c script.js` — passed. 
- Smoke test: `node scripts/smoke-ai-forced-non-skip-last-chance.js` — passed. 
- Other unrelated smoke tests (e.g. `node scripts/smoke-beneficial-wings-cargo.js` / `node scripts/smoke-cargo-spawn-grid-fallback.js`) still fail in this environment due to a pre-existing `CARGO_SAFE_MAX_DIM_PX is not defined` issue and are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53a26ec4832dadb1ce5c73e5d934)