### PR TITLE
Remove legacy AI removal hard-fail logic and add AI inventory non-usage analysis doc

### DIFF
--- a/docs/AI_INVENTORY_NON_USAGE_ANALYSIS_2026-04-26.md
+++ b/docs/AI_INVENTORY_NON_USAGE_ANALYSIS_2026-04-26.md
@@ -1,0 +1,64 @@
+# AI inventory non-usage analysis (2026-04-26)
+
+## Context
+User-reported symptom: AI does not use inventory at all.
+
+## Hypothesis 1 — AI often has no items because cargo is disabled or not collected
+- Inventory is primarily filled via cargo pickup during `updateCargoState()`.
+- Cargo grants items only when a plane intersects cargo beneficial zone.
+- If cargo is disabled (`settings.addCargo === false`), inventory layer is hidden and cargo spawn path is skipped.
+- In that state, inventory for AI can remain empty for a long time, making “AI never uses inventory” look like logic failure while the true reason is no incoming items.
+
+Evidence:
+- Inventory visibility depends on `settings.addCargo`.
+- Cargo pickup calls `addItemToInventory(plane.color, item)`.
+- AI pre-launch inventory routine exits if inventory total is 0.
+
+## Hypothesis 2 — AI logic only evaluates BLUE inventory, so role/color mismatch looks like “AI ignores inventory”
+- `evaluateBlueInventoryState()` hardcodes `inventoryState.blue` and all AI inventory planning/usage paths use it.
+- Computer-turn scheduling is also hard-limited to blue turn in computer mode.
+- If a tester expects AI behavior for green side (or a mode where AI side differs), inventory usage logic will appear dead because it does not look at green inventory.
+
+Evidence:
+- `evaluateBlueInventoryState()` reads only `inventoryState.blue`.
+- `scheduleComputerMoveWithCargoGate()` returns not applicable unless current turn is blue and game mode is computer.
+
+## Hypothesis 3 — Candidate execution can silently fail item-by-item, ending with “nothing applied”
+- Even when planner generates candidates, real execution has many per-item hard checks:
+  - item count rechecked right before apply,
+  - mine requires valid placement,
+  - dynamite requires resolved target,
+  - single-use-per-turn buff restriction.
+- If each candidate fails in sequence, result becomes `prelaunch_items_skipped_even_forced` and no item is consumed.
+- From outside this looks like “AI planned but never used inventory”.
+
+Evidence:
+- `maybeUseInventoryBeforeLaunch()` executes candidates and tracks skipped reasons.
+- If no item applied even with forced fallback, decision meta marks failure (`prelaunch_items_skipped_even_forced`).
+
+## Hypothesis 4 — Forced fallback can still fail because tactical items need geometry that may be unavailable
+- The system has a forced spend fallback, but mine and dynamite still need valid tactical geometry:
+  - mine: at least one valid placement point passing `isMinePlacementValid` and safety distance checks,
+  - dynamite: at least one valid collider center target.
+- On dense/odd maps these constraints can remove tactical options; if buff options also fail on prechecks, the whole fallback can produce zero applied items.
+
+Evidence:
+- Forced mine candidate is skipped if no quick mine plan exists.
+- Forced dynamite candidate is skipped if no quick target exists.
+- `isMinePlacementValid()` includes many blockers (field bounds, mines, bricks, colliders, bases, flags, plane proximity).
+
+## Hypothesis 5 — Legacy expectations/docs may not match current runtime (perception gap)
+- Repository contains docs about previous hard-fail phase and old AI removal timeline.
+- Current runtime in `script.js` includes active computer scheduling and inventory flow, but outdated expectations can bias debugging.
+- Team may keep looking for old AI hooks or expecting previous behavior (no inventory usage), while current path is different and requires checking current telemetry/events.
+
+Evidence:
+- Legacy-removal documents exist in `docs/`.
+- Active runtime function `scheduleComputerMoveWithCargoGate()` builds plans and calls `issueAIMoveFromDoComputerMove`, which runs inventory stage.
+
+## Practical debug checklist (non-invasive)
+1. Confirm mode/turn: computer mode, blue turn.
+2. Confirm inventory actually non-empty right before AI move.
+3. Log `plannedMove.inventoryDecisionMadeMeta` each AI turn.
+4. Track `inventory_prelaunch_item_skipped` / `inventory_prelaunch_gate_summary` events.
+5. When forced fallback fails, inspect skipped reasons distribution over several turns.

