### PR TITLE
Improve dynamite target selection and add baseline inventory ordering; add smoke test

### DIFF
--- a/script.js
+++ b/script.js
@@ -25878,21 +25878,67 @@ function buildAiInventoryCandidatePlans(context, plannedMove){
 
   if(allowTacticalItems && inventory.counts?.[INVENTORY_ITEM_TYPES.DYNAMITE] > 0){
     let resolvedDynamiteTarget = null;
+    const triedDynamiteTargetKeys = new Set();
+    const noteDynamiteProbe = (x, y, extra = {}) => {
+      if(!Number.isFinite(x) || !Number.isFinite(y)) return;
+      const key = `${Math.round(x)}:${Math.round(y)}`;
+      if(triedDynamiteTargetKeys.has(key)) return;
+      triedDynamiteTargetKeys.add(key);
+      const matchedSprite = typeof findMapSpriteForDynamiteDrop === "function"
+        ? findMapSpriteForDynamiteDrop({ boardX: x, boardY: y })
+        : null;
+      if(!matchedSprite || !Number.isFinite(matchedSprite?.cx) || !Number.isFinite(matchedSprite?.cy)) return;
+      const candidate = {
+        x: matchedSprite.cx,
+        y: matchedSprite.cy,
+        colliderId: extra?.colliderId ?? matchedSprite?.colliderId ?? null,
+        spriteId: matchedSprite?.id ?? null,
+      };
+      const candidateDist = dist(plannedMove.plane, candidate);
+      const currentBestDist = resolvedDynamiteTarget ? dist(plannedMove.plane, resolvedDynamiteTarget) : Number.POSITIVE_INFINITY;
+      if(candidateDist < currentBestDist){
+        resolvedDynamiteTarget = candidate;
+      }
+    };
+
     if(Array.isArray(colliders) && colliders.length > 0){
-      let nearestDist = Number.POSITIVE_INFINITY;
-      const maxColliderChecks = colliders.length;
-      for(let i = 0; i < maxColliderChecks; i += 1){
-        const collider = colliders[i];
-        if(!Number.isFinite(collider?.cx) || !Number.isFinite(collider?.cy)) continue;
-        const d = dist(plannedMove.plane, { x: collider.cx, y: collider.cy });
-        if(d < nearestDist){
-          nearestDist = d;
-          resolvedDynamiteTarget = {
-            x: collider.cx,
-            y: collider.cy,
-            colliderId: collider?.id ?? null,
-          };
-        }
+      const sortedColliders = colliders
+        .filter((collider) => Number.isFinite(collider?.cx) && Number.isFinite(collider?.cy))
+        .map((collider) => ({
+          collider,
+          d: dist(plannedMove.plane, { x: collider.cx, y: collider.cy }),
+        }))
+        .sort((a, b) => a.d - b.d)
+        .slice(0, 18);
+      for(const entry of sortedColliders){
+        const collider = entry.collider;
+        noteDynamiteProbe(collider.cx, collider.cy, { colliderId: collider?.id ?? null });
+      }
+    }
+
+    const dynamiteProbeAnchors = [
+      enemyBase,
+      priorityEnemy,
+      landingPoint,
+      plannedMove?.plane || null,
+    ].filter((point) => Number.isFinite(point?.x) && Number.isFinite(point?.y));
+    const probeOffsets = [
+      { ox: 0, oy: 0 },
+      { ox: 0.9, oy: 0.4 },
+      { ox: -0.9, oy: 0.4 },
+      { ox: 0.9, oy: -0.4 },
+      { ox: -0.9, oy: -0.4 },
+      { ox: 1.4, oy: 0 },
+      { ox: -1.4, oy: 0 },
+      { ox: 0, oy: 1.2 },
+      { ox: 0, oy: -1.2 },
+    ];
+    for(const anchor of dynamiteProbeAnchors){
+      for(const offset of probeOffsets){
+        noteDynamiteProbe(
+          anchor.x + offset.ox * CELL_SIZE,
+          anchor.y + offset.oy * CELL_SIZE,
+        );
       }
     }
 
@@ -25996,6 +26042,20 @@ function buildAiInventoryCandidatePlans(context, plannedMove){
     candidate.directUtility = Number(directUtility.toFixed(3));
     candidate.adjustedComparableScore = candidate.directUtility;
     candidate.releaseReady = true;
+    const baselineOrderBonusByType = {
+      [INVENTORY_ITEM_TYPES.CROSSHAIR]: 0.024,
+      [INVENTORY_ITEM_TYPES.FUEL]: 0.02,
+      [INVENTORY_ITEM_TYPES.WINGS]: 0.016,
+      [INVENTORY_ITEM_TYPES.DYNAMITE]: 0.012,
+      [INVENTORY_ITEM_TYPES.MINE]: 0.008,
+      [INVENTORY_ITEM_TYPES.INVISIBILITY]: 0.004,
+    };
+    const baselineOrderBonus = Number(baselineOrderBonusByType[candidate.itemType] || 0);
+    if(baselineOrderBonus > 0){
+      candidate.directUtility = Number((candidate.directUtility + baselineOrderBonus).toFixed(3));
+      candidate.adjustedComparableScore = candidate.directUtility;
+      candidate.baselineOrderBonus = baselineOrderBonus;
+    }
     if(candidate.itemType === INVENTORY_ITEM_TYPES.FUEL
       || candidate.itemType === INVENTORY_ITEM_TYPES.CROSSHAIR
       || candidate.itemType === INVENTORY_ITEM_TYPES.WINGS

--- a/scripts/smoke-ai-dynamite-standard-selection.js
+++ b/scripts/smoke-ai-dynamite-standard-selection.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const vm = require('vm');
+
+function extractFunctionSource(source, fnName){
+  const signature = `function ${fnName}(`;
+  const start = source.indexOf(signature);
+  if(start === -1) throw new Error(`Function not found in script.js: ${fnName}`);
+  const signatureEnd = source.indexOf(')', start);
+  const bodyStart = source.indexOf('{', signatureEnd);
+  let depth = 0;
+  for(let i = bodyStart; i < source.length; i += 1){
+    const ch = source[i];
+    if(ch === '{') depth += 1;
+    if(ch === '}') depth -= 1;
+    if(depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`Function body end not found for: ${fnName}`);
+}
+
+function assert(condition, message){
+  if(!condition) throw new Error(message);
+}
+
+const source = fs.readFileSync('script.js', 'utf8');
+const fnSrc = extractFunctionSource(source, 'buildAiInventoryCandidatePlans');
+
+const context = {
+  Math,
+  Number,
+  Array,
+  Object,
+  Set,
+  aiRoundState: { currentGoal: 'attack_enemy_plane' },
+  settings: { flightRangeCells: 30, aimingAmplitude: 80 },
+  CELL_SIZE: 40,
+  MAX_DRAG_DISTANCE: 300,
+  FIELD_FLIGHT_DURATION_SEC: 1,
+  ATTACK_RANGE_PX: 180,
+  FIELD_LEFT: 0,
+  FIELD_TOP: 0,
+  FIELD_RIGHT: 800,
+  FIELD_BOTTOM: 800,
+  MINE_TRIGGER_RADIUS: 18,
+  INVENTORY_ITEM_TYPES: {
+    MINE: 'mine',
+    CROSSHAIR: 'crosshair',
+    FUEL: 'fuel',
+    WINGS: 'wings',
+    DYNAMITE: 'dynamite',
+    INVISIBILITY: 'invisible',
+  },
+  colliders: [
+    { id: 'near-invalid', cx: 120, cy: 120 },
+    { id: 'valid-farther', cx: 220, cy: 220 },
+  ],
+  evaluateBlueInventoryState(){
+    return {
+      total: 1,
+      counts: {
+        mine: 0,
+        crosshair: 0,
+        fuel: 0,
+        wings: 0,
+        dynamite: 1,
+        invisible: 0,
+      },
+    };
+  },
+  getBluePriorityEnemy(){ return { id: 'green-1', x: 300, y: 300 }; },
+  getBaseAnchor(){ return { x: 360, y: 360 }; },
+  getAiMoveLandingPoint(){ return { x: 180, y: 180 }; },
+  getPlaneEffectiveRangePx(){ return 280; },
+  buildAiItemUnlockMoveMetrics(){ return { unlocksNewDistanceZone: false, trajectoryCargoTouches: 0, trajectoryEnemyTouches: 0, safetyScore: 0.5 }; },
+  compareAiItemUnlockMoveClass(){ return { unlocked: false, reasons: [], unlockScore: 0 }; },
+  dist(a, b){ return Math.hypot((a?.x || 0) - (b?.x || 0), (a?.y || 0) - (b?.y || 0)); },
+  isMinePlacementValid(){ return true; },
+  isPathClear(){ return true; },
+  getFlagAnchor(){ return null; },
+  logAiDecision(){},
+  recordInventoryAiDecision(){},
+  findMapSpriteForDynamiteDrop({ boardX, boardY }){
+    const roundedX = Math.round(boardX);
+    const roundedY = Math.round(boardY);
+    if(roundedX === 220 && roundedY === 220){
+      return { id: 'brick-1', cx: 220, cy: 220, colliderId: 'valid-farther' };
+    }
+    return null;
+  },
+};
+
+vm.createContext(context);
+vm.runInContext(fnSrc, context);
+
+const plannedMove = {
+  plane: { id: 'blue-1', color: 'blue', x: 100, y: 100 },
+  vx: 10,
+  vy: 0,
+  totalDist: 10,
+  routeClass: 'direct',
+  goalName: 'attack_enemy_plane',
+};
+
+const result = context.buildAiInventoryCandidatePlans({ enemies: [{ x: 300, y: 300 }], aiPlanes: [{ id: 'blue-1' }] }, plannedMove);
+assert(result && typeof result === 'object', 'Expected inventory planning result object.');
+assert(Array.isArray(result.candidates) && result.candidates.length > 0, 'Expected at least one inventory candidate.');
+const dynamiteCandidate = result.candidates.find((candidate) => candidate?.itemType === 'dynamite');
+assert(dynamiteCandidate, 'Expected dynamite candidate in standard selection flow.');
+assert(dynamiteCandidate.target?.x === 220 && dynamiteCandidate.target?.y === 220,
+  'Expected dynamite candidate target to be executable map sprite center, not nearest invalid collider.');
+assert(result.selectedCandidate?.itemType === 'dynamite', 'Expected dynamite to be selected when it is the only available item.');
+
+console.log('Smoke test passed: standard dynamite selection picks executable sprite target.');


### PR DESCRIPTION
### Motivation
- Make dynamite spending choose executable map sprite centers rather than nearest raw collider coordinates to avoid wasting dynamite on invalid targets.
- Reduce duplicate probes and prioritize meaningful nearby collider candidates while probing around tactical anchors for quick dynamite opportunities.
- Stabilize inventory candidate ordering by applying small baseline bonuses so similar-value items sort consistently.

### Description
- Add `noteDynamiteProbe` helper to dedupe probes by rounded board coordinates and map probes to executable sprite centers via `findMapSpriteForDynamiteDrop` before considering a target.
- Replace linear nearest-collider scan with a distance-sorted top-N probe of colliders (slice to 18) and add additional probes around anchor points (`enemyBase`, `priorityEnemy`, `landingPoint`, `plannedMove.plane`) using a set of offsets scaled by `CELL_SIZE`.
- Select the dynamite target closest to the planned plane and push a dynamite candidate only when a valid executable sprite center is resolved.
- Introduce `baselineOrderBonusByType` and apply small per-item baseline bonuses to `candidate.directUtility` for more stable tie-breaking among inventory candidates.
- Add a smoke test script `scripts/smoke-ai-dynamite-standard-selection.js` that extracts `buildAiInventoryCandidatePlans` from `script.js` and asserts correct dynamite target selection and candidate choice.

### Testing
- Executed the smoke test with `node scripts/smoke-ai-dynamite-standard-selection.js`, and all assertions passed (script prints success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec59716644832d9c15502d14d9d1e4)