### PR TITLE
Add gray circle feedback for invisibility buff, sync with blink timing

### DIFF
--- a/script.js
+++ b/script.js
@@ -1652,7 +1652,7 @@ const playerInventoryEffects = {
     invisibilityActive: false,
     invisibilityFeedbackActive: false,
     invisibilityFeedbackStartAtMs: 0,
-    invisibilityFeedbackStepDurationMs: 320,
+    invisibilityFeedbackStepDurationMs: 250,
     invisibilityQueuedAlpha: 1,
   },
   green: {
@@ -1661,12 +1661,12 @@ const playerInventoryEffects = {
     invisibilityActive: false,
     invisibilityFeedbackActive: false,
     invisibilityFeedbackStartAtMs: 0,
-    invisibilityFeedbackStepDurationMs: 320,
+    invisibilityFeedbackStepDurationMs: 250,
     invisibilityQueuedAlpha: 1,
   },
 };
 
-const INVISIBILITY_FEEDBACK_ALPHA_PHASES = Object.freeze([0.5, 0.9, 0.5, 0.9]);
+const INVISIBILITY_FEEDBACK_ALPHA_PHASES = Object.freeze([0.5, 0.9]);
 const INVISIBILITY_FADE_DURATION_MS = 1000;
 const INVISIBILITY_MIN_ALPHA = 0;
 


### PR DESCRIPTION
## Summary

- При применении невидимости из инвентаря теперь появляются серые расширяющиеся кружки над всеми живыми самолётами игрока — в едином дизайне с фидбеками других баффов (crosshair/fuel/wings)
- Кружки намеренно тонкие и ненавязчивые (lineWidth 1.5/1.0 vs 2.5/1.5 у других баффов), чтобы не выдавать позиции самолётов
- Моргание самолётов синхронизировано с кружками: оба эффекта длятся ровно 500мс и заканчиваются одновременно (было: 4 фазы × 320мс = 1280мс моргания против 500мс кружков)

## Changes

- `PLANE_BUFF_FX_COLORS.invisibility`: `#9a7bff` → `#aaaaaa` (серый)
- `drawPlaneBuffAppliedFx()`: тоньше линии и меньше прозрачность для типа `invisibility`
- `queueInvisibilityEffectForPlayer()`: при активации штампует `buffAppliedAtMs/Type/DurationMs` на все живые самолёты игрока
- `INVISIBILITY_FEEDBACK_ALPHA_PHASES`: `[0.5, 0.9, 0.5, 0.9]` → `[0.5, 0.9]`
- `invisibilityFeedbackStepDurationMs`: `320` → `250` (итого 500мс = длительность кружков)

https://claude.ai/code/session_01LGb4jgDmBSJmmEa8Nm2547

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGb4jgDmBSJmmEa8Nm2547)_