### PR TITLE
AI: buildPullPointForAiVector — уважать магнитуду vx/vy, не хардкодить MAX

### DIFF
--- a/script.js
+++ b/script.js
@@ -17273,10 +17273,25 @@ function buildPullPointForAiVector(plane, vx, vy){
     return { x: plane.x, y: plane.y };
   }
 
+  // Pull-distance должен быть пропорционален желаемой мощности — это обратная
+  // операция к computeLaunchVectorFromPull, где scale = dragDistance / MAX_DRAG_DISTANCE.
+  // Раньше здесь был хардкод MAX_DRAG_DISTANCE, из-за чего любые vx/vy от планировщика
+  // (даже короткие) преобразовывались в pull на полную дальность → powerRatio = 1.0
+  // → AI всегда летел на максимум, игнорируя выбор планировщика.
+  const effectiveRangePx = typeof getPlaneEffectiveRangePx === "function"
+    ? getPlaneEffectiveRangePx(plane)
+    : MAX_DRAG_DISTANCE;
+  const maxSpeed = Number.isFinite(effectiveRangePx) && effectiveRangePx > 0
+    && Number.isFinite(FIELD_FLIGHT_DURATION_SEC) && FIELD_FLIGHT_DURATION_SEC > 0
+    ? effectiveRangePx / FIELD_FLIGHT_DURATION_SEC
+    : speed;
+  const powerRatio = maxSpeed > 0 ? Math.max(0, Math.min(1, speed / maxSpeed)) : 1;
+  const pullDistance = MAX_DRAG_DISTANCE * powerRatio;
+
   const pullAngle = Math.atan2(-vy, -vx);
   return {
-    x: plane.x + Math.cos(pullAngle) * MAX_DRAG_DISTANCE,
-    y: plane.y + Math.sin(pullAngle) * MAX_DRAG_DISTANCE,
+    x: plane.x + Math.cos(pullAngle) * pullDistance,
+    y: plane.y + Math.sin(pullAngle) * pullDistance,
   };
 }
 


### PR DESCRIPTION
## Корневая причина «AI всегда летит на 30 клеток»

Не закрытая предыдущими PR (#2733, #2737). Ищу с самого начала — оказалось всё это время в одной маленькой функции.

`buildPullPointForAiVector` (script.js:17270-17281) принимала `(plane, vx, vy)` от планировщика, но **игнорировала магнитуду** — pull-point ВСЕГДА строился на расстоянии `MAX_DRAG_DISTANCE` от plane. Бралось только направление из `vx, vy`:

```javascript
// Было:
const pullAngle = Math.atan2(-vy, -vx);
return {
  x: plane.x + Math.cos(pullAngle) * MAX_DRAG_DISTANCE,  // ← хардкод
  y: plane.y + Math.sin(pullAngle) * MAX_DRAG_DISTANCE,  // ← хардкод
};
```

Это делало симметричную функцию `computeLaunchVectorFromPull` (которая использует `scale = dragDistance / MAX_DRAG_DISTANCE`) **несимметричной** для AI: какой бы короткий `vx, vy` ни вернул planner, на выходе из `buildPullPointForAiVector` всегда был full-MAX pull-point.

## Цепочка отказа

```
planner (короткий vx,vy)
  → buildPullPointForAiVector (хардкод MAX) ← КОРЕНЬ
  → computeAiAimMetricsFromPullPoint (powerRatio = MAX/MAX = 1.0)
  → buildHumanizedAiTargetAim (basePowerRatio = 1.0, humanizer-шум ±неск.%)
  → resolveAiLaunchTargetDistancePx (фикс из #2733: requested ≈ 1
     → plannerRequestsShorter = false → возврат max)
  → release с vx,vy на полной скорости
```

Это объясняет всё, что наблюдал пользователь:
- AI стабильно летит ~30 клеток (max), иногда 29.X — это humanizer-шум вокруг basePowerRatio = 1.0 от хардкода (а не реальная вариация мощности).
- Все правки в planner-scoring из #2733 и #2737 (preferMaximumLaunch tie-break, штраф длины, min-scale tie-break, distanceQuality peak, удаление aggressiveMove) **ничего не меняли** — финальный pull-point всё равно затирался на full max до их применения.

## Правка

Вычислять `pullDistance = MAX_DRAG_DISTANCE * (speed / maxSpeed)`, где `maxSpeed = effectiveRangePx / FIELD_FLIGHT_DURATION_SEC`. Это делает `buildPullPointForAiVector` точной обратной к `computeLaunchVectorFromPull` для любого scale в [0, 1]. Для full-power `vx, vy` поведение не меняется (speed = maxSpeed → pullDistance = MAX_DRAG_DISTANCE как было).

```javascript
const effectiveRangePx = getPlaneEffectiveRangePx(plane);
const maxSpeed = effectiveRangePx / FIELD_FLIGHT_DURATION_SEC;
const powerRatio = Math.max(0, Math.min(1, speed / maxSpeed));
const pullDistance = MAX_DRAG_DISTANCE * powerRatio;
```

## Что заработает после этой правки

- Если planner вернул short `vx, vy` (например, для атаки близкого врага) — pullPoint будет на пропорциональной дистанции, `powerRatio < 1` пройдёт всю цепочку до release, AI полетит коротко.
- Фикс из #2733 (`resolveAiLaunchTargetDistancePx` уважает запрашиваемый powerRatio<1) теперь действительно работает — он получает реальный powerRatio<1 от планировщика.
- Удаление aggressiveMove и mine-clamp из #2737 теперь видимы — directMove с `baseScale<1` доходит до launch без затирания.

## Откат

Вернуть `pullDistance` к `MAX_DRAG_DISTANCE`.

## Test plan

- [ ] `node ./scripts/smoke-ai-prelaunch-real-inventory-execution.js` — passes
- [ ] `node ./scripts/smoke-ai-prelaunch-selected-sequence-execution.js` — passes
- [ ] Открыть `index.html` в режиме Computer.
- [ ] Сценарий: AI с целью на 10–15 клеток. AI должен лететь до цели, не на 30. **Это главная проверка.**
- [ ] Сценарий: AI летит к далёкой цели (35+ клеток). AI всё ещё летит близко к 30 (естественный max — speed = maxSpeed).
- [ ] Defense-сценарий — поведение не должно ухудшиться.
- [ ] DevTools telemetry: `window.__AI_DECISION_LOG_BUFFER.filter(e => e.event === "ai_launch_release").slice(-5).map(e => ({rangeMode: e.rangeMode, base: e.baseTargetPowerRatio, adjusted: e.adjustedPowerRatio}))` — должны видеть **реальную вариацию** `base/adjusted` (0.3, 0.5, 0.8, и т.д.), а не всегда ≈ 1.0.

## Релейтед PR

- #2733 — preferMaximumLaunch tie-break + scoring штраф + resolveAiLaunchTargetDistancePx
- #2737 — удаление aggressiveMove + mine-clamp в buildMoveTowardTarget

Они становятся реально эффективными только после мерджа этого PR (или сами по себе после него — каждый закрывает свой канал force-max). Можно мерджить независимо в любом порядке.

https://claude.ai/code/session_01NaGeC4kYxNq8SjvAAMdjp8

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaGeC4kYxNq8SjvAAMdjp8)_