### PR TITLE
AI: убрать топтание и пропуск хода — 360° escape + минимум 5 клеток (scale-up)

### DIFF
--- a/script.js
+++ b/script.js
@@ -39270,22 +39270,26 @@ function issueAIMove(plane, vx, vy, options = {}){
   // Минимум хода: AI не должен коммитить ходы короче 5 клеток (аналог
   // player'ского `dragDistance < CELL_SIZE` гейта на script.js:17306).
   // Чокпойнт через который проходят ВСЕ источники AI launch — атаки,
-  // груз, центр, fallback'и. Caller (cascade fallback'ов) попробует
-  // следующий candidate. Mandatory fallback (`mandatoryScale = 0.35` в
-  // getMandatoryTurnMove) гарантирует ход ≥ 5 клеток как последний резерв.
+  // груз, центр, fallback'и. Реджектить здесь нельзя:
+  // runForcedNonSkipLastChance (script.js:14942-15007) не делает retry
+  // для ok:false и вызывает advanceTurn() — пропуск хода в игре не
+  // предусмотрен. Поэтому масштабируем vx/vy в том же направлении до
+  // 5 клеток. Это согласовано с mandatoryScale=0.35 fallback'ом
+  // (script.js:32890), который тоже коммитит без isPathClear.
   const candidateDistPx = Math.hypot(vx, vy) * FIELD_FLIGHT_DURATION_SEC;
-  if(candidateDistPx < CELL_SIZE * 5){
-    logAiDecision("ai_launch_below_min_distance_gate", {
+  const minDistPx = CELL_SIZE * 5;
+  if(candidateDistPx > 0.0001 && candidateDistPx < minDistPx){
+    const scaleFactor = minDistPx / candidateDistPx;
+    logAiDecision("ai_launch_min_distance_scaled_up", {
       planeId: plane?.id ?? null,
-      candidateDistPx: Number(candidateDistPx.toFixed(1)),
-      minDistancePx: CELL_SIZE * 5,
+      originalDistPx: Number(candidateDistPx.toFixed(1)),
+      scaledDistPx: Number(minDistPx.toFixed(1)),
+      scaleFactor: Number(scaleFactor.toFixed(3)),
       routeClass: options?.launchMeta?.routeClass || options?.routeClass || null,
       isFallbackMove: options?.isFallbackMove === true,
     });
-    return {
-      ok: false,
-      reason: "ai_launch_below_min_distance_gate",
-    };
+    vx *= scaleFactor;
+    vy *= scaleFactor;
   }
 
   // Set the recovery-suppression cooldown right when a launch attempt enters the gate. Even if


### PR DESCRIPTION
## Summary

Заменяет PR #2742 (закрыт). Тот же набор изменений с финальным фиксом регрессии skip-turn — все 4 коммита в одной ветке.

Закрывает регрессию из #2737, где AI на плотном минном поле и при близких целях коммитил ходы 1-3 клетки («топтание»). Решение в три инкремента + один hotfix:

- **`b86d12d`** — `buildMoveTowardTarget`: useful-threshold для mine-clamp + угловой escape ±15..±60° когда mine-clamp дал бы крошечный safeDist.
- **`9c9e19b`** — расширил escape до полного круга (±15..±180°) для случаев «впереди мины, в противоположной стороне пусто». Добавил гейт ≥ 5 клеток в `buildMoveTowardTarget`. Убрал desperate direct fallback.
- **`0467c75`** — добавил гейт `< 5 клеток → реджект` в общий чокпойнт `issueAIMove` (script.js:39258). Поднял минимум `strengthScales` в `getGuaranteedAnyLegalLaunch` с 0.24 до 0.30.
- **`49e4ba0`** ⚡ **fix регрессии skip-turn** — заменил реджект в `issueAIMove` на **scale-up** vx/vy до 5 клеток в том же направлении. Причина: `runForcedNonSkipLastChance` (script.js:14942-15007) не делает retry на `ok:false` от `tryIssueAiMoveWithInventory`, а сразу вызывает `advanceTurn()` — пропуск хода, чего в игре быть не должно. Scale-up гарантирует что AI всегда делает ход.

5 клеток ≈ 17% от стандартного max range 30. Аналог player'ского `dragDistance < CELL_SIZE` гейта (script.js:17306).

## Test plan

- [x] `node ./scripts/smoke-ai-prelaunch-real-inventory-execution.js` — проходит
- [x] `node ./scripts/smoke-ai-prelaunch-selected-sequence-execution.js` — проходит
- [ ] **AI никогда не пропускает ход**: `window.__AI_DECISION_LOG_BUFFER.filter(e => e.event === "simple_step2_forced_non_skip_last_chance_failed")` за полный матч → `[]`
- [ ] **Ни одного launch'а < 100px (5 клеток)**: `window.__AI_DECISION_LOG_BUFFER.filter(e => e.event === "ai_launch_release").map(e => Number(e.totalDist?.toFixed?.(1)))` — все ≥ 100
- [ ] **Браузер A**: мины кучкой между AI и центром, в противоположной стороне пусто → AI разворачивается в свободную сторону, ход на full max
- [ ] **Браузер B**: враг в 2-3 клетках от AI → AI коммитит scale-up ход 5 клеток в направлении врага (перелёт). Не топтание, не skip
- [ ] **Браузер C**: AI плотно зажат минами 360° → mandatory fallback (≥ 5 клеток через мину). Не skip
- [ ] **Regression**: одиночная мина впереди, поле чистое → AI останавливается перед миной (clamp с safeDist ≥ 5 клеток) или обходит малым углом

## Telemetry

```javascript
// Видимость где scale-up активировался (новое имя события):
window.__AI_DECISION_LOG_BUFFER
  .filter(e => e.event === "ai_launch_min_distance_scaled_up")
  .slice(-20)
```

## Не покрыто (вне scope)

- Реальные рикошеты от стен в `buildMoveTowardTarget` — пока только прямые угловые отклонения.
- Pre-existing failures в `smoke-ai-forced-non-skip-last-chance.js` и `smoke-mine-segment-hit-large-step.js` — падают и на main без этого PR.

https://claude.ai/code/session_01NaGeC4kYxNq8SjvAAMdjp8

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaGeC4kYxNq8SjvAAMdjp8)_