### PR TITLE
ИИ: убрать «двойное прицеливание» при использовании предмета инвентаря

### DIFF
--- a/script.js
+++ b/script.js
@@ -40613,12 +40613,23 @@ function gameDraw(){
 
   updateNukeTimeline(now);
 
+  // The !aiPostInventoryLaunchTimeout gate prevents a visible "double aim" race when AI uses an
+  // inventory item. After applying an item, issueAIMoveWithInventoryUsage schedules the actual
+  // launch via setTimeout(AI_POST_INVENTORY_LAUNCH_DELAY_MS=260ms) so the consume FX can play.
+  // The scheduler returns immediately and clears aiMoveScheduled, but aiLaunchSession isn't
+  // created until the timeout fires. Without this gate, the next frame's recovery would see
+  // !aiLaunchSession && !aiMoveScheduled and start a SECOND full AI turn — which creates its own
+  // aim session before the original setTimeout fires; the original launch then collides with the
+  // existing session, hits the existing-session retry path (handleFinalLaunchResult), nulls the
+  // session, and creates a third one. Visible result: AI aims, then re-aims (sometimes a different
+  // target). Triggered with ANY inventory item, since the 260ms delay always applies.
   if(
     gameMode === "computer"
     && turnColors?.[turnIndex] === "blue"
     && flyingPoints.length === 0
     && !aiLaunchSession
     && !aiMoveScheduled
+    && !aiPostInventoryLaunchTimeout
     && performance.now() >= aiMoveCooldownUntilMs
   ){
     scheduleComputerMoveWithCargoGate(performance.now(), AI_MOVE_CARGO_RETRY_DELAY_MS, {


### PR DESCRIPTION
## Симптом

Нашёл пользователь при тестировании. Без инвентаря ИИ просто прицеливается и бьёт. С **любым** предметом в инвентаре (предмет роли не играет — пробовали разные) ИИ прицеливается, потом снова прицеливается, иногда в другом направлении. Ход ИИ визуально разбивается на куски.

## Корень — race condition между отложенным launch'ем и `gameDraw` recovery

1. ИИ применяет предмет (sync) в `issueAIMoveWithInventoryUsage`.
2. На строках 28275-28330 ставится `setTimeout(AI_POST_INVENTORY_LAUNCH_DELAY_MS=260мс)` для отложенного launch'а — пауза, чтобы FX потребления успел проиграть.
3. Scheduler выходит сразу: `aiMoveScheduled = false` (строка 15480). Но `aiLaunchSession` ещё не создан (он создастся внутри setTimeout через 260мс).
4. **Следующий кадр** `gameDraw` recovery (строки 40616-40627) видит `!aiLaunchSession && !aiMoveScheduled && cooldown OK` → запускает **второй полный AI-ход**. Тот выбирает (возможно, другой) план и создаёт `aiLaunchSession A` → пользователь видит **первый прицел**.
5. Срабатывает оригинальный setTimeout → `issueAIMove` ловит «existing_session» reason на guard'е 40024 → `handleFinalLaunchResult` (27887-27901) обнуляет `aiLaunchSession` и создаёт сессию **B** с исходным target → пользователь видит **второй прицел в другом направлении**.

Без инвентаря этот путь не запускается (нет setTimeout'а → нет 260мс окна → нет гонки). Поэтому симптом завязан на «есть ли что-то в инвентаре», а не на типе предмета — что и наблюдал пользователь.

## Фикс

Один точечный гейт в recovery условии: `&& !aiPostInventoryLaunchTimeout`. Пока висит отложенный launch — `gameDraw` recovery ничего не перепланирует. setTimeout сам создаст `aiLaunchSession` без гонки.

```js
if(
  gameMode === "computer"
  && turnColors?.[turnIndex] === "blue"
  && flyingPoints.length === 0
  && !aiLaunchSession
  && !aiMoveScheduled
  && !aiPostInventoryLaunchTimeout   // ← новое
  && performance.now() >= aiMoveCooldownUntilMs
){ ... }
```

Плюс развёрнутый комментарий в коде, чтобы было понятно, зачем гейт.

## Что НЕ меняется

- Решения ИИ (выбор плана, инвентаря, target'а) — не трогаются.
- Sync-логика `issueAIMoveWithInventoryUsage`, setTimeout-задержка 260мс — не трогаются.
- `handleFinalLaunchResult` retry-путь (27887-27901) остаётся как safety net на случай других коллизий, но с этим фиксом в нормальном flow он не должен срабатывать.

## Test plan
- [ ] Без инвентаря: одно прицеливание + launch (как раньше).
- [ ] С CROSSHAIR: одно прицеливание + launch (раньше — двойное).
- [ ] С FUEL: одно прицеливание + launch (раньше — двойное).
- [ ] С DYNAMITE: одно прицеливание + launch (раньше — двойное).
- [ ] Микс из 2-3 предметов: одно прицеливание + launch.
- [ ] Если ИИ-ход реально завис на ошибке (ничего не запланировано, нет отложенного launch'а) — `gameDraw` recovery всё ещё восстанавливает.
- [ ] Smoke `smoke-ai-prelaunch-real-inventory-execution.js` и `smoke-ai-prelaunch-selected-sequence-execution.js` проходят.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_