### PR TITLE
Fix AI selected-plan inventory sequence handoff

### DIFF
--- a/script.js
+++ b/script.js
@@ -15210,15 +15210,28 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       : [];
     selectedPlan.selectedInventorySequence = selectedPlanEnhancementSequence;
 
+    const selectedInventorySequence = Array.isArray(selectedPlan.selectedInventorySequence)
+      ? selectedPlan.selectedInventorySequence.map((entry) => ({ ...entry }))
+      : [];
+
     let launchResult = tryIssueAiMoveWithInventory({
-      plane: launchReadyPlane,
-      color: selectedPlan.color || launchReadyPlane?.color || turnColors?.[turnIndex] || "blue",
+      plane: selectedPlan.plane || launchReadyPlane,
+      color: selectedPlan.color || selectedPlan?.plane?.color || launchReadyPlane?.color || turnColors?.[turnIndex] || "blue",
       landingX: selectedPlan.landingX,
       landingY: selectedPlan.landingY,
+      planDistance: selectedPlan.planDistance,
+      totalDist: selectedPlan.planDistance,
+      bounceCount: selectedPlan.bounceCount,
+      score: selectedPlan.score,
+      targetPoint: selectedPlan.targetPoint || null,
+      predictedOutcome: selectedPlan.predictedOutcome || null,
+      hasDirectEnemy: Boolean(selectedPlan.hasDirectEnemy),
+      readyCargoCount: selectedPlan.readyCargoCount,
       goalName: selectedPlan.goalName,
       decisionReason: selectedPlan.decisionReason,
       whyChosen: selectedPlan.whyChosen,
       routeClass: selectedPlan.routeClass || "direct",
+      selectedInventorySequence,
       preAppliedInventoryItemType: selectedPlan.preAppliedInventoryItemType || null,
     }, "simple_step2_selector");
 
@@ -26610,12 +26623,26 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
   }
 
   const orderedCandidates = [];
