### PR TITLE
ИИ: фикс регрессии — ИИ не ходил с пустым инвентарём после PR #2749

### DIFF
--- a/script.js
+++ b/script.js
@@ -28483,25 +28483,38 @@ function issueAIMoveWithInventoryUsage(context, plannedMove){
   handleFinalLaunchResult("immediate_launch", immediateLaunchResult);
   } // end continueAfterInventoryApplied
 
-  // Kick off the inventory-application phase. Deferred mode hands the queue to
-  // aiInventorySequenceState; runAiInventorySequenceTick advances it across frames with
-  // FX-tied per-item delays, and triggers continueAfterInventoryApplied as onSequenceComplete
-  // after the last item. If the queue is empty (no items to apply), maybeUseInventoryBeforeLaunch
-  // calls onSequenceComplete([]) inline before returning false — control flows through
-  // continueAfterInventoryApplied → mine gate → launch setTimeout, just like before, with
-  // empty consumedItemTypes.
+  // One-shot guard: maybeUseInventoryBeforeLaunch has THREE classes of return paths and we
+  // need continueAfterInventoryApplied to fire exactly once regardless of which path is taken:
+  //   (a) Deferred mode with non-empty queue → returns true; state machine calls onSequenceComplete
+  //       from runAiInventorySequenceTick after the last item. Caller must NOT call again.
+  //   (b) Deferred mode with empty queue (initialCandidates.length === 0) → calls
+  //       onSequenceComplete([]) INLINE, then returns false. Caller must NOT call again.
+  //   (c) Early bail-outs that predate the deferred block — `!plannedMove?.plane`,
+  //       `inventory.total <= 0` (empty inventory!), `preAppliedInventoryItemType` → return
+  //       false WITHOUT calling onSequenceComplete. Caller MUST call continueAfterInventoryApplied([])
+  //       or else the AI never launches. The empty-inventory bail caused the regression where
+  //       AI stopped moving when its inventory was empty.
+  let inventoryContinuationCalled = false;
+  const onInventorySequenceComplete = (consumedItemTypes) => {
+    if(inventoryContinuationCalled) return;
+    inventoryContinuationCalled = true;
+    continueAfterInventoryApplied(consumedItemTypes);
+  };
+
   try {
     const sequenceStarted = maybeUseInventoryBeforeLaunch(context, plannedMove, {
       usedBuffTypesThisTurn: usedSingleUseBuffTypesThisTurn,
       allowForcedInventorySpend: false,
       applyImmediately: false,
-      onSequenceComplete: continueAfterInventoryApplied,
+      onSequenceComplete: onInventorySequenceComplete,
     });
-    // sequenceStarted === true: state machine drives application; continueAfterInventoryApplied
-    //   will be called from runAiInventorySequenceTick when the last item lands.
-    // sequenceStarted === false: maybeUseInventoryBeforeLaunch called continueAfterInventoryApplied
-    //   inline (empty queue path) — launch is already scheduled.
-    void sequenceStarted;
+    // If maybeUseInventoryBeforeLaunch returned false WITHOUT calling onSequenceComplete inline
+    // (early bail paths above the deferred block), the guard ensures we still trigger the
+    // launch path with an empty consumed-items list. The guard makes this idempotent: if the
+    // function already called onSequenceComplete inline, this no-ops.
+    if(!sequenceStarted){
+      onInventorySequenceComplete([]);
+    }
   } catch (inventorySelectorError) {
     logAiDecision("inventory_selector_attempt_exception", {
       stage: "inventory_decision",
@@ -28510,9 +28523,8 @@ function issueAIMoveWithInventoryUsage(context, plannedMove){
       message: inventorySelectorError?.message || String(inventorySelectorError),
     });
     inventoryStopReason = "inventory_selector_exception_handled";
-    // Ensure the launch path still runs even if the inventory selector blew up before
-    // any item could be queued.
-    continueAfterInventoryApplied([]);
+    // Idempotent — if the exception was thrown after onSequenceComplete already fired, this no-ops.
+    onInventorySequenceComplete([]);
   }
 }
 


### PR DESCRIPTION
## Регрессия

После PR #2749 (Phase A+B рефакторинг применения инвентаря) ИИ перестал ходить, если у него **пустой инвентарь**. Launch не запускался.

## Корень

`maybeUseInventoryBeforeLaunch` имеет ТРИ класса return-путей, но в PR #2749 я заложил неверное предположение, что есть только два:

- **(a)** deferred-mode с непустой очередью → возвращает `true`, state machine зовёт `onSequenceComplete` после последнего предмета.
- **(b)** deferred-mode с пустой `initialCandidates` → зовёт `onSequenceComplete([])` **inline**, возвращает `false`.
- **(c)** early bail-out'ы ДО deferred-блока: `!plannedMove?.plane`, `inventory.total <= 0` (← это путь пустого инвентаря!), `preAppliedInventoryItemType` → возвращает `false` БЕЗ вызова `onSequenceComplete` вообще.

При пустом инвентаре срабатывал **(c)**, `continueAfterInventoryApplied` не вызывался, launch'а нет.

## Фикс

One-shot guard в `issueAIMoveWithInventoryUsage`:

```js
let inventoryContinuationCalled = false;
const onInventorySequenceComplete = (consumed) => {
  if(inventoryContinuationCalled) return;
  inventoryContinuationCalled = true;
  continueAfterInventoryApplied(consumed);
};

try {
  const sequenceStarted = maybeUseInventoryBeforeLaunch(..., {
    onSequenceComplete: onInventorySequenceComplete,
  });
  if(!sequenceStarted) onInventorySequenceComplete([]);  // ← покрывает (b) и (c)
} catch (...) {
  onInventorySequenceComplete([]);  // ← idempotent
}
```

Guard делает вызов `continueAfterInventoryApplied` идемпотентным — безопасно дёрнуть из любого пути:

- **(a)**: state machine зовёт onSequenceComplete; `sequenceStarted === true`, мы пропускаем явный вызов.
- **(b)**: inline `onSequenceComplete([])`; возвращается `false`; guard пропускает второй вызов.
- **(c)**: `onSequenceComplete` не зван; `sequenceStarted === false`; guard пропускает второй вызов, явный вызов из caller'а отрабатывает; launch запускается.

## Что НЕ меняется

- `maybeUseInventoryBeforeLaunch` сам по себе — не трогаем. Все три класса return-путей продолжают работать как раньше.
- Поведение применения предметов — не меняется. Только закрываем дырку в обработке "no items at all".
- Smoke-тесты `prelaunch-real-inventory-execution.js` и `prelaunch-selected-sequence-execution.js` продолжают проходить (default `applyImmediately: true` путь, не пересекается с этим фиксом).

## Test plan

- [ ] `node --check script.js` — passes (verified locally).
- [ ] Smoke tests pass (verified locally).
- [ ] **В браузере**: ИИ с пустым инвентарём ходит как раньше (главное — регрессия исправлена).
- [ ] **В браузере**: ИИ с предметами — последовательность работает как в PR #2749 (не сломалось).
- [ ] **В браузере**: ИИ с `preAppliedInventoryItemType` на плане (редкий путь scored-plan apply) — launch'ится.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_