### PR TITLE
ИИ: dynamite-augmented alternative plan — до 3 динамитов ради лучших целей

### DIFF
--- a/script.js
+++ b/script.js
@@ -15384,6 +15384,115 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       aiCoopResetBudget();
     }
 
+    // Dynamite-AUGMENTED alternative plan. Asks: "given 1..3 dynamites,
+    // can we reach a BETTER target (more cargo / deeper enemy / flag /
+    // base) by clearing one or more colliders?" — instead of "can we
+    // apply dynamite to the currently chosen target?". If a meaningfully
+    // better alt-plan exists, REWRITES selectedPlan (landing, score,
+    // routeClass) and REPLACES any DYNAMITE entries in the sequence with
+    // one entry per blocker to be destroyed. Inline guard and existing
+    // DYNAMITE replan below then operate on the already-aligned plan.
+    if(typeof findAiDynamiteAugmentedAlternativePlanAsync === "function"){
+      if(!isAiTurnStillApplicable()){ aiMoveScheduled = false; return; }
+      const augmentedDynamiteCharges = Number(evaluateInventoryState(aiColor)?.counts?.[INVENTORY_ITEM_TYPES.DYNAMITE] || 0);
+      if(augmentedDynamiteCharges > 0){
+        let altPlan = null;
+        try {
+          altPlan = await findAiDynamiteAugmentedAlternativePlanAsync(
+            selectedPlan.plane,
+            aiColor,
+            aiExecutionContext,
+            selectedPlan,
+            augmentedDynamiteCharges,
+          );
+        } catch(err){
+          logAiDecision("dynamite_augmented_plan_exception", {
+            planeId: selectedPlan.plane?.id ?? null,
+            message: err?.message || String(err),
+          });
+        }
+        if(!isAiTurnStillApplicable()){ aiMoveScheduled = false; return; }
+        if(altPlan && altPlan.plan && altPlan.target && Array.isArray(altPlan.blockers) && altPlan.blockers.length > 0){
+          const augFlightDur = Number.isFinite(FIELD_FLIGHT_DURATION_SEC) && FIELD_FLIGHT_DURATION_SEC > 0
+            ? FIELD_FLIGHT_DURATION_SEC
+            : 1;
+          const augNewLandingX = selectedPlan.plane.x + altPlan.plan.vx * augFlightDur;
+          const augNewLandingY = selectedPlan.plane.y + altPlan.plan.vy * augFlightDur;
+          const augOldLandingX = selectedPlan.landingX;
+          const augOldLandingY = selectedPlan.landingY;
+          const augOldScore = Number.isFinite(selectedPlan.score) ? selectedPlan.score : 0;
+
+          selectedPlan.landingX = augNewLandingX;
+          selectedPlan.landingY = augNewLandingY;
+          selectedPlan.planDistance = Math.hypot(altPlan.plan.vx, altPlan.plan.vy) * augFlightDur;
+          if(Number.isFinite(altPlan.plan.score)) selectedPlan.score = altPlan.plan.score;
+          selectedPlan.routeClass = altPlan.plan.routeClass || "direct";
+          selectedPlan.routeMetrics = altPlan.plan.routeMetrics || selectedPlan.routeMetrics || null;
+          selectedPlan.ricochetMeta = altPlan.plan.ricochetMeta || null;
+          selectedPlan.specialPromotionMeta = altPlan.plan.specialPromotionMeta || null;
+          selectedPlan.bounceCount = Number.isFinite(altPlan.plan.bounceCount) ? altPlan.plan.bounceCount : 0;
+          selectedPlan.predictedOutcome = altPlan.plan.predictedOutcome || null;
+          // Update plan's logical target so downstream (dynamite-replan,
+          // inline guard, telemetry, FUEL replan) sees the new destination.
+          selectedPlan.targetPoint = { x: altPlan.target.x, y: altPlan.target.y, kind: altPlan.target.kind };
+          if(altPlan.target.kind === "enemy"){
+            selectedPlan.targetEnemy = altPlan.target.ref || selectedPlan.targetEnemy;
+            selectedPlan.targetEnemySnapshot = { x: altPlan.target.x, y: altPlan.target.y };
+          }
+          selectedPlan.dynamiteAugmentedPlan = true;
+          selectedPlan.aiDynamiteAugmentedPlanMeta = {
+            targetKind: altPlan.target.kind,
+            targetPoint: { x: Number(altPlan.target.x.toFixed(1)), y: Number(altPlan.target.y.toFixed(1)) },
+            nDynamites: altPlan.nDynamites,
+            adjustedScore: Number(altPlan.adjustedScore.toFixed(3)),
+            colliderIds: altPlan.blockers.map((b) => b.id ?? null),
+            originalLanding: { x: Number(augOldLandingX.toFixed(1)), y: Number(augOldLandingY.toFixed(1)) },
+            replannedLanding: { x: Number(augNewLandingX.toFixed(1)), y: Number(augNewLandingY.toFixed(1)) },
+            originalScore: Number(augOldScore.toFixed(3)),
+          };
+
+          // Replace any existing DYNAMITE entries in the sequence with one
+          // entry per blocker required by this plan. The inline guard +
+          // executeCommittedInventoryAction will place them in order.
+          if(Array.isArray(selectedPlan.selectedInventorySequence)){
+            selectedPlan.selectedInventorySequence = selectedPlan.selectedInventorySequence.filter((entry) => (
+              entry && entry.itemType !== INVENTORY_ITEM_TYPES.DYNAMITE
+            ));
+            for(let bi = 0; bi < altPlan.blockers.length; bi += 1){
+              const blocker = altPlan.blockers[bi];
+              const bx = Number.isFinite(blocker?.cx)
+                ? blocker.cx
+                : (Number.isFinite(blocker?.centerX) ? blocker.centerX : null);
+              const by = Number.isFinite(blocker?.cy)
+                ? blocker.cy
+                : (Number.isFinite(blocker?.centerY) ? blocker.centerY : null);
+              if(!Number.isFinite(bx) || !Number.isFinite(by)) continue;
+              selectedPlan.selectedInventorySequence.push({
+                itemType: INVENTORY_ITEM_TYPES.DYNAMITE,
+                reason: `dynamite_augmented_${altPlan.target.kind}`,
+                target: {
+                  x: bx,
+                  y: by,
+                  colliderId: blocker?.id ?? null,
+                  spriteId: blocker?.spriteId ?? blocker?.id ?? null,
+                },
+                finalDestination: { x: altPlan.target.x, y: altPlan.target.y, kind: altPlan.target.kind },
+                executionSource: `dynamite_augmented_plan_${bi}`,
+              });
+            }
+          }
+
+          logAiDecision("dynamite_augmented_plan_selected", {
+            planeId: selectedPlan.plane?.id ?? null,
+            source: "scheduler_dynamite_augmented_plan",
+            ...selectedPlan.aiDynamiteAugmentedPlanMeta,
+          });
+          aiCoopResetBudget();
+        }
+      }
+      if(!isAiTurnStillApplicable()){ aiMoveScheduled = false; return; }
+    }
+
     // Scheduler-side DYNAMITE replan. When the inventory sequence contains a
     // DYNAMITE candidate with a finalDestination (the real point behind the
     // collider — enemy / cargo / flag / base), re-plan landing/vx/vy so the
