### PR TITLE
Normalize inventory item types and add real prelaunch inventory smoke tests

### DIFF
--- a/script.js
+++ b/script.js
@@ -2907,11 +2907,30 @@ function playNuclearStrikeFx(){
   showNuclearStrikeCinematicLayer();
 }
 
+
+function normalizeInventoryItemType(type){
+  const raw = String(type || "").trim().toLowerCase();
+  if(!raw) return null;
+  if(raw === "fuel") return INVENTORY_ITEM_TYPES.FUEL;
+  if(raw === "crosshair" || raw === "accuracy" || raw === "aim") return INVENTORY_ITEM_TYPES.CROSSHAIR;
+  if(raw === "wings" || raw === "wing" || raw === "broad_wing" || raw === "broadwing") return INVENTORY_ITEM_TYPES.WINGS;
+  if(raw === "invisibility" || raw === "invisible") return INVENTORY_ITEM_TYPES.INVISIBILITY;
+  if(raw === "mine") return INVENTORY_ITEM_TYPES.MINE;
+  if(raw === "dynamite") return INVENTORY_ITEM_TYPES.DYNAMITE;
+  return raw;
+}
+
+function getInventoryItemType(item){
+  if(typeof item === "string") return normalizeInventoryItemType(item);
+  return normalizeInventoryItemType(item?.type || item?.itemType || item?.kind || null);
+}
+
 function removeItemFromInventory(color, type){
-  if(!color || !type) return;
+  const normalizedType = normalizeInventoryItemType(type);
+  if(!color || !normalizedType) return;
   const items = inventoryState[color];
   if(!Array.isArray(items) || items.length === 0) return;
-  const index = items.findIndex((item) => item?.type === type);
+  const index = items.findIndex((item) => getInventoryItemType(item) === normalizedType);
   if(index < 0) return;
   items.splice(index, 1);
   syncInventoryUI(color);
@@ -2954,23 +2973,24 @@ function getPlaneAtBoardPoint(color, x, y){
 }
 
 function applyItemToOwnPlane(type, color, plane){
-  if(!plane) return false;
+  const normalizedType = normalizeInventoryItemType(type);
+  if(!plane || !normalizedType) return false;
   if(
-    type === INVENTORY_ITEM_TYPES.CROSSHAIR
-    || type === INVENTORY_ITEM_TYPES.FUEL
-    || type === INVENTORY_ITEM_TYPES.WINGS
+    normalizedType === INVENTORY_ITEM_TYPES.CROSSHAIR
+    || normalizedType === INVENTORY_ITEM_TYPES.FUEL
+    || normalizedType === INVENTORY_ITEM_TYPES.WINGS
   ){
     if(!plane.activeTurnBuffs || typeof plane.activeTurnBuffs !== "object"){
       plane.activeTurnBuffs = {};
     }
 
-    if(type === INVENTORY_ITEM_TYPES.WINGS && plane.activeTurnBuffs[type] === true){
+    if(normalizedType === INVENTORY_ITEM_TYPES.WINGS && plane.activeTurnBuffs[normalizedType] === true){
       // Повторное применение обновляет эффект до 1 хода (текущая модель баффов = флаг на ход).
-      plane.activeTurnBuffs[type] = true;
+      plane.activeTurnBuffs[normalizedType] = true;
       return true;
     }
 
-    plane.activeTurnBuffs[type] = true;
+    plane.activeTurnBuffs[normalizedType] = true;
     return true;
   }
 
@@ -2978,13 +2998,14 @@ function applyItemToOwnPlane(type, color, plane){
 }
 
 function useInventoryItemOnPlane(color, type, plane, options = {}){
-  if(!color || !type || !plane) return false;
+  const normalizedType = normalizeInventoryItemType(type);
+  if(!color || !normalizedType || !plane) return false;
   const items = inventoryState?.[color];
   if(!Array.isArray(items)) return false;
-  const itemIndex = items.findIndex((item) => item?.type === type);
+  const itemIndex = items.findIndex((item) => getInventoryItemType(item) === normalizedType);
   if(itemIndex < 0) return false;
 
-  const applied = applyItemToOwnPlane(type, color, plane);
+  const applied = applyItemToOwnPlane(normalizedType, color, plane);
   if(!applied) return false;
 
   items.splice(itemIndex, 1);
@@ -5113,11 +5134,17 @@ function drawInventoryHintOnHud(ctx) {
 }
 
 function addItemToInventory(color, item){
-  if(!color || !item) return;
+  if(!color || item == null) return;
+  const normalizedType = getInventoryItemType(item);
+  if(!normalizedType) return;
   if(!inventoryState[color]){
     inventoryState[color] = [];
   }
-  inventoryState[color].push(item);
+  if(typeof item === "object" && item !== null){
+    inventoryState[color].push({ ...item, type: normalizedType });
+  } else {
+    inventoryState[color].push(normalizedType);
+  }
   syncInventoryUI(color);
 }
 
@@ -5306,7 +5333,9 @@ function requestAiFuelTrainingForNextTurn(source = "debug_command"){
 
 function giveItem(itemId, qty = 1, opts = { silent: false }){
   if(!itemId) return;
-  const itemDef = INVENTORY_ITEMS.find((item) => item?.type === itemId) ?? null;
+  const normalizedItemId = normalizeInventoryItemType(itemId);
+  if(!normalizedItemId) return;
+  const itemDef = INVENTORY_ITEMS.find((item) => normalizeInventoryItemType(item?.type) === normalizedItemId) ?? null;
   if(!itemDef) return;
   const safeQty = Number.isFinite(qty) ? Math.max(0, Math.floor(qty)) : 0;
   if(safeQty === 0) return;
@@ -5385,8 +5414,8 @@ function giveOpponentItemFromConsole(itemType, qty = 1, source = "console_give_o
   if(!itemType) return { ok: false, reason: "missing_item_type" };
   const normalizedQty = Number.isFinite(qty) ? Math.max(1, Math.floor(qty)) : 1;
   const targetColor = getOpponentDebugTargetColor();
-  const normalizedItemType = String(itemType).toLowerCase();
-  const itemExists = INVENTORY_ITEMS.some((item) => item?.type === normalizedItemType);
+  const normalizedItemType = normalizeInventoryItemType(itemType);
+  const itemExists = INVENTORY_ITEMS.some((item) => normalizeInventoryItemType(item?.type) === normalizedItemType);
   if(!itemExists){
     return { ok: false, reason: "unknown_item_type", itemType: normalizedItemType };
   }
@@ -21390,8 +21419,8 @@ function evaluateInventoryState(color){
   };
 
   for(const item of items){
-    const type = item?.type;
-    if(type in counts){
+    const type = getInventoryItemType(item);
+    if(type && type in counts){
       counts[type] += 1;
     }
   }
@@ -26566,7 +26595,7 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
     if(!candidate || !candidate.itemType){
       return { executed: false, reason: "selected_candidate_missing" };
     }
-    const itemType = candidate.itemType;
+    const itemType = normalizeInventoryItemType(candidate.itemType);
     if(!PRE_LAUNCH_ALLOWED_ITEM_TYPES.has(itemType)){
       return { executed: false, reason: "selected_candidate_item_not_in_step5_scope", itemType };
     }

--- a/scripts/smoke-ai-prelaunch-real-inventory-execution.js
+++ b/scripts/smoke-ai-prelaunch-real-inventory-execution.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const vm = require('vm');
+
+function extractFunctionSource(source, fnName){
+  const signature = `function ${fnName}(`;
+  const start = source.indexOf(signature);
+  if(start === -1) throw new Error(`Function not found: ${fnName}`);
+  const signatureEnd = source.indexOf(')', start);
+  const bodyStart = source.indexOf('{', signatureEnd);
+  let depth = 0;
+  for(let i = bodyStart; i < source.length; i += 1){
+    const ch = source[i];
+    if(ch === '{') depth += 1;
+    if(ch === '}') depth -= 1;
+    if(depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`Function body end not found: ${fnName}`);
+}
+function assert(condition, message){ if(!condition) throw new Error(message); }
+
+const source = fs.readFileSync('script.js', 'utf8');
+const fnNames = [
+  'normalizeInventoryItemType',
+  'getInventoryItemType',
+  'removeItemFromInventory',
+  'applyItemToOwnPlane',
+  'useInventoryItemOnPlane',
+  'evaluateInventoryState',
+  'maybeUseInventoryBeforeLaunch',
+];
+const code = fnNames.map((name) => extractFunctionSource(source, name)).join('\n\n');
+
+const context = {
+  Math, Number, String, Array, Object, Set,
+  INVENTORY_ITEM_TYPES: { FUEL:'fuel', CROSSHAIR:'crosshair', WINGS:'wings', MINE:'mine', DYNAMITE:'dynamite', INVISIBILITY:'invisibility' },
+  inventoryState: { blue: [{ type: 'fuel' }], green: [] },
+  turnColors: ['blue'], turnIndex: 0,
+  aiRoundState: { currentGoal: 'simple_step2_selector' },
+  syncInventoryUI(){}, logAiDecision(){},
+  queueInvisibilityEffectForPlayer(){ return false; },
+  isMinePlacementValid(){ return false; },
+  placeMine(){ return false; },
+  placeBlueDynamiteAt(){ return false; },
+  setAiDynamiteIntentFromCandidate(){},
+  getAiMoveLandingPoint(){ return null; },
+  getBaseAnchor(){ return null; },
+  buildAiSelectedPlanInventoryEnhancements(){ return []; },
+};
+vm.createContext(context);
+vm.runInContext(code, context);
+
+const plannedMove = {
+  plane: { id: 'blue-plane', color: 'blue', x: 10, y: 10, activeTurnBuffs: {} },
+  color: 'blue',
+  selectedInventorySequence: [{ itemType: 'fuel', reason: 'test_real_selected_plan_fuel' }],
+  preAppliedInventoryItemType: null,
+  goalName: 'simple_step2_selector',
+  decisionReason: 'real_execution_smoke',
+  routeClass: 'direct',
+};
+
+const result = context.maybeUseInventoryBeforeLaunch({ color:'blue', enemies:[] }, plannedMove, {
+  allowForcedInventorySpend: false,
+  usedBuffTypesThisTurn: new Set(),
+});
+
+assert(result === true, 'Expected real maybeUseInventoryBeforeLaunch to return true.');
+assert(plannedMove.inventoryDecisionMadeMeta?.selected === true, 'Expected selected meta true.');
+assert(plannedMove.plane.activeTurnBuffs?.fuel === true, 'Expected activeTurnBuffs.fuel true.');
+assert(context.inventoryState.blue.length === 0, 'Expected inventoryState.blue fuel to be consumed once.');
+assert(context.evaluateInventoryState('blue').counts.fuel === 0, 'Expected evaluateInventoryState fuel count to be zero.');
+
+console.log('Smoke test passed: real prelaunch execution consumes real inventory and applies fuel buff.');

--- a/scripts/smoke-ai-prelaunch-selected-sequence-execution.js
+++ b/scripts/smoke-ai-prelaunch-selected-sequence-execution.js
@@ -54,6 +54,11 @@ const context = {
     DYNAMITE: 'dynamite',
     INVISIBILITY: 'invisibility',
   },
+
+  normalizeInventoryItemType(type){
+    const raw = String(type || '').toLowerCase();
+    return raw || null;
+  },
   evaluateInventoryState(color){
     if(color === 'green'){
       return {


### PR DESCRIPTION
### Motivation
- The AI sometimes failed to consume inventory items because runtime `inventoryState` entries used varied shapes/legacy keys and casing, while application code looked for `item?.type === <type>` only.
- Existing smoke test stubbed `useInventoryItemOnPlane()`, so it did not validate the real runtime path that applies and removes inventory items before launch.
- We need a low-level fix that normalizes item type access and an integration smoke test that exercises the real functions without stubs to prove the fix.

### Description
- Added `normalizeInventoryItemType(type)` and `getInventoryItemType(item)` to normalize strings, synonyms, legacy keys (`type`, `itemType`, `kind`) and casing. (`script.js`)
- Switched inventory read/write/usage paths to use normalization: `removeItemFromInventory`, `useInventoryItemOnPlane`, `applyItemToOwnPlane`, `evaluateInventoryState`, `addItemToInventory`, `giveItem`, and `giveOpponentItemFromConsole` now handle legacy/variant item shapes and normalized types. (`script.js`)
- Updated `maybeUseInventoryBeforeLaunch` to normalize `candidate.itemType` before checks and execution so selected-plan sequences match real inventory entries. (`script.js`)
- Added a new real-function smoke/integration test `scripts/smoke-ai-prelaunch-real-inventory-execution.js` that runs `maybeUseInventoryBeforeLaunch` together with real `useInventoryItemOnPlane`, `applyItemToOwnPlane`, `removeItemFromInventory`, `evaluateInventoryState`, and `inventoryState` and asserts: result true, `plannedMove.inventoryDecisionMadeMeta.selected === true`, `plane.activeTurnBuffs.fuel === true`, and inventory consumption. (`scripts/`)
- Updated the existing smoke harness `scripts/smoke-ai-prelaunch-selected-sequence-execution.js` to include a minimal normalization helper so it can exercise the real `maybeUseInventoryBeforeLaunch` without failing on missing helpers.

### Testing
- Ran the new integration smoke: `node scripts/smoke-ai-prelaunch-real-inventory-execution.js` — passed.
- Ran updated harness: `node scripts/smoke-ai-prelaunch-selected-sequence-execution.js` — passed.
- Changes committed (includes `script.js` modifications and new/updated smoke scripts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1bc888900832d9841a8fca3c97f57)