--- a/script.js
+++ b/script.js
@@ -14375,47 +14375,6 @@ const AI_MOVE_INITIAL_DELAY_MS = 300;
 const AI_MOVE_CARGO_RETRY_DELAY_MS = 200;
 const AI_MOVE_CARGO_WAIT_TIMEOUT_MS = 1800;
 const AI_TURN_MIN_RELEASE_BUDGET_MS = 900;
-let aiRemovalHardFailState = {
-  notifiedTurnCommitSequence: null,
-};
-
-function triggerComputerAiRemovedHardFail(reason = "unspecified"){
-  if(
-    isGameOver
-    || gameMode !== "computer"
-    || turnColors?.[turnIndex] !== "blue"
-  ){
-    return { ok: false, reasonCode: "ai_removed_hard_fail_not_applicable" };
-  }
-
-  aiMoveScheduled = false;
-  clearAiPostInventoryLaunchTimeout(`ai_removed_hard_fail:${reason}`);
-  clearAiLaunchSessionWatchdog();
-  aiLaunchSession = null;
-  cleanupHandle();
-
-  if(aiRemovalHardFailState.notifiedTurnCommitSequence !== turnCommitSequence){
-    aiRemovalHardFailState.notifiedTurnCommitSequence = turnCommitSequence;
-    showAiLaunchNotice("Старый AI удалён. Новый AI ещё не внедрён: компьютерный ход недоступен.", {
-      persistent: true,
-      kind: "ai_removed_hard_fail",
-    });
-    console.error("[AI_REMOVED_HARD_FAIL]", {
-      reason,
-      turnCommitSequence,
-      turnNumber: turnAdvanceCount,
-      gameMode,
-      turnColor: turnColors?.[turnIndex] || null,
-    });
-  }
-
-  return {
-    ok: false,
-    reasonCode: "ai_removed_hard_fail",
-    message: "Old AI removed. New AI is not implemented yet.",
-  };
-}
-
 function resetAiTurnTimingState(){
   aiTurnTimingState = {
     turnStartedAt: 0,
@@ -14505,7 +14464,6 @@ function invalidateAiPlanningState(reason = "unspecified"){
   aiLaunchSession = null;
   cleanupHandle();
   clearAiLaunchStallNotice();
-  aiRemovalHardFailState.notifiedTurnCommitSequence = null;
   if(reason === "turn_advanced" || reason === "round_reset" || reason === "game_reset"){
     resetAiTurnTimingState();
   }


### PR DESCRIPTION
### Motivation
- Cleanup legacy "AI removed hard-fail" code paths that blocked computer turns and confused current AI flow. 
- Provide a documented analysis to help diagnose why AI appears to never use inventory.

### Description
- Added `docs/AI_INVENTORY_NON_USAGE_ANALYSIS_2026-04-26.md` containing hypotheses, evidence, and a debug checklist for AI inventory non-usage. 
- Removed the legacy `aiRemovalHardFailState` and the `triggerComputerAiRemovedHardFail()` function from `script.js`, eliminating the old hard-fail notice and related shutdown sequence. 
- Removed the stale reset of `aiRemovalHardFailState.notifiedTurnCommitSequence` from `invalidateAiPlanningState()`, since the state was deleted. 
- Kept AI planning and timing cleanup behavior intact (`invalidateAiPlanningState`, `resetAiTurnTimingState`, etc.) while simplifying the code path that previously gated computer-mode turns.

### Testing
- No automated tests were added or modified for this change. 
- Recommend running existing project checks such as `npm test` and `npm run lint` in CI to validate there are no regressions related to the removed code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0295e524832d9d0a09dbb8876924)