### PR TITLE
ИИ: launch-задержка после DYNAMITE — дождаться удаления brick'а

### DIFF
--- a/script.js
+++ b/script.js
@@ -18631,6 +18631,18 @@ const AI_OPENING_SOFT_RANDOM_AIM_ANGLE_TOLERANCE_DEG = 20;
 const AI_OPENING_SOFT_RANDOM_AIM_DISTANCE_TOLERANCE_SCALE = 0.2;
 const AI_POST_INVENTORY_LAUNCH_DELAY_MS = 260;
 const AI_POST_TACTICAL_INVENTORY_LAUNCH_DELAY_MS = 120;
+// When DYNAMITE was applied, the targeted brick stays inside `colliders` until
+// the explosion animation reaches DYNAMITE_BRICK_REMOVAL_FRAME_INDEX and the
+// subsequent DYNAMITE_BRICK_FADE_OUT_DURATION_MS fade completes (see
+// updateAndDrawDynamiteExplosions / removeBrickSpriteForDynamite). Launching the
+// plane before that window means the plane hits the still-alive brick and
+// ricochets off — visually "AI explodes the wall but flies a different route".
+// Use a delay that exceeds the full anim + fade window with a small safety
+// buffer. MINE has no destruction animation, so it keeps the short 120 ms gap.
+const AI_POST_DYNAMITE_LAUNCH_DELAY_MS = Math.max(
+  AI_POST_TACTICAL_INVENTORY_LAUNCH_DELAY_MS,
+  DYNAMITE_EXPLOSION_TOTAL_DURATION_MS + DYNAMITE_BRICK_FADE_OUT_DURATION_MS + 120
+);
 // Per-item delays for the AI inventory sequence state machine. Items are now applied one at
 // a time per gameDraw tick, with a delay tied to each item's visible FX so the player can
 // register each effect before the next one starts. See runAiInventorySequenceTick.
@@ -29059,11 +29071,13 @@ function issueAIMoveWithInventoryUsage(context, plannedMove){
   }
 
   if(effectiveItemUsed === true){
-    const usedTacticalInventoryItem = consumedItemTypes.includes(INVENTORY_ITEM_TYPES.MINE)
-      || consumedItemTypes.includes(INVENTORY_ITEM_TYPES.DYNAMITE);
-    const postInventoryLaunchDelayMs = usedTacticalInventoryItem
-      ? AI_POST_TACTICAL_INVENTORY_LAUNCH_DELAY_MS
-      : AI_POST_INVENTORY_LAUNCH_DELAY_MS;
+    const usedDynamite = consumedItemTypes.includes(INVENTORY_ITEM_TYPES.DYNAMITE);
+    const usedTacticalInventoryItem = consumedItemTypes.includes(INVENTORY_ITEM_TYPES.MINE) || usedDynamite;
+    const postInventoryLaunchDelayMs = usedDynamite
+      ? AI_POST_DYNAMITE_LAUNCH_DELAY_MS
+      : (usedTacticalInventoryItem
+        ? AI_POST_TACTICAL_INVENTORY_LAUNCH_DELAY_MS
+        : AI_POST_INVENTORY_LAUNCH_DELAY_MS);
     if(aiPostInventoryLaunchTimeout){
       clearTimeout(aiPostInventoryLaunchTimeout);
       aiPostInventoryLaunchTimeout = null;


### PR DESCRIPTION
## Summary

Жалоба после PR #2752/#2753: «отличные цели за стеной — ИИ взрывает стену — ещё до окончания анимации взрыва улетает по другому маршруту».

**Корневая причина** — НЕ в replan-логике (та корректна), а в физике/тайминге:

- `placeBlueDynamiteAt` пушит entry в `dynamiteState`, но **brick остаётся в `colliders`** пока `updateAndDrawDynamiteExplosions` не достигнет `DYNAMITE_BRICK_REMOVAL_FRAME_INDEX` и `DYNAMITE_BRICK_FADE_OUT_DURATION_MS` (280мс) не пройдёт. Полный цикл ≈ `DYNAMITE_EXPLOSION_TOTAL_DURATION_MS + 280мс ≈ 1180мс` (при 12 frames).
- Задержка перед launch'ом самолёта когда применён tactical item: `AI_POST_TACTICAL_INVENTORY_LAUNCH_DELAY_MS = 120мс`.
- 120 ≪ 1180 → самолёт стартует когда brick ещё в `colliders` → физика отскакивает → визуально «летит по другому маршруту».

Replan'ы из #2752/#2753 правильно вычисляют landing сквозь будущий проход — но launch исполняется до фактического удаления brick'а.

## Fix

Новая константа:
```js
const AI_POST_DYNAMITE_LAUNCH_DELAY_MS = Math.max(
  AI_POST_TACTICAL_INVENTORY_LAUNCH_DELAY_MS,
  DYNAMITE_EXPLOSION_TOTAL_DURATION_MS + DYNAMITE_BRICK_FADE_OUT_DURATION_MS + 120
);
```

При N=12 frames это ≈ **1300мс** — гарантированно покрывает полную анимацию с запасом ~120мс. Применяется **только** когда `consumedItemTypes.includes(DYNAMITE)`. MINE остаётся на `AI_POST_TACTICAL_INVENTORY_LAUNCH_DELAY_MS = 120мс` (у мин нет анимации разрушения).

Не меняется физика. Не меняется анимация. Не меняется behavior игрока. Только AI ждёт пока colliders обновятся естественным путём в render-loop'е — что соответствует пользовательской подсказке: «у него есть задержка между прицеливанием и выстрелом — её как раз хватит, чтобы анимация взрыва проигралась».

## Test plan

- [x] `node --check script.js` проходит.
- [x] `scripts/smoke-ai-prelaunch-real-inventory-execution.js` проходит.
- [x] `scripts/smoke-ai-prelaunch-selected-sequence-execution.js` проходит.
- [x] Sanity: при N=12 frames финальный delay = 1300мс (покрывает 1180мс с запасом).
- [ ] **Browser**: ИИ ставит динамит, **дожидается** конца анимации взрыва, потом пролетает сквозь освобождённый коридор. Раньше «летел сразу мимо», теперь — после паузы пролетает там, где была стена. По логам — `post_inventory_delay_applied` с `delayMs ≈ 1300` для случая DYNAMITE.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_