### PR TITLE
Slow down invisibility blink to 500ms per phase for smoother UX

### DIFF
--- a/script.js
+++ b/script.js
@@ -1652,7 +1652,7 @@ const playerInventoryEffects = {
     invisibilityActive: false,
     invisibilityFeedbackActive: false,
     invisibilityFeedbackStartAtMs: 0,
-    invisibilityFeedbackStepDurationMs: 250,
+    invisibilityFeedbackStepDurationMs: 500,
     invisibilityQueuedAlpha: 1,
   },
   green: {
@@ -1661,7 +1661,7 @@ const playerInventoryEffects = {
     invisibilityActive: false,
     invisibilityFeedbackActive: false,
     invisibilityFeedbackStartAtMs: 0,
-    invisibilityFeedbackStepDurationMs: 250,
+    invisibilityFeedbackStepDurationMs: 500,
     invisibilityQueuedAlpha: 1,
   },
 };


### PR DESCRIPTION
250ms per phase felt jerky (glitch-like). 500ms per phase (1000ms total) gives one slow, readable pulse — plane dims as circles appear, then gently brightens back. The circles end at 500ms (mid-way through the return phase), creating a natural fade-out echo rather than a hard cut.

https://claude.ai/code/session_01LGb4jgDmBSJmmEa8Nm2547