@@ -22439,6 +22548,134 @@ async function buildDynamiteReplannedMoveAsync(plane, plannedMoveLike, context, 
 
     return { move: replanned, target, opportunity };
   });
+}
+
+// Dynamite-augmented alternative plan finder. Iterates ALL viable targets
+// (enemies / cargo / flags / base), and for each target identifies which
+// colliders block the direct line. If 1..maxDynamites colliders block the
+// path and removing them opens a clear direct route, score this hypothetical
+// plan. Returns the BEST such alternative (by adjusted score), or null if
+// the current plan is comparable or better.
+//
+// Key insight: this answers "can we get to a BETTER target if we spend N
+// dynamites?" — instead of the previous question "can we apply dynamite to
+// the currently chosen target?". This lets the AI fundamentally rewrite its
+// plan when dynamite unlocks more valuable destinations (more cargo, deeper
+// enemies, flag pickup, etc.).
+async function findAiDynamiteAugmentedAlternativePlanAsync(plane, color, context, currentPlan, dynamiteCharges){
+  if(!plane || !Number.isFinite(plane.x) || !Number.isFinite(plane.y)) return null;
+  if(!Number.isFinite(dynamiteCharges) || dynamiteCharges <= 0) return null;
+  if(typeof withTemporarilyIgnoredColliderIdsAsync !== "function") return null;
+  if(typeof planPathToPoint !== "function") return null;
+  if(typeof checkLineIntersectionWithCollider !== "function") return null;
+
+  const maxDynamites = Math.min(3, Math.trunc(dynamiteCharges));
+  const baseRangePx = Math.max(1, getEffectiveFlightRangeCells(plane) * CELL_SIZE);
+  const reachLimit = baseRangePx * 1.6;
+  const enemyColor = color === "green" ? "blue" : "green";
+
+  // Build target list with rough "value" weights. Higher = more important.
+  const targets = [];
+  const aliveEnemies = Array.isArray(context?.enemies) ? context.enemies : [];
+  for(const enemy of aliveEnemies){
+    if(!enemy || enemy.isAlive === false) continue;
+    if(!Number.isFinite(enemy.x) || !Number.isFinite(enemy.y)) continue;
+    targets.push({ x: enemy.x, y: enemy.y, kind: "enemy", value: 1.0, ref: enemy });
+  }
+  if(typeof cargoState !== "undefined" && Array.isArray(cargoState)){
+    for(const cargo of cargoState){
+      if(!cargo || cargo.state !== "ready") continue;
+      const center = (typeof getCargoVisualCenter === "function")
+        ? getCargoVisualCenter(cargo)
+        : { x: cargo.x, y: cargo.y };
+      if(!Number.isFinite(center?.x) || !Number.isFinite(center?.y)) continue;
+      targets.push({ x: center.x, y: center.y, kind: "cargo", value: 0.7, ref: cargo });
+    }
+  }
+  const enemyFlags = Array.isArray(context?.availableEnemyFlags)
+    ? context.availableEnemyFlags
+    : (typeof getAvailableFlagsByColor === "function" ? getAvailableFlagsByColor(enemyColor) : []);
+  for(const flag of enemyFlags || []){
+    const anchor = (typeof getFlagAnchor === "function") ? getFlagAnchor(flag) : null;
+    const ax = Number.isFinite(anchor?.x) ? anchor.x : flag?.x;
+    const ay = Number.isFinite(anchor?.y) ? anchor.y : flag?.y;
+    if(!Number.isFinite(ax) || !Number.isFinite(ay)) continue;
+    targets.push({ x: ax, y: ay, kind: "flag", value: 0.85, ref: flag });
+  }
+  const enemyBase = (typeof getBaseAnchor === "function") ? getBaseAnchor(enemyColor) : null;
+  if(enemyBase && Number.isFinite(enemyBase.x) && Number.isFinite(enemyBase.y)){
+    targets.push({ x: enemyBase.x, y: enemyBase.y, kind: "base", value: 0.3, ref: null });
+  }
+  if(targets.length === 0) return null;
+
+  const liveColliders = Array.isArray(colliders) ? colliders : [];
+  if(liveColliders.length === 0) return null;
+
+  let bestAlt = null;
+
+  for(const target of targets){
+    if(typeof aiCoopMaybeYield === "function") await aiCoopMaybeYield();
+    if(typeof isAiTurnStillApplicable === "function" && !isAiTurnStillApplicable()) return null;
+
+    const dist = Math.hypot(target.x - plane.x, target.y - plane.y);
+    if(dist > reachLimit) continue;
+
+    // If the direct path is already clear, dynamite isn't needed for this target.
+    // The main planner would have considered it naturally; skip here.
+    if(typeof isPathClear === "function" && isPathClear(plane.x, plane.y, target.x, target.y)) continue;
+
+    // Identify colliders that the direct line plane → target intersects.
+    const blockers = [];
+    for(const c of liveColliders){
+      if(!c || c.id == null) continue;
+      if(checkLineIntersectionWithCollider(plane.x, plane.y, target.x, target.y, c)){
+        blockers.push(c);
+      }
+    }
+    if(blockers.length === 0 || blockers.length > maxDynamites) continue;
+
+    const blockerIds = blockers.map((b) => b.id);
+
+    // Plan a direct path with these blockers temporarily removed from the world.
+    let planAfter = null;
+    try {
+      planAfter = await withTemporarilyIgnoredColliderIdsAsync(blockerIds, async () => {
+        if(typeof isPathClear === "function" && !isPathClear(plane.x, plane.y, target.x, target.y)){
+          return null; // still blocked by something else (cannot fix with these N)
+        }
+        try {
+          return planPathToPoint(plane, target.x, target.y, {
+            routeClass: "direct",
+            goalName: "dynamite_augmented_plan",
+            decisionReason: `dynamite_augmented_${target.kind}`,
+          });
+        } catch(_innerErr){
+          return null;
+        }
+      });
+    } catch(_outerErr){
+      planAfter = null;
+    }
+    if(!planAfter || !Number.isFinite(planAfter.vx) || !Number.isFinite(planAfter.vy)) continue;
+
+    const baseScore = Number.isFinite(planAfter.score) ? planAfter.score : 0;
+    const dynamiteCost = blockerIds.length * 0.05; // 5% penalty per charge spent
+    const adjustedScore = baseScore * target.value - dynamiteCost;
+
+    if(!bestAlt || adjustedScore > bestAlt.adjustedScore){
+      bestAlt = { target, blockers, plan: planAfter, adjustedScore, nDynamites: blockerIds.length };
+    }
+  }
+
+  if(!bestAlt) return null;
+
+  // Only switch to the alternative if it's meaningfully better than the
+  // current plan. Threshold 10% prevents marginal swaps that aren't worth
+  // the dynamite cost.
+  const currentScore = Number.isFinite(currentPlan?.score) ? currentPlan.score : 0;
+  if(bestAlt.adjustedScore <= currentScore * 1.10) return null;
+
+  return bestAlt;
 }
 
 function findFallbackRicochetPreparationMove(plane, enemy){


### PR DESCRIPTION
## Summary

Пользователь: динамит должен **открывать доступ к лучшим целям** (больше грузов, дальше враги, флаги), а не подгоняться под уже выбранную цель. Плюс разрешить **1–3 динамита одновременно**.

Все мои предыдущие фиксы (#2752–#2757) пытались согласовать landing с уже выбранным `selectedPlan` — а сам план был выбран **без учёта** того, что динамит может расчистить путь. Поэтому если pathfinder изначально решил «лети рикошетом к enemy1» — мы могли только подогнать динамит под этого enemy1, но не **переключиться** на enemy2 (за стеной), который реально лучше.

## Подход

Новая функция `findAiDynamiteAugmentedAlternativePlanAsync` — async-задача в scheduler'е **до** existing DYNAMITE-replan блока.

**Алгоритм:**

1. Собрать viable targets: `enemies` (value 1.0), `cargo` (0.7), `flags` (0.85), `enemy base` (0.3).
2. Для каждого target:
   - Если direct уже свободен — пропустить (основной планировщик сам справится).
   - Найти `colliders` на прямой `plane → target` через `checkLineIntersectionWithCollider`.
   - Если блокеров `1..min(3, dynamiteCharges)` — попробовать `planPathToPoint(direct)` внутри `withTemporarilyIgnoredColliderIdsAsync` с этими N убранными.
   - `adjustedScore = plan.score × target.value - 0.05 × N`.
3. Выбрать target с **максимальным** adjustedScore.
4. Если `adjustedScore > currentScore × 1.10` (10% порог) — alt-plan принят.

**Integration в scheduler:** если alt-plan найден — **переписать** `selectedPlan` (landing/vx/vy/score/routeClass/`targetPoint`/`targetEnemy`) и **заменить** DYNAMITE entries в sequence на N новых — по одной на каждый блокер с уникальным `executionSource` (`dynamite_augmented_plan_0/1/2`). Каждая entry имеет свой `target.colliderId` и общий `finalDestination` (новая plan-цель).

`inline guard` (#2755/#2756) и existing DYNAMITE-replan (#2752/#2753) остаются как safety nets, но теперь обычно no-op'ят — augmented planner уже всё выровнял.

## Это переход

**От:** «подогнать динамит под уже выбранную цель плана».
**К:** «выбрать лучший план, учитывая что динамиты могут открыть новые маршруты».

## Снят лимит на 1 динамит

В sequence теперь добавляется N entries (по одной на каждый коллайдер). `executeCommittedInventoryAction` итерирует sequence и ставит каждую → 1–3 динамита за ход. Между ними `AI_INVENTORY_SEQUENCE_DELAY_DYNAMITE_MS = 900мс` (анимация одного успевает доиграть до следующей). После последнего — `AI_POST_DYNAMITE_LAUNCH_DELAY_MS ≈ 1300мс` до launch'а.

## Стоимость

`~10–25 targets × 1 await planPathToPoint` в `withTemporarilyIgnoredColliderIdsAsync`. `aiCoopMaybeYield` между targets — frame не блокируется.

## Test plan

- [x] `node --check script.js` проходит.
- [x] Оба prelaunch smoke прохода.
- [ ] **Browser**: ситуация с несколькими ценными целями за разными стенами. Ожидаемо: ИИ выбирает **лучшую** цель, ставит 1-3 динамита на пути к ней, летит сквозь расчищенный коридор. Логи: `dynamite_augmented_plan_selected` с `nDynamites`, `targetKind`, `adjustedScore`, `colliderIds[]`.
- [ ] Случай когда альтернатива не лучше — ИИ остаётся с исходным планом (никаких лишних динамитов).
- [ ] Случай когда динамит позволяет добраться до single deep target — ставит 1-2 динамита, летит прямо.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_