### PR TITLE
Fix AI cargo fallback selecting wall-ram direct shots

### DIFF
--- a/script.js
+++ b/script.js
@@ -9631,27 +9631,6 @@ function buildAiCargoLongRangeTargets(plane, cargo, context){
     carryDistance: Math.min(MAX_DRAG_DISTANCE, carryToBase * 1.08),
   });
 
-  if(homeBase){
-    const sideWallTargets = [
-      { wall: "left", wallX: leftWallX + CELL_SIZE * 0.6 },
-      { wall: "right", wallX: rightWallX - CELL_SIZE * 0.6 },
-    ];
-    for(const wallCandidate of sideWallTargets){
-      const bounceAnchor = {
-        x: wallCandidate.wallX,
-        y: clamp((cargoCenter.y + homeBase.y) / 2, topWallY + CELL_SIZE * 0.6, bottomWallY - CELL_SIZE * 0.6),
-      };
-      const homeGain = dist(cargoCenter, homeBase) - dist(bounceAnchor, homeBase);
-      if(homeGain <= CELL_SIZE * 0.4) continue;
-      pushDirectionalTarget(`side_wall_ricochet_${wallCandidate.wall}`, bounceAnchor, {
-        targetKind: "long",
-        preferredRouteClass: "ricochet",
-        usedRicochetHint: true,
-        carryDistance: Math.min(MAX_DRAG_DISTANCE, carryToBase * 1.12),
-      });
-    }
-  }
-
   const seen = new Set();
   return targets.filter((entry) => {
     const key = `${Math.round(entry.targetX)}:${Math.round(entry.targetY)}:${entry.preferredRouteClass || "direct"}`;
@@ -9723,15 +9702,10 @@ function getAiCargoRouteClassOrder(routeTarget){
 
 function getAiCargoRicochetPreferenceBonus(routeCandidate){
   if(!routeCandidate || typeof routeCandidate !== "object") return 0;
-  const routeName = `${routeCandidate?.routeTarget?.name || ""}`.toLowerCase();
   const prefersRicochetClass = routeCandidate?.usedRicochet === true
     || routeCandidate?.requestedRouteClass === "ricochet";
   if(!prefersRicochetClass) return 0;
-  const baseBonus = Math.max(4, CELL_SIZE * 0.22);
-  const sideWallBonus = routeName.includes("side_wall_ricochet_")
-    ? Math.max(2, CELL_SIZE * 0.16)
-    : 0;
-  return baseBonus + sideWallBonus;
+  return Math.max(4, CELL_SIZE * 0.22);
 }
 
 function collectAiCargoRouteCandidates(plane, cargo, context){
@@ -14865,22 +14839,74 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
     };
 
     const buildGuaranteedAdvanceMove = (plane) => {
+      if(!plane) return null;
       const profile = getAiFlightRangeProfile(plane);
       const maxFlightDistancePx = Math.max(1, Number.isFinite(profile?.flightDistancePx) ? profile.flightDistancePx : (CELL_SIZE * 6));
       const preferredTarget = {
         x: plane.x,
         y: FIELD_TOP + FIELD_HEIGHT,
       };
+      const advanceY = FIELD_TOP + FIELD_HEIGHT;
+      const centerAnchor = (() => {
+        try {
+          return typeof getNearestPointInCenterControlZone === "function"
+            ? getNearestPointInCenterControlZone(plane)
+            : null;
+        } catch(_) { return null; }
+      })();
+      const homeBase = getBaseAnchor(plane.color) || null;
+      const positionalTargets = [];
+      if(centerAnchor && Number.isFinite(centerAnchor.x) && Number.isFinite(centerAnchor.y)){
+        positionalTargets.push({ name: "guaranteed_center_control", target: centerAnchor });
+      }
+      positionalTargets.push({ name: "guaranteed_forward_advance", target: { x: plane.x, y: advanceY } });
+      if(homeBase && Number.isFinite(homeBase.x) && Number.isFinite(homeBase.y)){
+        positionalTargets.push({ name: "guaranteed_home_pullback", target: homeBase });
+      }
+
+      const tryTargetWithRouteClasses = (decisionReason, target) => {
+        for(const routeClass of [null, "ricochet"]){
+          const move = planPathToPoint(plane, target.x, target.y, {
+            goalName: decisionReason,
+            decisionReason,
+            ...(routeClass ? { routeClass } : {}),
+          });
+          if(!move) continue;
+          const durationSec = Number.isFinite(FIELD_FLIGHT_DURATION_SEC) && FIELD_FLIGHT_DURATION_SEC > 0
+            ? FIELD_FLIGHT_DURATION_SEC : 1;
+          const landingX = plane.x + (move.vx || 0) * durationSec;
+          const landingY = plane.y + (move.vy || 0) * durationSec;
+          if(!Number.isFinite(landingX) || !Number.isFinite(landingY)) continue;
+          return {
+            plane,
+            landingX,
+            landingY,
+            targetPoint: target,
+            decisionReason,
+            goalName: decisionReason,
+            whyChosen: "no_primary_plan_use_positional_or_ricochet",
+            routeClass: move?.candidateClass || move?.routeClass || (routeClass || "direct"),
+            bounceCount: Number.isFinite(move?.bounceCount) ? move.bounceCount : 0,
+          };
+        }
+        return null;
+      };
+
+      for(const entry of positionalTargets){
+        const move = tryTargetWithRouteClasses(entry.name, entry.target);
+        if(move) return move;
+      }
+
       const fractions = [1, 0.85, 0.7, 0.55, 0.4, 0.3, 0.2];
       for(const fraction of fractions){
         const candidateTarget = {
           x: plane.x + (preferredTarget.x - plane.x) * fraction,
-          y: plane.y + (preferredTarget.y - plane.y) * fraction,
+          y: plane.y + (advanceY - plane.y) * fraction,
         };
         const candidateMove = buildMoveTowardTarget(plane, candidateTarget, maxFlightDistancePx, {
-          decisionReason: "simple_step2_guaranteed_advance",
-          goalName: "simple_step2_guaranteed_advance",
-          whyChosen: "no_good_plan_available_force_non_skip_move",
+          decisionReason: "guaranteed_short_advance",
+          goalName: "guaranteed_short_advance",
+          whyChosen: "no_path_to_positional_targets_short_clear_step",
         });
         if(candidateMove) return candidateMove;
       }
@@ -36650,7 +36676,14 @@ function planPathToPoint(plane, tx, ty, options = {}){
     const simulated = findBestSimulatedShot(plane, { x: tx, y: ty }, {
       maxBounces: AI_SIM_MAX_BOUNCES_DEFAULT,
     });
-    if(simulated?.sim){
+    const simulatedBounceCount = Number(simulated?.sim?.bounceCount) || 0;
+    const simulatedDirectHitButRicochetRequested = shouldForceNonDirectBranch
+      && simulated?.sim
+      && simulatedBounceCount === 0;
+    if(simulatedDirectHitButRicochetRequested){
+      mirrorRejectCode = "requested_ricochet_but_simulated_direct_hit";
+    }
+    if(simulated?.sim && !simulatedDirectHitButRicochetRequested){
       const launchDx = simulated.sim.launchVector.dx;
       const launchDy = simulated.sim.launchVector.dy;
       const baseAngle = Math.atan2(launchDy, launchDx);
@@ -36664,8 +36697,8 @@ function planPathToPoint(plane, tx, ty, options = {}){
         targetX: tx,
         targetY: ty,
       });
-      const moveType = simulated.sim.bounceCount > 0 ? "mirror" : "direct";
-      const candidateClass = simulated.sim.bounceCount > 0 ? "ricochet" : "direct";
+      const moveType = simulatedBounceCount > 0 ? "mirror" : "direct";
+      const candidateClass = simulatedBounceCount > 0 ? "ricochet" : "direct";
       const simMove = buildMoveWithSafeDeviation(baseAngle, simDist, scale, {
         moveType,
         candidateClass,


### PR DESCRIPTION
### Motivation
- Prevent the AI from favoring synthetic side-wall targets that were scored as perfect direct hits but produced wall-ram behavior instead of useful ricochets. 
- Ensure that when a `ricochet` route is explicitly requested, a simulated direct hit is not silently accepted. 
- Make the emergency/fallback advance move try full routing (including ricochet probing) before issuing a short direct step. 
- Remove special-casing that biased ricochet bonus toward removed side-wall route names.

### Description
- Removed synthetic `side_wall_ricochet_*` targets from `buildAiCargoLongRangeTargets` to avoid high-scoring but useless wall-ram candidates (`script.js`).
- Simplified `getAiCargoRicochetPreferenceBonus` to return a common ricochet preference bonus and eliminate side-wall name special-case (`script.js`).
- In `planPathToPoint`, added enforcement so that when a forced non-direct branch / `shouldForceNonDirectBranch` (i.e. requested `ricochet`) is set, simulated candidates with `bounceCount === 0` are rejected and marked with `requested_ricochet_but_simulated_direct_hit` (`script.js`).
- Reworked `buildGuaranteedAdvanceMove` to try `planPathToPoint` for positional anchors (`guaranteed_center_control`, `guaranteed_forward_advance`, `guaranteed_home_pullback`) and to probe both direct and `ricochet` route classes before falling back to a short direct advance (`script.js`).

### Testing
- Ran `node --check script.js` to validate JavaScript syntax; the check completed successfully.
- No additional automated tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edda601960832dafd4a6536a8fd2a2)