### PR TITLE
Fix selected-plan invisibility crash when score state is missing

### DIFF
--- a/script.js
+++ b/script.js
@@ -26319,8 +26319,9 @@ function shouldAiUseWingsForSelectedPlan(context, selectedPlan){
   if(Array.isArray(context?.availableEnemyFlags)){
     pointsOfInterest.push(...context.availableEnemyFlags.filter((flag) => Number.isFinite(flag?.x) && Number.isFinite(flag?.y)).map((flag) => ({ x: flag.x, y: flag.y })));
   }
-  if(Array.isArray(colliders)){
-    pointsOfInterest.push(...colliders.filter((item) => Number.isFinite(item?.cx) && Number.isFinite(item?.cy)).slice(0, 32).map((item) => ({ x: item.cx, y: item.cy })));
+  const runtimeColliders = typeof colliders !== "undefined" ? colliders : null;
+  if(Array.isArray(runtimeColliders)){
+    pointsOfInterest.push(...runtimeColliders.filter((item) => Number.isFinite(item?.cx) && Number.isFinite(item?.cy)).slice(0, 32).map((item) => ({ x: item.cx, y: item.cy })));
   }
 
   const nearestDistance = pointsOfInterest
@@ -26334,12 +26335,15 @@ function shouldAiUseWingsForSelectedPlan(context, selectedPlan){
 
 function shouldAiUseInvisibilityForSelectedPlan(context, selectedPlan){
   const plane = selectedPlan?.plane || null;
-  const aiColor = selectedPlan?.color || plane?.color || context?.color || turnColors?.[turnIndex] || "blue";
+  const runtimeTurnColors = typeof turnColors !== "undefined" ? turnColors : null;
+  const runtimeTurnIndex = typeof turnIndex !== "undefined" ? turnIndex : 0;
+  const aiColor = selectedPlan?.color || plane?.color || context?.color || runtimeTurnColors?.[runtimeTurnIndex] || "blue";
   if(!plane || !aiColor) return false;
-  if(isPlayerInvisibilityActive(aiColor)) return false;
+  if(typeof isPlayerInvisibilityActive === "function" && isPlayerInvisibilityActive(aiColor)) return false;
 
-  const allyPlanes = Array.isArray(points)
-    ? points.filter((entry) => entry?.color === aiColor)
+  const runtimePoints = typeof points !== "undefined" ? points : null;
+  const allyPlanes = Array.isArray(runtimePoints)
+    ? runtimePoints.filter((entry) => entry?.color === aiColor)
     : [];
   const survivingAllies = allyPlanes.filter((entry) => entry?.active !== false).length;
   if(survivingAllies <= 0) return false;
@@ -26348,7 +26352,11 @@ function shouldAiUseInvisibilityForSelectedPlan(context, selectedPlan){
     ? context.enemies.some((enemy) => Number.isFinite(enemy?.x) && Number.isFinite(enemy?.y) && dist(plane, enemy) <= CELL_SIZE * 4.5)
     : false;
   const carryingObjective = Boolean(plane?.hasCargo || plane?.hasFlag || plane?.carryingCargo || plane?.carryingFlag);
-  const isAheadByScore = Number(aiScores?.[aiColor] ?? 0) > Number(aiScores?.[aiColor === "blue" ? "green" : "blue"] ?? 0);
+  const scoreState = context?.scoreState || context?.scores || null;
+  const enemyColor = aiColor === "blue" ? "green" : "blue";
+  const isAheadByScore = scoreState
+    ? Number(scoreState?.[aiColor] ?? 0) > Number(scoreState?.[enemyColor] ?? 0)
+    : false;
 
   return survivingAllies >= 2 && (carryingObjective || nearbyEnemyThreat || isAheadByScore);
 }
@@ -26357,7 +26365,9 @@ function buildAiSelectedPlanInventoryEnhancements(context, selectedPlan, options
   const plane = selectedPlan?.plane || null;
   if(!plane) return [];
 
-  const color = selectedPlan?.color || plane?.color || context?.color || turnColors?.[turnIndex] || "blue";
+  const runtimeTurnColors = typeof turnColors !== "undefined" ? turnColors : null;
+  const runtimeTurnIndex = typeof turnIndex !== "undefined" ? turnIndex : 0;
+  const color = selectedPlan?.color || plane?.color || context?.color || runtimeTurnColors?.[runtimeTurnIndex] || "blue";
   const availableCounts = evaluateInventoryState(color)?.counts || {};
   const maxItems = Number.isFinite(options?.maxItems)
     ? Math.max(0, Math.min(2, Math.trunc(options.maxItems)))

--- a/scripts/smoke-ai-temporary-item-candidate.js
+++ b/scripts/smoke-ai-temporary-item-candidate.js
@@ -48,7 +48,6 @@ const context = {
     { id: 'blue-1', color: 'blue', active: true, x: 0, y: 0, activeTurnBuffs: {} },
     { id: 'blue-2', color: 'blue', active: true, x: 20, y: 0, activeTurnBuffs: {} },
   ],
-  aiScores: { blue: 10, green: 8 },
   colliders: [],
   INVENTORY_ITEM_TYPES: {
     FUEL: 'fuel',
@@ -157,5 +156,39 @@ const lowValuePlan = {
 };
 const lowValueSequence = context.buildAiSelectedPlanInventoryEnhancements({ color: 'blue', enemies: [] }, lowValuePlan);
 assert(!lowValueSequence.some((entry) => entry.itemType === 'mine' || entry.itemType === 'dynamite'), 'Expected no blind mine/dynamite spending in selected-plan enhancement sequence.');
+
+const survivabilityPlanWithoutScoreState = {
+  plane: { ...basePlane, hasCargo: true },
+  color: 'blue',
+  landingX: 12,
+  landingY: 0,
+  planDistance: 12,
+  goalName: 'simple_step2_pickup_cargo',
+  decisionReason: 'carry_objective',
+  routeClass: 'direct',
+};
+const noScoreStateSequence = context.buildAiSelectedPlanInventoryEnhancements(
+  { color: 'blue', enemies: [] },
+  survivabilityPlanWithoutScoreState,
+);
+assert(
+  noScoreStateSequence.some((entry) => entry.itemType === 'invisibility'),
+  'Expected no crash and invisibility support when score state is absent but objective pressure exists.',
+);
+
+const survivabilityPlanWithScoreState = {
+  ...survivabilityPlanWithoutScoreState,
+  plane: { ...basePlane, hasCargo: false },
+  goalName: 'simple_step2_center',
+  decisionReason: 'score_lead_hold',
+};
+const scoreStateSequence = context.buildAiSelectedPlanInventoryEnhancements(
+  { color: 'blue', enemies: [], scoreState: { blue: 9, green: 6 } },
+  survivabilityPlanWithScoreState,
+);
+assert(
+  scoreStateSequence.some((entry) => entry.itemType === 'invisibility'),
+  'Expected invisibility to use optional scoreState when provided.',
+);
 
 console.log('Smoke test passed: selected-plan inventory enhancements are deterministic and avoid heavy candidate rebuilds.');


### PR DESCRIPTION
### Motivation
- A runtime `ReferenceError` occurred because `shouldAiUseInvisibilityForSelectedPlan` referenced a global `aiScores` that does not exist in the real browser runtime, while the smoke test had been masking the bug by injecting `aiScores` into the VM context.  
- The change ensures invisibility logic is robust when score data is absent and avoids introducing new crashes from missing globals used by the selected-plan inventory helpers.

### Description
- Removed direct use of the global `aiScores` inside `shouldAiUseInvisibilityForSelectedPlan` and switched to an optional lookup of `context.scoreState` or `context.scores` when comparing scores (`isAheadByScore`).
- Added runtime guards for possibly-absent globals used by selected-plan helpers: `turnColors`, `turnIndex`, `points`, and `colliders` are checked with `typeof` before use so missing globals do not throw.
- Guarded `isPlayerInvisibilityActive` with a `typeof` check before calling it to avoid calling an undefined function in some environments.
- Updated the smoke test `scripts/smoke-ai-temporary-item-candidate.js` to stop injecting a fake global `aiScores`, added a test asserting `buildAiSelectedPlanInventoryEnhancements()` does not crash and can return `invisibility` when `context.scoreState` is absent, and added a separate test where `context.scoreState` is provided to exercise the score-based branch.
- Changes preserve the selected-plan inventory behavior: fuel/crosshair/wings selection unchanged; invisibility is still optional and may be chosen based on objective/threat even without score data.

### Testing
- Ran `node --check script.js` and it passed (no syntax errors).  
- Ran `node scripts/smoke-ai-temporary-item-candidate.js` and the smoke test passed, including new assertions for (a) no-crash invisibility flow without score state and (b) optional score-state-based invisibility flow when provided.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef210d4f68832d8160beb33ee464b2)