### PR TITLE
fix: AI mine detection + debug mine give command

### DIFF
--- a/script.js
+++ b/script.js
@@ -5550,6 +5550,12 @@ if (DEBUG_CHEATS && typeof window !== "undefined") {
   window.DEBUG_GIVE_OPPONENT_FUEL = (qty = 1) => giveOpponentFuelFromConsole(qty, "debug_give_opponent_fuel");
   window.DEBUG_GIVE_OPPONENT_ITEM = (itemType, qty = 1) => giveOpponentItemFromConsole(itemType, qty, "debug_give_opponent_item");
   window.DEBUG_CLEAR_INVENTORY = () => resetInventoryState();
+  window.DEBUG_GIVE_CURRENT_MINES = (qty = 10) => {
+    const color = turnColors[turnIndex];
+    if(!color){ console.warn("DEBUG_GIVE_CURRENT_MINES: no active turn color"); return; }
+    for(let i = 0; i < qty; i++) addItemToInventory(color, INVENTORY_ITEM_TYPES.MINE);
+    console.log(`DEBUG_GIVE_CURRENT_MINES: gave ${qty} mines to ${color}`);
+  };
 }
 
 const MAIN_MENU_ASSETS = [


### PR DESCRIPTION
## Summary

- **Bug fix:** AI больше не летит в мины без причины — исправлен `clearlyLethalCrossing` в `resolveFinalAiLaunchMoveWithMineGate`
- **Debug:** добавлена консольная команда `DEBUG_GIVE_CURRENT_MINES(qty)` для выдачи мин текущему игроку

## Детали бага

В `clearlyLethalCrossing` было два бага:
1. Проверялось `threatMeta?.enemy?.landingThreat` — но такого вложенного свойства не существует (всегда `undefined`)
2. Требовалось одновременно `pathHit AND landingThreat` — но `pathHit=true` уже достаточно для смерти

Из-за этого AI разрешал "soft pass" через мину, когда путь лишь слегка касался зоны триггера (`pathHit=true`, `landingThreat=false`). Риск-скор в таком случае мог быть 0.55–0.69 < 0.7, и самолёт летел в мину.

**Фикс:** `clearlyLethalCrossing` теперь срабатывает при `pathHit OR landingThreat`.

## Debug команда

```js
DEBUG_GIVE_CURRENT_MINES()    // 10 мин тому, кто ходит
DEBUG_GIVE_CURRENT_MINES(5)   // произвольное количество
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjSZJEMn1SxYTBgfa5j35p)_