### PR TITLE
AI: убрать синтетический scale=1 кандидат и не лететь через мины

### DIFF
--- a/script.js
+++ b/script.js
@@ -14820,10 +14820,27 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       if(!Number.isFinite(desiredDistancePx) || desiredDistancePx <= 0.0001){
         return null;
       }
-      const scaledDistancePx = Math.min(maxFlightDistancePx, desiredDistancePx);
-      const scale = scaledDistancePx / desiredDistancePx;
-      const landingX = plane.x + (targetPoint.x - plane.x) * scale;
-      const landingY = plane.y + (targetPoint.y - plane.y) * scale;
+      let scaledDistancePx = Math.min(maxFlightDistancePx, desiredDistancePx);
+      let scale = scaledDistancePx / desiredDistancePx;
+      let landingX = plane.x + (targetPoint.x - plane.x) * scale;
+      let landingY = plane.y + (targetPoint.y - plane.y) * scale;
+      // Mine-aware clamp: isPathClear не учитывает мины. Если на пути мина —
+      // обрезать landing до безопасной точки перед миной.
+      if(typeof getMineThreatMetaForSegment === "function"){
+        const mineThreat = getMineThreatMetaForSegment(plane.x, plane.y, landingX, landingY, plane);
+        if(mineThreat?.pathHit && mineThreat.triggeringMine){
+          const m = mineThreat.triggeringMine;
+          const mineDistFromPlane = Math.hypot(m.x - plane.x, m.y - plane.y);
+          const triggerRadius = Number.isFinite(mineThreat.triggerRadius) ? mineThreat.triggerRadius : 0;
+          const safeDist = Math.max(0, mineDistFromPlane - triggerRadius - CELL_SIZE * 0.3);
+          if(safeDist > 0.0001 && safeDist < scaledDistancePx){
+            scaledDistancePx = safeDist;
+            scale = scaledDistancePx / desiredDistancePx;
+            landingX = plane.x + (targetPoint.x - plane.x) * scale;
+            landingY = plane.y + (targetPoint.y - plane.y) * scale;
+          }
+        }
+      }
       const pathClear = isPathClear(plane.x, plane.y, landingX, landingY);
       if(pathClear !== true){
         return null;
@@ -35894,33 +35911,12 @@ function planPathToPoint(plane, tx, ty, options = {}){
       }
     }
 
