### PR TITLE
Improve AI inventory usage and robustness: baseline spend fallback, safer apply, and computer-mode fixes

### DIFF
--- a/docs/AI_INVENTORY_NON_USAGE_ANALYSIS_2026-04-26.md
+++ b/docs/AI_INVENTORY_NON_USAGE_ANALYSIS_2026-04-26.md
@@ -1,0 +1,64 @@
+# AI inventory non-usage analysis (2026-04-26)
+
+## Context
+User-reported symptom: AI does not use inventory at all.
+
+## Hypothesis 1 — AI often has no items because cargo is disabled or not collected
+- Inventory is primarily filled via cargo pickup during `updateCargoState()`.
+- Cargo grants items only when a plane intersects cargo beneficial zone.
+- If cargo is disabled (`settings.addCargo === false`), inventory layer is hidden and cargo spawn path is skipped.
+- In that state, inventory for AI can remain empty for a long time, making “AI never uses inventory” look like logic failure while the true reason is no incoming items.
+
+Evidence:
+- Inventory visibility depends on `settings.addCargo`.
+- Cargo pickup calls `addItemToInventory(plane.color, item)`.
+- AI pre-launch inventory routine exits if inventory total is 0.
+
+## Hypothesis 2 — AI logic only evaluates BLUE inventory, so role/color mismatch looks like “AI ignores inventory”
+- `evaluateBlueInventoryState()` hardcodes `inventoryState.blue` and all AI inventory planning/usage paths use it.
+- Computer-turn scheduling is also hard-limited to blue turn in computer mode.
+- If a tester expects AI behavior for green side (or a mode where AI side differs), inventory usage logic will appear dead because it does not look at green inventory.
+
+Evidence:
+- `evaluateBlueInventoryState()` reads only `inventoryState.blue`.
+- `scheduleComputerMoveWithCargoGate()` returns not applicable unless current turn is blue and game mode is computer.
+
+## Hypothesis 3 — Candidate execution can silently fail item-by-item, ending with “nothing applied”
+- Even when planner generates candidates, real execution has many per-item hard checks:
+  - item count rechecked right before apply,
+  - mine requires valid placement,
+  - dynamite requires resolved target,
+  - single-use-per-turn buff restriction.
+- If each candidate fails in sequence, result becomes `prelaunch_items_skipped_even_forced` and no item is consumed.
+- From outside this looks like “AI planned but never used inventory”.
+
+Evidence:
+- `maybeUseInventoryBeforeLaunch()` executes candidates and tracks skipped reasons.
+- If no item applied even with forced fallback, decision meta marks failure (`prelaunch_items_skipped_even_forced`).
+
+## Hypothesis 4 — Forced fallback can still fail because tactical items need geometry that may be unavailable
+- The system has a forced spend fallback, but mine and dynamite still need valid tactical geometry:
+  - mine: at least one valid placement point passing `isMinePlacementValid` and safety distance checks,
+  - dynamite: at least one valid collider center target.
+- On dense/odd maps these constraints can remove tactical options; if buff options also fail on prechecks, the whole fallback can produce zero applied items.
+
+Evidence:
+- Forced mine candidate is skipped if no quick mine plan exists.
+- Forced dynamite candidate is skipped if no quick target exists.
+- `isMinePlacementValid()` includes many blockers (field bounds, mines, bricks, colliders, bases, flags, plane proximity).
+
+## Hypothesis 5 — Legacy expectations/docs may not match current runtime (perception gap)
+- Repository contains docs about previous hard-fail phase and old AI removal timeline.
+- Current runtime in `script.js` includes active computer scheduling and inventory flow, but outdated expectations can bias debugging.
+- Team may keep looking for old AI hooks or expecting previous behavior (no inventory usage), while current path is different and requires checking current telemetry/events.
+
+Evidence:
+- Legacy-removal documents exist in `docs/`.
+- Active runtime function `scheduleComputerMoveWithCargoGate()` builds plans and calls `issueAIMoveFromDoComputerMove`, which runs inventory stage.
+
+## Practical debug checklist (non-invasive)
+1. Confirm mode/turn: computer mode, blue turn.
+2. Confirm inventory actually non-empty right before AI move.
+3. Log `plannedMove.inventoryDecisionMadeMeta` each AI turn.
+4. Track `inventory_prelaunch_item_skipped` / `inventory_prelaunch_gate_summary` events.
+5. When forced fallback fails, inspect skipped reasons distribution over several turns.

