### PR TITLE
AI: снять принудительный максимум дальности, дать выбирать самостоятельно

### DIFF
--- a/script.js
+++ b/script.js
@@ -16727,28 +16727,32 @@ function resolveAiLaunchTargetDistancePx(targetAim, fallbackDistancePx = MAX_DRA
   const requestedDistancePx = clamp(requestedPowerRatio * MAX_DRAG_DISTANCE, 0, MAX_DRAG_DISTANCE);
   const rawReason = targetAim?.powerAdjustmentReason || null;
   const reductionReason = classifyAiRangeReductionReason(rawReason);
-  const hasExplicitReductionRequest = targetAim?.intentionalPowerReduction === true && requestedDistancePx < maxDistancePx;
+  // Уважаем запрос планировщика — если AI явно хочет короче max, не затирать.
+  // Раньше требовался флаг intentionalPowerReduction, но он почти никогда
+  // не выставляется (только humanizer-шумом в одну сторону), поэтому AI
+  // фактически летел всегда на максимум.
+  const plannerRequestsShorter = requestedDistancePx < maxDistancePx - 0.5;
 
-  if(!hasExplicitReductionRequest || !reductionReason){
+  if(plannerRequestsShorter){
     return {
       baseTargetDistancePx: maxDistancePx,
-      targetDistancePx: maxDistancePx,
-      workingPullDistancePx: maxDistancePx,
-      rangeMode: "max_default",
-      reductionReason: null,
+      targetDistancePx: requestedDistancePx,
+      workingPullDistancePx: requestedDistancePx,
+      rangeMode: reductionReason ? "reduced_for_reason" : "respect_planner_request",
+      reductionReason: reductionReason || "respect_planner_request",
       reductionReasonSource: rawReason || null,
-      reductionApplied: false,
+      reductionApplied: true,
     };
   }
 
   return {
     baseTargetDistancePx: maxDistancePx,
-    targetDistancePx: requestedDistancePx,
-    workingPullDistancePx: requestedDistancePx,
-    rangeMode: "reduced_for_reason",
-    reductionReason,
-    reductionReasonSource: rawReason,
-    reductionApplied: true,
+    targetDistancePx: maxDistancePx,
+    workingPullDistancePx: maxDistancePx,
+    rangeMode: "max_default",
+    reductionReason: null,
+    reductionReasonSource: rawReason || null,
+    reductionApplied: false,
   };
 }
 


### PR DESCRIPTION
## Что и зачем

Исторически у ИИ было принудительное условие «всегда лети на максимум клеток» — чтобы не топтался на базе и не выбирал слабые осторожные ходы. Сейчас это даёт побочный эффект: ИИ делает странные ходы, например стреляет рикошетом за свою стену ради формального максимума, или летит на 30 клеток когда мог сходить меньше и остаться в безопасной зоне.

Цель: разрешить ИИ контролировать дальность самостоятельно. Высокая дальность остаётся **мягким предпочтением по умолчанию** через scale-floors и scoring штрафов длины — так что защита от старого «топтания» сохраняется.

## Что найдено

Принуждение жило в **четырёх местах**, каждое со своим механизмом. Все четыре отключены/смягчены:

### 1. `pickBestCandidate` в `planPathToPoint` (`script.js:35752-35777`)
Жёсткий tie-break: при квази-равном `routeQualityScore` (epsilon 1e-6) кандидат с `preferMaximumLaunch=true` всегда побеждал. Заменено на числовой bias `AI_PREFER_MAX_LAUNCH_BIAS = 0` — теперь aggressive-кандидат честно конкурирует по score. Откат: `bias = 0.000001`.

### 2. `enumerateAIShotCandidates` (`script.js:38338, 38356`)
Сортировка пула шотов по убыванию score была stable, и при tie на score выбирался какой попадётся первым — часто scale=1.0. Добавлен tie-break: при `|Δscore| ≤ 0.5` побеждает кандидат с **меньшим** scale.

### 3. `scoreAISimulatedCandidate` (`script.js:38309`)
Штраф травеля был слишком слабым: `score -= travel * 0.18`. Поднят до `* 0.3` — overshoot стал ощутимо дороже относительно бонуса +1200 за hit.

### 4. **`resolveAiLaunchTargetDistancePx` (`script.js:16718-16752`) — главная причина**
Финальный launch session-builder архитектурно затирал любой запрошенный планировщиком powerRatio обратно на `MAX_DRAG_DISTANCE`, если `targetAim.intentionalPowerReduction !== true`. А этот флаг устанавливается **только** в `buildHumanizedAiTargetAim` и срабатывает лишь когда humanizer-шум случайно понизил power. Сам AI-планировщик его не выставляет никак.

Поэтому что бы планировщик ни решил — `releaseAiLaunchSession` вычислял launch-vector через `computeLaunchVectorFromPull(pullPoint)`, где pullPoint строился из `session.targetDistancePx = MAX_DRAG_DISTANCE`. ИИ стабильно летел ровно 30 клеток.

Правка: уважать `requestedPowerRatio` если он < 1, без требования флага humanizer'а. Если planner просит max — max, если короче — короче. В логах появляется `rangeMode: "respect_planner_request"`.

## Что НЕ тронуто (защита от старого топтания)

- `applyAiMinLaunchScale` со scale-floors (`AI_ATTACK_SCALE_GUARD_FLOOR = 0.32`, `AI_ATTACK_CLOSE_RANGE_SAFE_MIN_SCALE = 0.34` и пр.) — нижние пороги остаются.
- `tryGetAiTacticalMediumScale` + `consecutiveLongLaunches` — рандомизация в medium при стрике длинных.
- `getAiCandidateClassComparableScore` со штрафом длины (`AI_CLASS_SCORE_LENGTH_WEIGHT = 0.38`).
- `forceFuelMoveToMaxRange` — корректное поведение при использовании топливного айтема.
- Aggressive-кандидат в `planPathToPoint` (генерация остаётся) — может выиграть по `routeQualityScore` в overshoot-сценариях, но без искусственного preferMaximumLaunch-приоритета.

## Откат

Каждая правка откатывается одной строкой/значением. Самая важная — #4: `requestedDistancePx < maxDistancePx - 0.5` → `targetAim?.intentionalPowerReduction === true && requestedDistancePx < maxDistancePx && reductionReason`.

## Test plan

- [ ] Открыть `index.html` в режиме Computer, сценарий с целью на 10–15 клеток — ИИ летит ~до цели, не на 30.
- [ ] Сценарий: цель на 25+ клеток или нет цели рядом — ИИ всё ещё летит близко к 30 (естественный max).
- [ ] Defense-сценарий (враг идёт на базу) — поведение не должно измениться (`isDefenseOrRetreatContext` отключает aggressive-кандидата).
- [ ] Серия 8–10 ходов — ИИ не съезжает в постоянное короткое топтание.
- [ ] DevTools telemetry: `window.__AI_DECISION_LOG_BUFFER.filter(e => e.event === "ai_launch_release").slice(-5).map(e => ({rangeMode: e.rangeMode, adjusted: e.adjustedPowerRatio}))` — должны появиться `rangeMode: "respect_planner_request"` с `adjusted < 1` для коротких ходов.
- [ ] `node ./scripts/smoke-ai-prelaunch-real-inventory-execution.js` — passes
- [ ] `node ./scripts/smoke-ai-prelaunch-selected-sequence-execution.js` — passes

## Коммиты

- `687dd64` — preferMaximumLaunch tie-break → числовой bias
- `0eaeef0` — overshoot penalty 0.18→0.3, min-scale tie-break, distanceQuality peak 0.9→0.6
- `09e3499` — `resolveAiLaunchTargetDistancePx`: уважать short-shot запрос планировщика **(главная правка)**

https://claude.ai/code/session_01NaGeC4kYxNq8SjvAAMdjp8

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaGeC4kYxNq8SjvAAMdjp8)_