### PR TITLE
Сохранение данных path_candidate_passport в компактных AI-логах

### DIFF
--- a/script.js
+++ b/script.js
@@ -18470,7 +18470,7 @@ function flushAiDecisionScope(scope){
           aggregatedGoalName: scope.meta?.goalName ?? null,
         }
       : {
-          ...buildAiDecisionCompactPayload(lastPayload, derived),
+          ...buildAiDecisionCompactPayload(reason, lastPayload, derived),
           suppressedRepeatCount: entry.count,
           aggregatedWithin: scope.meta?.type || "ai_scope",
           aggregatedPlaneId: scope.meta?.planeId ?? null,
@@ -18574,12 +18574,50 @@ function buildAiDecisionDeepPayload(reason, payload, derived = {}){
   };
 }
 
-function buildAiDecisionCompactPayload(payload, derived = {}){
+function buildAiDecisionCompactPayload(reason, payload, derived = {}){
   const compactPayload = {
     reasonCode: payload?.reasonCode ?? payload?.reason ?? null,
     planeId: derived.planeId,
     numbers: collectAiDecisionKeyNumbers(payload, derived),
   };
+
+  if(reason === "path_candidate_passport"){
+    compactPayload.goalName = payload?.goalName || null;
+    compactPayload.decisionReason = payload?.decisionReason || null;
+    compactPayload.finalStatus = payload?.finalStatus || null;
+    compactPayload.selectedCandidateClass = payload?.selectedCandidateClass || null;
+    compactPayload.selectedMoveType = payload?.selectedMoveType || null;
+    compactPayload.rejectCode = payload?.rejectCode || null;
+    compactPayload.routeStrictnessMode = payload?.routeStrictnessMode || null;
+    compactPayload.requestedRouteClass = payload?.requestedRouteClass || null;
+    compactPayload.hasDirectLine = payload?.hasDirectLine === true;
+    compactPayload.candidateCount = Number.isFinite(payload?.candidateCount)
+      ? payload.candidateCount
+      : null;
+
+    if(Array.isArray(payload?.entries) && payload.entries.length > 0){
+      compactPayload.entries = payload.entries.slice(-60).map((entry) => ({
+        seq: Number.isFinite(entry?.seq) ? entry.seq : null,
+        event: entry?.event || null,
+        stage: entry?.stage || null,
+        candidateClass: entry?.candidateClass || null,
+        moveType: entry?.moveType || null,
+        decisionReason: entry?.decisionReason || null,
+        goalName: entry?.goalName || null,
+        routeQualityScore: Number.isFinite(entry?.routeQualityScore)
+          ? Number(entry.routeQualityScore.toFixed(6))
+          : null,
+        totalDist: Number.isFinite(entry?.totalDist)
+          ? Number(entry.totalDist.toFixed(2))
+          : null,
+        killedAtStage: entry?.killedAtStage || null,
+        killedByReason: entry?.killedByReason || null,
+        selected: entry?.selected === true,
+      }));
+    } else {
+      compactPayload.entries = [];
+    }
+  }
 
   if(Object.keys(compactPayload.numbers).length === 0){
     delete compactPayload.numbers;
@@ -18661,7 +18699,7 @@ function logAiDecision(reason, details = {}){
 
   const debugPayload = AI_DECISION_DEEP_DEBUG_FLAG
     ? buildAiDecisionDeepPayload(reason, payload, derived)
-    : buildAiDecisionCompactPayload(payload, derived);
+    : buildAiDecisionCompactPayload(reason, payload, derived);
 
   console.debug(`[ai] ${reason}`, debugPayload);
 


### PR DESCRIPTION
### Motivation
- Диагностика `last_five_path_motivations` часто показывала пустые/обрезанные записи для `path_candidate_passport`, что скрывало реальные попытки рикошета и давало ложное впечатление внезапного перехода в fallback.

### Description
- Изменён `buildAiDecisionCompactPayload` чтобы принимать `reason` и сохранять ключевые поля для `path_candidate_passport` (включая `goalName`, `decisionReason`, `finalStatus`, `selectedCandidateClass`, `selectedMoveType`, `rejectCode`, `routeStrictnessMode`, `requestedRouteClass`, `hasDirectLine`, `candidateCount`).
- Компактный лог теперь включает до 60 последних `entries` из payload, сериализованных в сокращённом виде, чтобы экспорт и анализ показывали реальные кандидаты.
- Передача `reason` добавлена в места агрегирования/суммарной записи (`flushAiDecisionScope`) и в основное логирование, чтобы компактный билдер мог корректно формировать payload как для обычных событий, так и для summary.
- Ничего в логике выбора маршрутов не изменено, только формат и содержимое компактных diagnostic-логов.

### Testing
- Запуск синтаксической проверки: `node --check script.js` — успешно.
- Смоук-тест: `node scripts/smoke-ai-forced-non-skip-last-chance.js` — успешно (проход теста подтверждён).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec58b89724832db78d57c7019f32c8)