### PR TITLE
Fix mine gate threat evaluation logic for lethal crossing detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -26327,8 +26327,7 @@ function resolveFinalAiLaunchMoveWithMineGate(plannedMove, context = {}, options
   const progressToGoalMeta = getProgressToStrategicTargetMeta();
   const clearlyLethalCrossing = Boolean(
     gateResult?.threatClass === "critical_forbidden"
-    && (gateResult?.threatMeta?.enemy?.landingThreat || gateResult?.threatMeta?.landingThreat)
-    && gateResult?.threatMeta?.pathHit
+    && (gateResult?.threatMeta?.pathHit || gateResult?.threatMeta?.landingThreat)
   );
   const canSoftPassModerateRisk = !clearlyLethalCrossing
     && gateResult?.ownMineThreat !== true


### PR DESCRIPTION
## Summary
Corrected the threat evaluation logic in the mine gate crossing function to properly identify clearly lethal crossing scenarios.

## Key Changes
- Simplified the threat condition check by removing redundant `enemy?.landingThreat` property access
- Reordered the threat evaluation to check `pathHit` first, followed by `landingThreat`
- Changed the logical operator from `&&` to `||` between `pathHit` and `landingThreat` to correctly identify when either threat condition indicates a lethal crossing

## Implementation Details
The fix addresses a logic error in `resolveFinalAiLaunchMoveWithMineGate()` where the threat assessment was overly restrictive. The previous condition required both `enemy.landingThreat` OR `landingThreat` AND `pathHit` to be true simultaneously. The corrected logic now properly evaluates whether a crossing is clearly lethal when the threat class is critical and either a path hit OR landing threat is detected, which better reflects the intended threat assessment behavior.

https://claude.ai/code/session_01NjSZJEMn1SxYTBgfa5j35p