### PR TITLE
Invisibility blink: slow down + fix opacity snap

### DIFF
--- a/script.js
+++ b/script.js
@@ -1666,7 +1666,7 @@ const playerInventoryEffects = {
   },
 };
 
-const INVISIBILITY_FEEDBACK_ALPHA_PHASES = Object.freeze([0.5, 0.9]);
+const INVISIBILITY_FEEDBACK_ALPHA_PHASES = Object.freeze([0.5, 0.5]);
 const INVISIBILITY_FADE_DURATION_MS = 1000;
 const INVISIBILITY_MIN_ALPHA = 0;
 


### PR DESCRIPTION
## Что изменилось

Два доработочных коммита поверх уже смержённого PR #2727:

1. **Замедление моргания** — 250мс → 500мс на фазу (1000мс итого). Было дёрганым, теперь плавный медленный пульс.

2. **Фикс скачка opacity** — фазы `[0.5, 0.9]` → `[0.5, 0.5]`. Раньше самолёт тускнел до 0.5, потом возвращался к 0.9, затем резко прыгал обратно к 0.5 — это резало глаза. Теперь тускнеет до 0.5 и плавно держится там, никакого рывка.

https://claude.ai/code/session_01LGb4jgDmBSJmmEa8Nm2547

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGb4jgDmBSJmmEa8Nm2547)_