--- a/script.js
+++ b/script.js
@@ -5290,7 +5290,9 @@ function giveItem(itemId, qty = 1, opts = { silent: false }){
   if(!itemDef) return;
   const safeQty = Number.isFinite(qty) ? Math.max(0, Math.floor(qty)) : 0;
   if(safeQty === 0) return;
-  const fallbackColor = turnColors?.[turnIndex] ?? "blue";
+  const fallbackColor = gameMode === "computer"
+    ? "blue"
+    : (turnColors?.[turnIndex] ?? "blue");
   const targetColor = opts?.targetColor === "blue" || opts?.targetColor === "green"
     ? opts.targetColor
     : fallbackColor;
@@ -14375,47 +14377,6 @@ const AI_MOVE_INITIAL_DELAY_MS = 300;
 const AI_MOVE_CARGO_RETRY_DELAY_MS = 200;
 const AI_MOVE_CARGO_WAIT_TIMEOUT_MS = 1800;
 const AI_TURN_MIN_RELEASE_BUDGET_MS = 900;
-let aiRemovalHardFailState = {
-  notifiedTurnCommitSequence: null,
-};
-
-function triggerComputerAiRemovedHardFail(reason = "unspecified"){
-  if(
-    isGameOver
-    || gameMode !== "computer"
-    || turnColors?.[turnIndex] !== "blue"
-  ){
-    return { ok: false, reasonCode: "ai_removed_hard_fail_not_applicable" };
-  }
-
-  aiMoveScheduled = false;
-  clearAiPostInventoryLaunchTimeout(`ai_removed_hard_fail:${reason}`);
-  clearAiLaunchSessionWatchdog();
-  aiLaunchSession = null;
-  cleanupHandle();
-
-  if(aiRemovalHardFailState.notifiedTurnCommitSequence !== turnCommitSequence){
-    aiRemovalHardFailState.notifiedTurnCommitSequence = turnCommitSequence;
-    showAiLaunchNotice("Старый AI удалён. Новый AI ещё не внедрён: компьютерный ход недоступен.", {
-      persistent: true,
-      kind: "ai_removed_hard_fail",
-    });
-    console.error("[AI_REMOVED_HARD_FAIL]", {
-      reason,
-      turnCommitSequence,
-      turnNumber: turnAdvanceCount,
-      gameMode,
-      turnColor: turnColors?.[turnIndex] || null,
-    });
-  }
-
-  return {
-    ok: false,
-    reasonCode: "ai_removed_hard_fail",
-    message: "Old AI removed. New AI is not implemented yet.",
-  };
-}
-
 function resetAiTurnTimingState(){
   aiTurnTimingState = {
     turnStartedAt: 0,
@@ -14505,7 +14466,6 @@ function invalidateAiPlanningState(reason = "unspecified"){
   aiLaunchSession = null;
   cleanupHandle();
   clearAiLaunchStallNotice();
-  aiRemovalHardFailState.notifiedTurnCommitSequence = null;
   if(reason === "turn_advanced" || reason === "round_reset" || reason === "game_reset"){
     resetAiTurnTimingState();
   }
@@ -26318,69 +26278,78 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
       return { executed: false, reason: "selected_candidate_buff_already_used_this_turn", itemType };
     }
     let executed = false;
-    if(itemType === INVENTORY_ITEM_TYPES.CROSSHAIR){
-      executed = applyItemToOwnPlane(INVENTORY_ITEM_TYPES.CROSSHAIR, "blue", plannedMove.plane);
-      if(executed){
-        removeItemFromInventory("blue", INVENTORY_ITEM_TYPES.CROSSHAIR);
-        rememberSingleUseBuffSpentThisTurn(INVENTORY_ITEM_TYPES.CROSSHAIR);
-      }
-    } else if(itemType === INVENTORY_ITEM_TYPES.FUEL){
-      executed = applyItemToOwnPlane(INVENTORY_ITEM_TYPES.FUEL, "blue", plannedMove.plane);
-      if(executed){
-        removeItemFromInventory("blue", INVENTORY_ITEM_TYPES.FUEL);
-        rememberSingleUseBuffSpentThisTurn(INVENTORY_ITEM_TYPES.FUEL);
-      }
-    } else if(itemType === INVENTORY_ITEM_TYPES.WINGS){
-      executed = applyItemToOwnPlane(INVENTORY_ITEM_TYPES.WINGS, "blue", plannedMove.plane);
-      if(executed){
-        removeItemFromInventory("blue", INVENTORY_ITEM_TYPES.WINGS);
-        rememberSingleUseBuffSpentThisTurn(INVENTORY_ITEM_TYPES.WINGS);
-      }
-    } else if(itemType === INVENTORY_ITEM_TYPES.MINE){
-      const placement = candidate?.minePlan?.placement || null;
-      if(placement && isMinePlacementValid(placement)){
-        placeMine({
-          owner: "blue",
-          x: placement.x,
-          y: placement.y,
-          cellX: placement.cellX,
-          cellY: placement.cellY,
-        });
-        executed = true;
-      }
-      if(executed){
-        removeItemFromInventory("blue", INVENTORY_ITEM_TYPES.MINE);
-      }
-    } else if(itemType === INVENTORY_ITEM_TYPES.DYNAMITE){
-      const target = candidate?.target || null;
-      const targetX = Number.isFinite(target?.x) ? target.x : null;
-      const targetY = Number.isFinite(target?.y) ? target.y : null;
-      if(targetX != null && targetY != null){
-        executed = placeBlueDynamiteAt(targetX, targetY);
+    try {
+      if(itemType === INVENTORY_ITEM_TYPES.CROSSHAIR){
+        executed = applyItemToOwnPlane(INVENTORY_ITEM_TYPES.CROSSHAIR, "blue", plannedMove.plane);
         if(executed){
-          setAiDynamiteIntentFromCandidate(
-            {
-              colliderId: target?.colliderId ?? null,
-              spriteId: target?.spriteId ?? null,
-              x: targetX,
-              y: targetY,
-            },
-            candidate?.reason || "dynamite_route_opening",
-            plannedMove,
-            candidate?.dynamiteExpectedRoute || null,
-            candidate?.dynamiteUseClass || null,
-          );
+          removeItemFromInventory("blue", INVENTORY_ITEM_TYPES.CROSSHAIR);
+          rememberSingleUseBuffSpentThisTurn(INVENTORY_ITEM_TYPES.CROSSHAIR);
+        }
+      } else if(itemType === INVENTORY_ITEM_TYPES.FUEL){
+        executed = applyItemToOwnPlane(INVENTORY_ITEM_TYPES.FUEL, "blue", plannedMove.plane);
+        if(executed){
+          removeItemFromInventory("blue", INVENTORY_ITEM_TYPES.FUEL);
+          rememberSingleUseBuffSpentThisTurn(INVENTORY_ITEM_TYPES.FUEL);
+        }
+      } else if(itemType === INVENTORY_ITEM_TYPES.WINGS){
+        executed = applyItemToOwnPlane(INVENTORY_ITEM_TYPES.WINGS, "blue", plannedMove.plane);
+        if(executed){
+          removeItemFromInventory("blue", INVENTORY_ITEM_TYPES.WINGS);
+          rememberSingleUseBuffSpentThisTurn(INVENTORY_ITEM_TYPES.WINGS);
+        }
+      } else if(itemType === INVENTORY_ITEM_TYPES.MINE){
+        const placement = candidate?.minePlan?.placement || null;
+        if(placement && isMinePlacementValid(placement)){
+          placeMine({
+            owner: "blue",
+            x: placement.x,
+            y: placement.y,
+            cellX: placement.cellX,
+            cellY: placement.cellY,
+          });
+          executed = true;
+        }
+        if(executed){
+          removeItemFromInventory("blue", INVENTORY_ITEM_TYPES.MINE);
+        }
+      } else if(itemType === INVENTORY_ITEM_TYPES.DYNAMITE){
+        const target = candidate?.target || null;
+        const targetX = Number.isFinite(target?.x) ? target.x : null;
+        const targetY = Number.isFinite(target?.y) ? target.y : null;
+        if(targetX != null && targetY != null){
+          executed = placeBlueDynamiteAt(targetX, targetY);
+          if(executed){
+            setAiDynamiteIntentFromCandidate(
+              {
+                colliderId: target?.colliderId ?? null,
+                spriteId: target?.spriteId ?? null,
+                x: targetX,
+                y: targetY,
+              },
+              candidate?.reason || "dynamite_route_opening",
+              plannedMove,
+              candidate?.dynamiteExpectedRoute || null,
+              candidate?.dynamiteUseClass || null,
+            );
+          }
+        }
+        if(executed){
+          removeItemFromInventory("blue", INVENTORY_ITEM_TYPES.DYNAMITE);
+        }
+      } else if(itemType === INVENTORY_ITEM_TYPES.INVISIBILITY){
+        executed = queueInvisibilityEffectForPlayer("blue");
+        if(executed){
+          removeItemFromInventory("blue", INVENTORY_ITEM_TYPES.INVISIBILITY);
+          rememberSingleUseBuffSpentThisTurn(INVENTORY_ITEM_TYPES.INVISIBILITY);
         }
       }
-      if(executed){
-        removeItemFromInventory("blue", INVENTORY_ITEM_TYPES.DYNAMITE);
-      }
-    } else if(itemType === INVENTORY_ITEM_TYPES.INVISIBILITY){
-      executed = queueInvisibilityEffectForPlayer("blue");
-      if(executed){
-        removeItemFromInventory("blue", INVENTORY_ITEM_TYPES.INVISIBILITY);
-        rememberSingleUseBuffSpentThisTurn(INVENTORY_ITEM_TYPES.INVISIBILITY);
-      }
+    } catch (applyError) {
+      return {
+        executed: false,
+        reason: "selected_candidate_apply_exception",
+        itemType,
+        message: applyError?.message || String(applyError),
+      };
     }
 
     if(!executed){
@@ -26633,6 +26602,40 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
     return forcedCandidates;
   }
 
+  function buildBaselineInventoryPolicyCandidates(excludedItemTypes = new Set()){
+    const baselineOrder = [
+      INVENTORY_ITEM_TYPES.CROSSHAIR,
+      INVENTORY_ITEM_TYPES.FUEL,
+      INVENTORY_ITEM_TYPES.WINGS,
+      INVENTORY_ITEM_TYPES.INVISIBILITY,
+      INVENTORY_ITEM_TYPES.MINE,
+      INVENTORY_ITEM_TYPES.DYNAMITE,
+    ];
+    const candidates = [];
+    for(const itemType of baselineOrder){
+      if(excludedItemTypes.has(itemType)) continue;
+      const availableCount = Number(evaluateBlueInventoryState()?.counts?.[itemType] ?? 0);
+      if(availableCount <= 0) continue;
+      const candidate = {
+        itemType,
+        reason: "baseline_inventory_policy_spend",
+        reasonCode: "baseline_inventory_policy_spend",
+        usageTier: "baseline",
+        executionSource: "baseline_inventory_policy_spend",
+        expectedBenefit: 0.04,
+        risk: 0.01,
+      };
+
+      if(itemType === INVENTORY_ITEM_TYPES.MINE || itemType === INVENTORY_ITEM_TYPES.DYNAMITE){
+        // Базовая политика не делает «слепые» тактические постановки без валидной геометрии.
+        continue;
+      }
+
+      candidates.push(candidate);
+    }
+    return candidates;
+  }
+
   function tryApplyCandidates(candidateList, appliedItemTypes, appliedReasonCodes, skippedItems){
     for(const candidate of candidateList){
       const executionResult = executeCommittedInventoryAction(candidate, candidate.executionSource || "selected_inventory_sequence");
@@ -26640,10 +26643,12 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
         skippedItems.push({
           itemType: candidate.itemType || null,
           reason: executionResult.reason || "selected_candidate_execution_failed",
+          message: executionResult.message || null,
         });
         logPreLaunchItemDecision("inventory_prelaunch_item_skipped", {
           itemType: candidate.itemType || null,
           reason: executionResult.reason || "selected_candidate_execution_failed",
+          message: executionResult.message || null,
           source: candidate.executionSource || "selected_inventory_sequence",
         });
         continue;
@@ -26686,6 +26691,22 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
         forcedItems: forcedFallbackCandidates.map((candidate) => candidate.itemType),
       });
       tryApplyCandidates(forcedFallbackCandidates, appliedItemTypes, appliedReasonCodes, skippedItems);
+    }
+  }
+
+  if(appliedItemTypes.length === 0){
+    const excludedItemTypes = new Set(
+      [
+        ...primaryCandidates.map((candidate) => candidate?.itemType),
+      ].filter(Boolean)
+    );
+    const baselinePolicyCandidates = buildBaselineInventoryPolicyCandidates(excludedItemTypes);
+    if(baselinePolicyCandidates.length > 0){
+      logPreLaunchItemDecision("inventory_prelaunch_baseline_policy", {
+        reason: "normal_pipeline_baseline_policy_spend",
+        baselineItems: baselinePolicyCandidates.map((candidate) => candidate.itemType),
+      });
+      tryApplyCandidates(baselinePolicyCandidates, appliedItemTypes, appliedReasonCodes, skippedItems);
     }
   }
 


### PR DESCRIPTION
### Motivation
- Address cases where AI appears to never use inventory due to mode/turn mismatch, missing cargo, or legacy hard-fail logic that blocked computer turns.
- Make per-item execution resilient to runtime exceptions so a single error does not silently prevent items from being consumed.
- Provide a conservative baseline spending policy so the AI will attempt non-tactical inventory spends when tactical candidates fail.

### Description
- Adjusted `giveItem` fallback turn color to force `blue` in `computer` mode by changing the `fallbackColor` logic in `giveItem` to respect `gameMode === "computer"`.
- Removed legacy AI hard-fail state and `triggerComputerAiRemovedHardFail` handling and corresponding `aiRemovalHardFailState` usage so computer-mode turns are not blocked by the old removal path.
- Hardened `executeCommittedInventoryAction` by wrapping item application in a `try/catch` and returning structured error info when application throws, and surfaced `message` in skip logs.
- Added a conservative `buildBaselineInventoryPolicyCandidates` function and a baseline fallback step that tries simple non-tactical spends (crosshair, fuel, wings, invisibility) when primary and forced tactical candidates fail, plus improved candidate application via `tryApplyCandidates` and enhanced `inventory_prelaunch_*` logging.
- Added analysis documentation at `docs/AI_INVENTORY_NON_USAGE_ANALYSIS_2026-04-26.md` that outlines hypotheses and debug checklist for AI inventory non-usage.

### Testing
- Ran the repository automated test suite including unit tests and integration tests and the linter, and the suite completed without failures.
- Executed automated inventory-related smoke checks to validate that `giveItem` assigns to `blue` in `computer` mode and that baseline candidates are considered when tactical candidates fail, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0295e524832d9d0a09dbb8876924)