### PR TITLE
ИИ: ослабить DYNAMITE-replan — разрешить strategic_setup, не блокировать

### DIFF
--- a/script.js
+++ b/script.js
@@ -15445,14 +15445,40 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
           });
         };
 
+        // Soft skip: keep the DYNAMITE entry in the sequence (so the charge
+        // can still be spent as strategic_setup — opening a corridor for a
+        // future turn), but don't update landing. The inline guard in
+        // executeCommittedInventoryAction will run a final sync replan
+        // attempt and align the plan when possible.
+        const softSkipDynamite = (eventName, extra) => {
+          logAiDecision(eventName, {
+            planeId: selectedPlan.plane?.id ?? null,
+            colliderId: dynEntry.target?.colliderId ?? null,
+            finalDestination: dynEntry.finalDestination || null,
+            source: "scheduler_dynamite_replan",
+            outcome: "kept_for_strategic_setup",
+            ...(extra || {}),
+          });
+        };
+
         if(!dynResult){
-          rejectDynamite("dynamite_replan_failed_unreachable", null);
+          // Pathfinder couldn't find any route at all with this collider
+          // removed — even strategic-setup is questionable. Soft skip:
+          // still let it fire as a future-corridor opener.
+          softSkipDynamite("dynamite_replan_skipped_unreachable", null);
         } else if(dynResult.rejected === "multiple_blockers"){
+          // Multiple obstacles on the path — dynamite alone won't help.
+          // Hard reject: the charge is wasted if we place it now.
           rejectDynamite("dynamite_replan_failed_multiple_blockers", null);
         } else if(dynResult.rejected === "slot_occupied"){
+          // Already a blue dynamite on this sprite — placeBlueDynamiteAt would
+          // refuse anyway.
           rejectDynamite("dynamite_replan_failed_slot_occupied", null);
         } else if(dynResult.rejected === "no_corridor_usage"){
-          rejectDynamite("dynamite_replan_failed_no_corridor_usage", {
+          // Pathfinder found a route, but it bypasses the collider — keep the
+          // entry, let strategic_setup behavior take over (open the corridor
+          // for next turn).
+          softSkipDynamite("dynamite_replan_skipped_no_corridor_usage", {
             corridorDistance: Number.isFinite(dynResult.corridorDistance) ? Number(dynResult.corridorDistance.toFixed(1)) : null,
           });
         } else {
@@ -15507,7 +15533,9 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
             });
             aiCoopResetBudget();
           } else {
-            rejectDynamite("dynamite_replan_failed_no_improvement", {
+            // Replan found a corridor-aligned route but it's not better than
+            // the current plan. Keep DYNAMITE entry — strategic_setup is fine.
+            softSkipDynamite("dynamite_replan_skipped_no_improvement", {
               originalScore: Number.isFinite(selectedPlan.score) ? Number(selectedPlan.score.toFixed(2)) : null,
               replannedScore: Number.isFinite(replannedMove.score) ? Number(replannedMove.score.toFixed(2)) : null,
               originalDistToDest: Number(distOldToDest.toFixed(1)),
@@ -27120,16 +27148,13 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
         const target = candidate?.target || null;
         const targetX = Number.isFinite(target?.x) ? target.x : null;
         const targetY = Number.isFinite(target?.y) ? target.y : null;
-        // Hard corridor-usage guard: do NOT place dynamite unless the current
-        // planned flight actually passes through the targeted collider. If it
-        // doesn't, try a sync inline replan via the existing
-        // replanMoveForDynamiteOpening helper (which uses
-        // withTemporarilyIgnoredDynamiteCollider + planPathWithSpecialRouteProbe
-        // — and verifies usesOpenedCorridor internally). If neither the current
-        // plan nor an inline replan flies through the corridor, refuse to place
-        // dynamite (charge stays in inventory). This is a catch-all for any
-        // path that gets a DYNAMITE candidate into the sequence without going
-        // through the scheduler-side replan (PR #2752–#2754).
+        // Best-effort inline corridor sync: if the current plan does NOT pass
+        // through the targeted collider, try a sync inline replan via
+        // replanMoveForDynamiteOpening (script.js:25016). If it finds a path
+        // that uses the cleared corridor, update plannedMove so plane/dynamite
+        // are aligned. If it does not — we still place the dynamite
+        // (strategic_setup intent: the corridor will be useful next turn).
+        // This is non-blocking: never refuses the dynamite charge.
         if(targetX != null && targetY != null){
           const inlineDur = Number.isFinite(FIELD_FLIGHT_DURATION_SEC) && FIELD_FLIGHT_DURATION_SEC > 0
             ? FIELD_FLIGHT_DURATION_SEC
@@ -27142,101 +27167,107 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
           const currentLandingY = Number.isFinite(plannedMove.landingY)
             ? plannedMove.landingY
             : planePtY + (plannedMove.vy || 0) * inlineDur;
-          const inlineCorridorTolerance = Math.max(
-            CELL_SIZE * 0.8,
-            typeof AI_DYNAMITE_INTENT_LINE_TOLERANCE === "number" ? AI_DYNAMITE_INTENT_LINE_TOLERANCE : 0
-          );
-          const currentCorridorDistance = (typeof distancePointToSegment === "function")
-            ? distancePointToSegment(targetX, targetY, planePtX, planePtY, currentLandingX, currentLandingY)
-            : Number.POSITIVE_INFINITY;
-          const currentPlanUsesCorridor = Number.isFinite(currentCorridorDistance) && currentCorridorDistance <= inlineCorridorTolerance;
 
-          let inlineReplanApplied = false;
-          if(!currentPlanUsesCorridor){
-            // Locate the live targetGeometry by colliderId so we can call
-            // replanMoveForDynamiteOpening. Fall back to spriteId match if
-            // colliderId is missing on the candidate.
-            const lookupColliderId = target?.colliderId ?? null;
-            const lookupSpriteId = target?.spriteId ?? null;
-            let targetGeometry = null;
-            if(Array.isArray(currentMapSprites)){
-              for(let i = 0; i < currentMapSprites.length; i += 1){
-                const geom = getMapSpriteGeometry(currentMapSprites[i], i);
-                if(!geom?.collider) continue;
-                if(lookupColliderId != null && geom.collider.id === lookupColliderId){
-                  targetGeometry = geom;
-                  break;
-                }
-                if(lookupColliderId == null && lookupSpriteId != null && geom.id === lookupSpriteId){
-                  targetGeometry = geom;
-                  break;
-                }
+          // Locate the live targetGeometry by colliderId (fall back to
+          // spriteId) so doesMoveUseDynamiteCorridor + replanMoveForDynamite
+          // Opening can work with the actual collider object.
+          const lookupColliderId = target?.colliderId ?? null;
+          const lookupSpriteId = target?.spriteId ?? null;
+          let targetGeometry = null;
+          if(Array.isArray(currentMapSprites)){
+            for(let i = 0; i < currentMapSprites.length; i += 1){
+              const geom = getMapSpriteGeometry(currentMapSprites[i], i);
+              if(!geom?.collider) continue;
+              if(lookupColliderId != null && geom.collider.id === lookupColliderId){
+                targetGeometry = geom;
+                break;
               }
-            }
-            if(targetGeometry && typeof replanMoveForDynamiteOpening === "function"){
-              const inlineReplan = replanMoveForDynamiteOpening(context, plannedMove, targetGeometry, {
-                compareLabel: ["dynamite_inline_guard", plannedMove.goalName || "", plannedMove.plane?.id || ""],
-              });
-              const inlineMove = inlineReplan?.move || null;
-              const inlineUsesCorridor = inlineReplan?.usesOpenedCorridor === true
-                || (inlineMove && typeof doesMoveUseDynamiteCorridor === "function"
-                  && doesMoveUseDynamiteCorridor({ ...inlineMove, plane: plannedMove.plane }, targetGeometry));
-              if(inlineMove && Number.isFinite(inlineMove.vx) && Number.isFinite(inlineMove.vy) && inlineUsesCorridor){
-                const newLx = planePtX + inlineMove.vx * inlineDur;
-                const newLy = planePtY + inlineMove.vy * inlineDur;
-                plannedMove.vx = inlineMove.vx;
-                plannedMove.vy = inlineMove.vy;
-                plannedMove.landingX = newLx;
-                plannedMove.landingY = newLy;
-                plannedMove.totalDist = Math.hypot(inlineMove.vx, inlineMove.vy) * inlineDur;
-                if(Number.isFinite(inlineMove.score)) plannedMove.score = inlineMove.score;
-                plannedMove.routeClass = inlineMove.routeClass || plannedMove.routeClass;
-                plannedMove.dynamiteReplanned = true;
-                plannedMove.aiDynamiteReplanMeta = {
-                  ...(plannedMove.aiDynamiteReplanMeta || {}),
-                  colliderId: target?.colliderId ?? null,
-                  spriteId: target?.spriteId ?? null,
-                  source: "executeCommittedInventoryAction_inline_guard",
-                  inlineReplanLanding: { x: Number(newLx.toFixed(1)), y: Number(newLy.toFixed(1)) },
-                };
-                inlineReplanApplied = true;
-                logAiDecision("dynamite_inline_replan_applied", {
-                  planeId: plannedMove.plane?.id ?? null,
-                  colliderId: target?.colliderId ?? null,
-                  replannedLanding: { x: Number(newLx.toFixed(1)), y: Number(newLy.toFixed(1)) },
-                  previousLanding: { x: Number(currentLandingX.toFixed(1)), y: Number(currentLandingY.toFixed(1)) },
-                  source: "executeCommittedInventoryAction_inline_guard",
-                });
+              if(lookupColliderId == null && lookupSpriteId != null && geom.id === lookupSpriteId){
+                targetGeometry = geom;
+                break;
               }
             }
           }
 
-          if(currentPlanUsesCorridor || inlineReplanApplied){
-            executed = placeBlueDynamiteAt(targetX, targetY);
-            if(executed){
-              setAiDynamiteIntentFromCandidate(
-                {
-                  colliderId: target?.colliderId ?? null,
-                  spriteId: target?.spriteId ?? null,
-                  x: targetX,
-                  y: targetY,
-                },
-                candidate?.reason || "dynamite_route_opening",
-                plannedMove,
-                candidate?.dynamiteExpectedRoute || null,
-                candidate?.dynamiteUseClass || null,
-              );
-            }
-          } else {
-            logAiDecision("dynamite_inline_guard_blocked", {
-              planeId: plannedMove.plane?.id ?? null,
-              colliderId: target?.colliderId ?? null,
-              spriteId: target?.spriteId ?? null,
-              currentCorridorDistance: Number.isFinite(currentCorridorDistance) ? Number(currentCorridorDistance.toFixed(1)) : null,
-              tolerance: Number(inlineCorridorTolerance.toFixed(1)),
-              currentLanding: { x: Number(currentLandingX.toFixed(1)), y: Number(currentLandingY.toFixed(1)) },
-              reason: "current_plan_does_not_use_corridor_and_inline_replan_failed",
+          // Check current plan via doesMoveUseDynamiteCorridor when geometry
+          // is available (more accurate than a point-to-segment distance
+          // alone — it also catches line/collider intersection).
+          let currentPlanUsesCorridor = false;
+          if(targetGeometry && typeof doesMoveUseDynamiteCorridor === "function"){
+            currentPlanUsesCorridor = doesMoveUseDynamiteCorridor({
+              plane: plannedMove.plane,
+              vx: (currentLandingX - planePtX) / inlineDur,
+              vy: (currentLandingY - planePtY) / inlineDur,
+            }, targetGeometry);
+          } else if(typeof distancePointToSegment === "function"){
+            const fallbackTol = Math.max(
+              CELL_SIZE * 0.8,
+              typeof AI_DYNAMITE_INTENT_LINE_TOLERANCE === "number" ? AI_DYNAMITE_INTENT_LINE_TOLERANCE : 0
+            );
+            const d = distancePointToSegment(targetX, targetY, planePtX, planePtY, currentLandingX, currentLandingY);
+            currentPlanUsesCorridor = Number.isFinite(d) && d <= fallbackTol;
+          }
+
+          if(!currentPlanUsesCorridor && targetGeometry && typeof replanMoveForDynamiteOpening === "function"){
+            const inlineReplan = replanMoveForDynamiteOpening(context, plannedMove, targetGeometry, {
+              compareLabel: ["dynamite_inline_sync", plannedMove.goalName || "", plannedMove.plane?.id || ""],
             });
+            const inlineMove = inlineReplan?.move || null;
+            const inlineUsesCorridor = inlineReplan?.usesOpenedCorridor === true
+              || (inlineMove && typeof doesMoveUseDynamiteCorridor === "function"
+                && doesMoveUseDynamiteCorridor({ ...inlineMove, plane: plannedMove.plane }, targetGeometry));
+            if(inlineMove && Number.isFinite(inlineMove.vx) && Number.isFinite(inlineMove.vy) && inlineUsesCorridor){
+              const newLx = planePtX + inlineMove.vx * inlineDur;
+              const newLy = planePtY + inlineMove.vy * inlineDur;
+              plannedMove.vx = inlineMove.vx;
+              plannedMove.vy = inlineMove.vy;
+              plannedMove.landingX = newLx;
+              plannedMove.landingY = newLy;
+              plannedMove.totalDist = Math.hypot(inlineMove.vx, inlineMove.vy) * inlineDur;
+              if(Number.isFinite(inlineMove.score)) plannedMove.score = inlineMove.score;
+              plannedMove.routeClass = inlineMove.routeClass || plannedMove.routeClass;
+              plannedMove.dynamiteReplanned = true;
+              plannedMove.aiDynamiteReplanMeta = {
+                ...(plannedMove.aiDynamiteReplanMeta || {}),
+                colliderId: target?.colliderId ?? null,
+                spriteId: target?.spriteId ?? null,
+                source: "executeCommittedInventoryAction_inline_sync",
+                inlineReplanLanding: { x: Number(newLx.toFixed(1)), y: Number(newLy.toFixed(1)) },
+              };
+              logAiDecision("dynamite_inline_replan_applied", {
+                planeId: plannedMove.plane?.id ?? null,
+                colliderId: target?.colliderId ?? null,
+                replannedLanding: { x: Number(newLx.toFixed(1)), y: Number(newLy.toFixed(1)) },
+                previousLanding: { x: Number(currentLandingX.toFixed(1)), y: Number(currentLandingY.toFixed(1)) },
+                source: "executeCommittedInventoryAction_inline_sync",
+              });
+            } else {
+              // Replan didn't find a corridor-aligned path. Keep current plan,
+              // place dynamite anyway (strategic_setup intent).
+              logAiDecision("dynamite_inline_replan_skipped_strategic_setup", {
+                planeId: plannedMove.plane?.id ?? null,
+                colliderId: target?.colliderId ?? null,
+                spriteId: target?.spriteId ?? null,
+                currentLanding: { x: Number(currentLandingX.toFixed(1)), y: Number(currentLandingY.toFixed(1)) },
+                reason: inlineMove ? "inline_replan_does_not_use_corridor" : "inline_replan_no_move",
+              });
+            }
+          }
+
+          executed = placeBlueDynamiteAt(targetX, targetY);
+          if(executed){
+            setAiDynamiteIntentFromCandidate(
+              {
+                colliderId: target?.colliderId ?? null,
+                spriteId: target?.spriteId ?? null,
+                x: targetX,
+                y: targetY,
+              },
+              candidate?.reason || "dynamite_route_opening",
+              plannedMove,
+              candidate?.dynamiteExpectedRoute || null,
+              candidate?.dynamiteUseClass || null,
+            );
           }
         }
         if(executed){


### PR DESCRIPTION
## Summary

Жалоба после PR #2755: «теперь он почти не использует динамит».

Я перекрутил гайки. В исходной игре DYNAMITE имел **два** валидных режима:
- **current_route**: динамит на пути этого самолёта, летим сквозь сразу.
- **strategic_setup**: динамит открывает коридор для будущих ходов.

Мой жёсткий guard из #2755 + strict rejections в scheduler-replan из #2752/#2753 блокировали оба режима когда replan не находил **идеальный** сквозной маршрут на текущем ходу. strategic_setup перестал ставиться вообще.

## Fix: best-effort corridor sync

### 1. Inline guard в `executeCommittedInventoryAction` — стал не-блокирующим

- Всегда ставит динамит если place-target валиден.
- Если текущий план НЕ проходит сквозь — пробует sync inline replan через `replanMoveForDynamiteOpening` + проверку через `doesMoveUseDynamiteCorridor` (более точная — учитывает line/collider intersection, не только distance).
- Если replan нашёл корректный коридорный путь → обновляет `plannedMove.vx/vy/landingX/Y/score`. Лог `dynamite_inline_replan_applied`.
- Если не нашёл → ставит динамит с **исходным** планом как strategic_setup. Лог `dynamite_inline_replan_skipped_strategic_setup`.

### 2. Scheduler-replan — soft vs hard skip

Разделил отказы:

**HARD** (`rejectDynamite` — удаляет entry, динамит не ставится):
- `multiple_blockers` — другие препятствия на пути, динамит бесполезен.
- `slot_occupied` — синий динамит уже на этом sprite'е.

**SOFT** (`softSkipDynamite` — оставляет entry, динамит ставится как strategic_setup):
- `unreachable` — pathfinder не нашёл ничего.
- `no_corridor_usage` — путь есть, но обходит коллайдер.
- `no_improvement` — replan не лучше исходного.

События переименованы: `dynamite_replan_skipped_*` (вместо `_failed_`) с `outcome: "kept_for_strategic_setup"`.

## Инвариант

Scheduler-replan и inline guard работают как **best-effort corridor sync**:
- Когда находят путь сквозь — самолёт летит сквозь (current_route).
- Когда не находят — динамит ставится как strategic_setup, не теряется.

Это соответствует пользовательскому ожиданию «активнее пользоваться преимуществами, не беречь предметы».

## Test plan

- [x] `node --check script.js` проходит.
- [x] Оба prelaunch smoke прохода.
- [ ] **Browser**: ИИ часто использует динамит (как раньше). В случаях когда replan возможен — летит сквозь. В остальных случаях — ставит как «на будущее», на этом ходу делает другой ход. По логам: соотношение `dynamite_inline_replan_applied` (current_route) vs `dynamite_inline_replan_skipped_strategic_setup` покажет распределение.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_