-    const shouldPreferMaximumLaunch = !isDefenseOrRetreatContext(reasonText)
-      && !isIntentionalShortControlContext(reasonText, baseScale)
-      && (isAttackContext(reasonText)
-        || isCombatGoal(options?.goalName || "")
-        || shouldPrioritizeDirectFinisher);
-
-    if(shouldPreferMaximumLaunch && baseScale < 0.999){
-      const aggressiveMove = buildMoveWithSafeDeviation(baseAngle, flightDistancePx, 1, {
-        moveType: "direct",
-        candidateClass: "direct",
-        decisionReason: `${options?.decisionReason || "direct"}__prefer_maximum_launch`,
-        goalName: options?.goalName || null,
-      });
-      if(aggressiveMove){
-        aggressiveMove.preferMaximumLaunch = true;
-        registerCandidate(aggressiveMove);
-        logAiDecision("ai_prefer_maximum_launch_candidate", {
-          planeId: plane?.id ?? null,
-          targetX: tx,
-          targetY: ty,
-          baseScale: Number(baseScale.toFixed(3)),
-          aggressiveScale: 1,
-          goalName: options?.goalName || null,
-          decisionReason: options?.decisionReason || null,
-        });
-      }
-    }
+    // Аггрессивный «scale=1» кандидат удалён: artifact в evaluateRouteMetrics
+    // (progressNorm = progress / distance, где distance = flightDistancePx)
+    // давал ему синтетический progressNorm = 1.0, и он почти всегда побеждал
+    // natural directMove по routeQualityScore. Теперь directMove с baseScale
+    // конкурирует честно. Если AI реально хочет полный max — baseScale сам
+    // даст это (когда target дальше maxFlight).
 
     const directMove = buildMoveWithSafeDeviation(baseAngle, dist, scale, {
       moveType: "direct",


### PR DESCRIPTION
Продолжение работы над снятием force-max в AI. Этот PR — отдельный от #2733, содержит только новые правки.

## Две причины почему AI всё ещё летел на максимум

### 1. Артефакт `progressNorm` в `evaluateRouteMetrics` (script.js:34388)
```javascript
const progressNorm = Math.max(0, Math.min(1, progress / Math.max(1, distance)));
```
`distance` — параметр функции. Для **aggressiveMove** в `planPathToPoint` передавался `flightDistancePx` (full max), для **directMove** — реальное `dist` до цели:
- aggressiveMove: progress = full max → `progressNorm = 1.0`
- directMove: progress = baseScale × dist → `progressNorm` часто 0.1–0.5

`progressNorm * 0.5` это 50% веса `qualityScore`. **AggressiveMove побеждал не на tie-break, а по сути score.** Предыдущий fix (#2733) убирал tie-break preferMaximumLaunch, но это не решало проблему — побеждал через progress component.

**Правка:** удалил блок генерации aggressiveMove полностью (script.js:35892-35918). Теперь конкурирует только честный `directMove` с `baseScale = min(dist/maxFlight, 1)`. Если planner реально хочет полный max — `baseScale` сам это даст (когда target дальше maxFlight).

### 2. `buildMoveTowardTarget` не учитывает мины (script.js:14811-14834)
- `isPathClear` проверяет ТОЛЬКО стены/colliders.
- `isCandidateLandingSafe` проверяет ТОЛЬКО точку landing (передаёт одинаковые start/end в `getMineThreatMetaForSegment`).

Поэтому AI планировал maximum-distance landing, не видя мину на пути, и врезался в неё в конце маршрута.

**Правка:** добавил mine-aware clamp в `buildMoveTowardTarget`. Использует существующую `getMineThreatMetaForSegment` (script.js:19716), которая возвращает `triggeringMine` + `triggerRadius`. Если `pathHit` — обрезаю landing до `mineDist - triggerRadius - 0.3*CELL_SIZE` (буфер).

## Что НЕ тронуто

- `applyAiMinLaunchScale` со scale-floors — защита от старого «топтания на базе».
- `tryGetAiTacticalMediumScale` + `consecutiveLongLaunches` — рандомизация.
- `getAiLongShotPenaltyMultiplier`, scoring штрафы длины — работают на цель.
- `forceFuelMoveToMaxRange` — корректное поведение для топлива.
- Mine-clamp пока **только в `buildMoveTowardTarget`**. Если `buildSimulatedEnemyCandidate` (атака врага) тоже летит через мины — добавлю mine-clamp туда отдельно.

## Откат

Каждая правка локальна и обратима — восстановить удалённый блок aggressiveMove, либо убрать mine-clamp.

## Test plan

- [ ] Открыть `index.html` в режиме Computer.
- [ ] Сценарий: AI с целью на 10–15 клеток (близко). AI летит до цели, не на 30.
- [ ] Сценарий: AI летит к далёкой цели/центру с миной на пути. AI останавливается ПЕРЕД миной.
- [ ] Сценарий: AI летит к далёкой цели без мин. AI всё ещё летит близко к 30 (естественный max).
- [ ] Defense-сценарий — поведение не должно ухудшиться.
- [ ] Серия 8–10 ходов — ИИ не съезжает в постоянное короткое топтание.
- [ ] DevTools telemetry: `window.__AI_DECISION_LOG_BUFFER.filter(e => e.event === "ai_prefer_maximum_launch_candidate")` — должен быть **пустой** массив (события больше не генерируются).
- [ ] `node ./scripts/smoke-ai-prelaunch-real-inventory-execution.js` — passes
- [ ] `node ./scripts/smoke-ai-prelaunch-selected-sequence-execution.js` — passes

https://claude.ai/code/session_01NaGeC4kYxNq8SjvAAMdjp8

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaGeC4kYxNq8SjvAAMdjp8)_