-  const deterministicEnhancements = buildAiSelectedPlanInventoryEnhancements(context, {
-    ...plannedMove,
-    color: aiColor,
-  }, {
-    maxItems: 2,
-  });
+  const deterministicEnhancements = selectedInventorySequence.length > 0
+    ? []
+    : buildAiSelectedPlanInventoryEnhancements(context, {
+        ...plannedMove,
+        color: aiColor,
+      }, {
+        maxItems: 2,
+      });
+
+  for(const step of selectedInventorySequence){
+    orderedCandidates.push({
+      ...step,
+      reasonCode: step.reason || "selected_plan_enhancement",
+      executionSource: "selected_plan_enhancement",
+      usageTier: "selected_plan_enhancement",
+      expectedBenefit: 0.1,
+      risk: 0.01,
+    });
+  }
+
   for(const enhancement of deterministicEnhancements){
     orderedCandidates.push({
       ...enhancement,
@@ -26629,9 +26656,6 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
 
   if(selectedInventoryCandidate){
     orderedCandidates.push({ ...selectedInventoryCandidate, executionSource: "selected_inventory_candidate" });
-  }
-  for(const entry of selectedInventorySequence){
-    orderedCandidates.push({ ...entry, executionSource: "selected_inventory_sequence" });
   }
   if(Array.isArray(plannedMove?.inventoryCandidates)){
     for(const entry of plannedMove.inventoryCandidates){

--- a/scripts/smoke-ai-selected-plan-handoff.js
+++ b/scripts/smoke-ai-selected-plan-handoff.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const vm = require('vm');
+
+function extractFunctionSource(source, fnName){
+  const signature = `function ${fnName}(`;
+  const start = source.indexOf(signature);
+  if(start === -1) throw new Error(`Function not found in script.js: ${fnName}`);
+  const signatureEnd = source.indexOf(')', start);
+  const bodyStart = source.indexOf('{', signatureEnd);
+  let depth = 0;
+  for(let i = bodyStart; i < source.length; i += 1){
+    const ch = source[i];
+    if(ch === '{') depth += 1;
+    if(ch === '}') depth -= 1;
+    if(depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`Function body end not found for: ${fnName}`);
+}
+
+function assert(condition, message){
+  if(!condition) throw new Error(message);
+}
+
+const source = fs.readFileSync('script.js', 'utf8');
+const scheduleSrc = extractFunctionSource(source, 'scheduleComputerMoveWithCargoGate');
+
+const selectedPlanPlane = { id: 'blue-selected', color: 'blue', x: 10, y: 10 };
+const capturedMoves = [];
+
+const context = {
+  Math,
+  Number,
+  Boolean,
+  Array,
+  Object,
+  JSON,
+  performance: { now: () => 0 },
+  AI_MOVE_INITIAL_DELAY_MS: 0,
+  AI_MOVE_CARGO_RETRY_DELAY_MS: 0,
+  FIELD_FLIGHT_DURATION_SEC: 1,
+  CELL_SIZE: 10,
+  FIELD_TOP: 0,
+  FIELD_HEIGHT: 100,
+  isGameOver: false,
+  gameMode: 'computer',
+  turnColors: ['blue'],
+  turnIndex: 0,
+  aiLaunchSession: null,
+  aiMoveScheduled: false,
+  points: [selectedPlanPlane],
+  flyingPoints: [],
+  cargoState: [],
+  colliders: [],
+  settings: { flagsMode: false },
+  INVENTORY_ITEM_TYPES: {
+    FUEL: 'fuel',
+  },
+  markAiTurnStarted: () => {},
+  hasAnimatingCargo: () => false,
+  getBaseAnchor: () => ({ x: 10, y: 90 }),
+  getAvailableFlagsByColor: () => [],
+  isPlaneLaunchStateReady: () => true,
+  isPlaneTargetable: () => true,
+  buildAiShotSimulationQualityProfile: () => ({
+    coarseAngleStepDeg: 6,
+    fineAngleStepDeg: 2,
+    coarseScaleStep: 0.08,
+    fineScaleStep: 0.03,
+    seedCount: 8,
+    coarsePoolSize: 20,
+    maxEnemyCandidatesPerPlane: 3,
+    profileName: 'smoke',
+  }),
+  getAiFlightRangeProfile: () => ({ flightDistancePx: 40 }),
+  getEffectiveFlightRangeCells: () => 4,
+  getCargoVisualCenter: (cargo) => ({ x: cargo.x || 0, y: cargo.y || 0 }),
+  dist: (a, b) => Math.hypot((a?.x || 0) - (b?.x || 0), (a?.y || 0) - (b?.y || 0)),
+  getNearestPointInCenterControlZone: () => ({ x: 10, y: 50 }),
+  getNearestReachableCenterControlPoint: () => ({ x: 10, y: 50 }),
+  isPathClear: () => true,
+  getMandatoryTurnMove: () => null,
+  collectAiCargoRouteCandidates: () => [],
+  getAiCargoRicochetPreferenceBonus: () => 0,
+  AI_CARGO_RISK_ACCEPTANCE: 1,
+  getPlaneEffectiveRangePx: () => 40,
+  findBestSimulatedShot: () => null,
+  advanceTurn: () => {},
+  logAiDecision: () => {},
+  buildAiSelectedPlanInventoryEnhancements: () => ([
+    { itemType: 'fuel', reason: 'selected_plan_range_pressure' },
+  ]),
+  issueAIMoveFromDoComputerMove: (_ctx, plannedMove, meta) => {
+    if(meta?.source === 'simple_step2_selector'){
+      capturedMoves.push(plannedMove);
+      return { selected: true, reason: 'ok' };
+    }
+    return { selected: false, reason: 'unexpected_source' };
+  },
+  setTimeout(fn){ fn(); return 1; },
+};
+
+vm.createContext(context);
+vm.runInContext(scheduleSrc, context);
+context.scheduleComputerMoveWithCargoGate();
+
+assert(capturedMoves.length === 1, 'Expected exactly one simple_step2_selector launch attempt.');
+const plannedMove = capturedMoves[0];
+assert(plannedMove?.plane === selectedPlanPlane, 'Expected selectedPlan.plane to be preserved as plannedMove.plane.');
+assert(Array.isArray(plannedMove?.selectedInventorySequence), 'Expected selectedInventorySequence to be forwarded into planned move.');
+assert(
+  plannedMove.selectedInventorySequence.some((entry) => entry?.itemType === 'fuel'),
+  'Expected selectedInventorySequence to include FUEL from selected-plan enhancements.'
+);
+
+console.log('Smoke test passed: selected-plan inventory sequence and plane survive schedule -> tryIssue handoff.');


### PR DESCRIPTION
### Motivation
- The AI computed a `selectedInventorySequence` for a chosen plan but that sequence was not forwarded into the launch flow, causing the selected plan's inventory choices to be lost before execution.
- This mismatch allowed downstream logic to recompute or diverge from the plan, risking random or incorrect inventory spending.
- The change ensures the selected-plan decisions are honored without adding logging or redesigning the system.

### Description
- Copy and forward `selectedInventorySequence` from `scheduleComputerMoveWithCargoGate` into the `tryIssueAiMoveWithInventory` call and include selected-plan metadata (distance, score, target, etc.).
- Prefer `selectedPlan.plane` over `launchReadyPlane` when building the planned move so inventory enhancements computed against the selected plane remain valid. 
- Update `maybeUseInventoryBeforeLaunch` to prefer and consume a passed `selectedInventorySequence` first and only build deterministic enhancements when no sequence was provided, avoiding duplicate deterministic insertion. 
- Convert each `selectedInventorySequence` step into an executable candidate with `reasonCode`, `executionSource`, `usageTier`, `expectedBenefit`, and `risk`, and retain the existing `useInventoryItemOnPlane` path for buff items (FUEL/CROSSHAIR/WINGS). 
- Add a new smoke test `scripts/smoke-ai-selected-plan-handoff.js` that stubs a selected plan returning `FUEL` from `buildAiSelectedPlanInventoryEnhancements` and asserts the handoff preserves `selectedInventorySequence` and `plannedMove.plane`.

### Testing
- Ran syntax check with `node --check script.js` and it completed successfully. 
- Ran existing smoke tests `node scripts/smoke-ai-temporary-item-candidate.js` and `node scripts/smoke-ai-forced-non-skip-last-chance.js` and both passed. 
- Ran the new handoff smoke test `node scripts/smoke-ai-selected-plan-handoff.js` and it passed, validating that `selectedInventorySequence` with `FUEL` and `selectedPlan.plane` survive the schedule -> tryIssue handoff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa010714c832d826de53000648335)