### PR TITLE
Preserve and propagate planning metadata through move scheduling

### DIFF
--- a/script.js
+++ b/script.js
@@ -14813,12 +14813,24 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       const vx = (plan.landingX - plan.plane.x) / durationSec;
       const vy = (plan.landingY - plan.plane.y) / durationSec;
       const totalDist = Math.hypot(vx || 0, vy || 0) * FIELD_FLIGHT_DURATION_SEC;
+      const propagatedPlanDistance = Number.isFinite(plan.planDistance)
+        ? plan.planDistance
+        : (Number.isFinite(plan.totalDist) ? plan.totalDist : totalDist);
       const plannedMove = {
         plane: plan.plane,
         color: plan?.plane?.color || plan.color || turnColors?.[turnIndex] || "blue",
         vx,
         vy,
         totalDist,
+        landingX: plan.landingX,
+        landingY: plan.landingY,
+        planDistance: propagatedPlanDistance,
+        score: Number.isFinite(plan.score) ? plan.score : null,
+        targetPoint: plan.targetPoint || null,
+        predictedOutcome: plan.predictedOutcome || null,
+        bounceCount: Number.isFinite(plan.bounceCount) ? plan.bounceCount : 0,
+        hasDirectEnemy: Boolean(plan.hasDirectEnemy),
+        readyCargoCount: plan.readyCargoCount,
         goalName: plan.goalName || "simple_step2_center",
         decisionReason: plan.decisionReason || "simple_step2_center_control",
         whyChosen: plan.whyChosen || "multi_plane_best_effort_selection",
@@ -34001,7 +34013,15 @@ function issueAIMoveFromDoComputerMove(context, plannedMove, metadata = {}){
     inventoryPlanning = buildAiInventoryCandidatePlans(context, plannedMove);
     plannedMove.inventoryCandidates = Array.isArray(inventoryPlanning?.candidates) ? inventoryPlanning.candidates.slice() : [];
     plannedMove.rejectedInventoryCandidates = Array.isArray(inventoryPlanning?.rejected) ? inventoryPlanning.rejected.slice() : [];
-    plannedMove.selectedInventorySequence = Array.isArray(inventoryPlanning?.selectedSequence) ? inventoryPlanning.selectedSequence.slice() : [];
+    const heavySelectedInventorySequence = Array.isArray(inventoryPlanning?.selectedSequence)
+      ? inventoryPlanning.selectedSequence.slice()
+      : [];
+    const upstreamSelectedInventorySequence = Array.isArray(plannedMove.selectedInventorySequence)
+      ? plannedMove.selectedInventorySequence.slice()
+      : [];
+    plannedMove.selectedInventorySequence = heavySelectedInventorySequence.length > 0
+      ? heavySelectedInventorySequence
+      : upstreamSelectedInventorySequence;
     if(inventoryPlanning?.selectedCandidate){
       plannedMove.selectedInventoryCandidate = inventoryPlanning.selectedCandidate;
       plannedMove.inventoryUsageReason = inventoryPlanning.selectedCandidate.reason || plannedMove.inventoryUsageReason || null;


### PR DESCRIPTION
## Summary
This PR enhances the move planning system to preserve and propagate detailed planning metadata through the scheduling pipeline, and improves inventory sequence selection logic to respect upstream decisions.

## Key Changes

- **Enhanced plannedMove object construction** in `scheduleComputerMoveWithCargoGate()`:
  - Added propagation of `planDistance` with fallback logic (prefers `plan.planDistance`, then `plan.totalDist`, then calculated `totalDist`)
  - Preserved landing coordinates (`landingX`, `landingY`)
  - Preserved planning metrics: `score`, `targetPoint`, `predictedOutcome`, `bounceCount`, `hasDirectEnemy`, `readyCargoCount`
  - These fields now flow through the entire move planning pipeline for better decision tracing and debugging

- **Improved inventory sequence selection logic** in `issueAIMoveFromDoComputerMove()`:
  - Changed from unconditionally overwriting `selectedInventorySequence` to a merge strategy
  - Now preserves upstream-provided `selectedInventorySequence` when the heavy computation produces no results
  - Prioritizes newly computed sequences but falls back to existing upstream decisions, preventing loss of valid planning information

## Implementation Details
The changes maintain backward compatibility while enabling better information flow through the planning system. The inventory sequence logic now respects both upstream planning decisions and newly computed candidates, using whichever provides the most complete information.

https://claude.ai/code/session_01D9BxQKxcL1VAzis1ABDSky