### PR TITLE
Удалить scale=1 aggressiveMove и добавить mine-clamp в buildMoveTowar…

### DIFF
--- a/script.js
+++ b/script.js
@@ -14814,10 +14814,27 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       if(!Number.isFinite(desiredDistancePx) || desiredDistancePx <= 0.0001){
         return null;
       }
-      const scaledDistancePx = Math.min(maxFlightDistancePx, desiredDistancePx);
-      const scale = scaledDistancePx / desiredDistancePx;
-      const landingX = plane.x + (targetPoint.x - plane.x) * scale;
-      const landingY = plane.y + (targetPoint.y - plane.y) * scale;
+      let scaledDistancePx = Math.min(maxFlightDistancePx, desiredDistancePx);
+      let scale = scaledDistancePx / desiredDistancePx;
+      let landingX = plane.x + (targetPoint.x - plane.x) * scale;
+      let landingY = plane.y + (targetPoint.y - plane.y) * scale;
+      // Mine-aware clamp: isPathClear не учитывает мины. Если на пути мина —
+      // обрезать landing до безопасной точки перед миной.
+      if(typeof getMineThreatMetaForSegment === "function"){
+        const mineThreat = getMineThreatMetaForSegment(plane.x, plane.y, landingX, landingY, plane);
+        if(mineThreat?.pathHit && mineThreat.triggeringMine){
+          const m = mineThreat.triggeringMine;
+          const mineDistFromPlane = Math.hypot(m.x - plane.x, m.y - plane.y);
+          const triggerRadius = Number.isFinite(mineThreat.triggerRadius) ? mineThreat.triggerRadius : 0;
+          const safeDist = Math.max(0, mineDistFromPlane - triggerRadius - CELL_SIZE * 0.3);
+          if(safeDist > 0.0001 && safeDist < scaledDistancePx){
+            scaledDistancePx = safeDist;
+            scale = scaledDistancePx / desiredDistancePx;
+            landingX = plane.x + (targetPoint.x - plane.x) * scale;
+            landingY = plane.y + (targetPoint.y - plane.y) * scale;
+          }
+        }
+      }
       const pathClear = isPathClear(plane.x, plane.y, landingX, landingY);
       if(pathClear !== true){
         return null;
@@ -35889,33 +35906,12 @@ function planPathToPoint(plane, tx, ty, options = {}){
       }
     }
 
-    const shouldPreferMaximumLaunch = !isDefenseOrRetreatContext(reasonText)
-      && !isIntentionalShortControlContext(reasonText, baseScale)
-      && (isAttackContext(reasonText)
-        || isCombatGoal(options?.goalName || "")
-        || shouldPrioritizeDirectFinisher);
-
-    if(shouldPreferMaximumLaunch && baseScale < 0.999){
-      const aggressiveMove = buildMoveWithSafeDeviation(baseAngle, flightDistancePx, 1, {
-        moveType: "direct",
-        candidateClass: "direct",
-        decisionReason: `${options?.decisionReason || "direct"}__prefer_maximum_launch`,
-        goalName: options?.goalName || null,
-      });
-      if(aggressiveMove){
-        aggressiveMove.preferMaximumLaunch = true;
-        registerCandidate(aggressiveMove);
-        logAiDecision("ai_prefer_maximum_launch_candidate", {
-          planeId: plane?.id ?? null,
-          targetX: tx,
-          targetY: ty,
-          baseScale: Number(baseScale.toFixed(3)),
-          aggressiveScale: 1,
-          goalName: options?.goalName || null,
-          decisionReason: options?.decisionReason || null,
-        });
-      }
-    }
+    // Аггрессивный «scale=1» кандидат удалён: artifact в evaluateRouteMetrics
+    // (progressNorm = progress / distance, где distance = flightDistancePx)
+    // давал ему синтетический progressNorm = 1.0, и он почти всегда побеждал
+    // natural directMove по routeQualityScore. Теперь directMove с baseScale
+    // конкурирует честно. Если AI реально хочет полный max — baseScale сам
+    // даст это (когда target дальше maxFlight).
 
     const directMove = buildMoveWithSafeDeviation(baseAngle, dist, scale, {
       moveType: "direct",


### PR DESCRIPTION
…dTarget

Две причины почему AI всё ещё летел на максимум после прошлых правок:

1. evaluateRouteMetrics артефакт (script.js:34388): progressNorm = progress / distance, где distance — параметр функции и для aggressiveMove = flightDistancePx (полный max), а для directMove = реальное расстояние до цели. Результат: aggressiveMove получает синтетический progressNorm = 1.0 (50% веса в qualityScore), а directMove с честным baseScale<1 — меньше. AggressiveMove стабильно побеждал по routeQualityScore, не на tie-break, а по сути score. Удалил блок генерации aggressiveMove в planPathToPoint полностью. Теперь directMove с baseScale конкурирует честно. Если AI реально хочет полный max — baseScale сам это даст (когда target дальше maxFlight).

2. Mine-awareness отсутствовал (script.js:14811-14834): isPathClear проверяет только стены/colliders, мины игнорирует. isCandidateLandingSafe проверяет ТОЛЬКО точку landing, не путь. Поэтому AI летел через мины и врезался в них в конце маршрута. Добавил mine-clamp в buildMoveTowardTarget: если на пути мина, обрезать landing до safe distance перед миной (mineDist - triggerRadius - 0.3*CELL_SIZE buffer). Использует существующую функцию getMineThreatMetaForSegment, которая уже возвращает triggeringMine и triggerRadius.

Не тронуто: floor-механизмы (applyAiMinLaunchScale), штрафы длины в scoring (consecutiveLongLaunches, getAiLongShotPenaltyMultiplier), forceFuelMoveToMaxRange (корректное поведение для топлива).