### PR TITLE
AI: убрать топчущиеся ходы — 360° escape + минимум 5 клеток

### DIFF
--- a/script.js
+++ b/script.js
@@ -32812,6 +32812,9 @@ function getGuaranteedAnyLegalLaunch(context){
   );
   if (!fallbackAiPlanes.length) return null;
 
+  // Минимум 0.30 согласован с гейтом issueAIMove (CELL_SIZE * 5).
+  // 0.30 × 1200 px/s × 0.5s = 180px = 9 клеток (запас). При меньшей
+  // speedPxPerSec mandatory fallback (mandatoryScale = 0.35) подхватит.
   const strengthScales = [
     1.00,
     0.92,
@@ -32823,7 +32826,6 @@ function getGuaranteedAnyLegalLaunch(context){
     0.44,
     0.36,
     0.30,
-    0.24,
   ];
   const angleStep = Math.PI / 72;
   const halfTurnSteps = Math.floor(Math.PI / angleStep);
@@ -39262,6 +39264,27 @@ function issueAIMove(plane, vx, vy, options = {}){
       ok: false,
       reason: validation.reason || "invalid_move",
       message: validation.message || null,
+    };
+  }
+
+  // Минимум хода: AI не должен коммитить ходы короче 5 клеток (аналог
+  // player'ского `dragDistance < CELL_SIZE` гейта на script.js:17306).
+  // Чокпойнт через который проходят ВСЕ источники AI launch — атаки,
+  // груз, центр, fallback'и. Caller (cascade fallback'ов) попробует
+  // следующий candidate. Mandatory fallback (`mandatoryScale = 0.35` в
+  // getMandatoryTurnMove) гарантирует ход ≥ 5 клеток как последний резерв.
+  const candidateDistPx = Math.hypot(vx, vy) * FIELD_FLIGHT_DURATION_SEC;
+  if(candidateDistPx < CELL_SIZE * 5){
+    logAiDecision("ai_launch_below_min_distance_gate", {
+      planeId: plane?.id ?? null,
+      candidateDistPx: Number(candidateDistPx.toFixed(1)),
+      minDistancePx: CELL_SIZE * 5,
+      routeClass: options?.launchMeta?.routeClass || options?.routeClass || null,
+      isFallbackMove: options?.isFallbackMove === true,
+    });
+    return {
+      ok: false,
+      reason: "ai_launch_below_min_distance_gate",
     };
   }
 


### PR DESCRIPTION
## Summary

Закрывает регрессию из #2737, где AI на плотном минном поле и при близких целях коммитил ходы 1-3 клетки («топтание») вместо нормального launch'а. Три инкремента в одной ветке:

- **`b86d12d`** — `buildMoveTowardTarget`: useful-threshold для mine-clamp + угловой escape ±15..±60° когда mine-clamp дал бы крошечный safeDist.
- **`9c9e19b`** — расширил escape до полного круга (±15..±180°) для случаев «впереди мины, в противоположной стороне пусто». Добавил гейт ≥ 5 клеток в `buildMoveTowardTarget`. Убрал desperate direct fallback.
- **`0467c75`** — финальный общий гейт в `issueAIMove` (script.js:39258) — единственный чокпойнт через который проходят ВСЕ источники AI launch (атаки, груз, центр, fallback'и). Поднял минимум `strengthScales` в `getGuaranteedAnyLegalLaunch` с 0.24 до 0.30 для согласованности.

5 клеток ≈ 17% от стандартного max range 30 клеток. Аналог player'ского `dragDistance < CELL_SIZE` гейта (script.js:17306). Mandatory fallback (`mandatoryScale = 0.35` в `getMandatoryTurnMove`) гарантирует ≥ 5 клеток как последний резерв — AI всегда коммитит ход.

## Test plan

- [x] `node ./scripts/smoke-ai-prelaunch-real-inventory-execution.js` — проходит
- [x] `node ./scripts/smoke-ai-prelaunch-selected-sequence-execution.js` — проходит
- [ ] **Браузер A**: мины кучкой между AI и центром, в противоположной стороне пусто → AI разворачивается в свободную сторону, ход на full max
- [ ] **Браузер B**: враг в 2-3 клетках от AI → AI выбирает другой план (центр/груз), не летит 2 клетки
- [ ] **Браузер C**: AI плотно зажат минами 360° → mandatory fallback (≥ 5 клеток через мину), не топтание
- [ ] **Regression**: одиночная мина впереди, поле чистое → AI останавливается перед миной (clamp с safeDist ≥ 5 клеток) или обходит малым углом
- [ ] **Telemetry**: `window.__AI_DECISION_LOG_BUFFER.filter(e => e.event === "ai_launch_release").map(e => e.totalDist)` — ни одного значения < 100px
- [ ] **Telemetry**: `window.__AI_DECISION_LOG_BUFFER.filter(e => e.event === "ai_launch_below_min_distance_gate")` — показывает какие candidates были отброшены

## Не покрыто (вне scope)

- Реальные рикошеты от стен в `buildMoveTowardTarget` — пока только прямые угловые отклонения. Если AI зажат в угол и единственный выход — отскок, нужно интегрировать `planPathToPoint` или симуляцию (отдельный PR).
- Pre-existing failures в `smoke-ai-forced-non-skip-last-chance.js` и `smoke-mine-segment-hit-large-step.js` — падают и на main без этого PR.

https://claude.ai/code/session_01NaGeC4kYxNq8SjvAAMdjp8

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaGeC4kYxNq8SjvAAMdjp8)_