### PR TITLE
ИИ: диагностические логи DYNAMITE + порог augmented planner 1.10 → 1.01

### DIFF
--- a/script.js
+++ b/script.js
@@ -22667,13 +22667,32 @@ async function findAiDynamiteAugmentedAlternativePlanAsync(plane, color, context
     }
   }
 
-  if(!bestAlt) return null;
+  if(!bestAlt){
+    logAiDecision("dynamite_augmented_plan_no_alternative", {
+      planeId: plane?.id ?? null,
+      dynamiteCharges,
+      targetsConsidered: targets.length,
+      currentScore: Number.isFinite(currentPlan?.score) ? Number(currentPlan.score.toFixed(3)) : null,
+    });
+    return null;
+  }
 
-  // Only switch to the alternative if it's meaningfully better than the
-  // current plan. Threshold 10% prevents marginal swaps that aren't worth
-  // the dynamite cost.
+  // Lower threshold (was 1.10) — user wants "use dynamite more actively, even
+  // for small improvements". Switch when adjusted score is just slightly better.
   const currentScore = Number.isFinite(currentPlan?.score) ? currentPlan.score : 0;
-  if(bestAlt.adjustedScore <= currentScore * 1.10) return null;
+  const acceptanceThreshold = 1.01;
+  const accepted = bestAlt.adjustedScore > currentScore * acceptanceThreshold;
+  logAiDecision("dynamite_augmented_plan_evaluation", {
+    planeId: plane?.id ?? null,
+    bestTargetKind: bestAlt.target.kind,
+    bestAdjustedScore: Number(bestAlt.adjustedScore.toFixed(3)),
+    currentScore: Number(currentScore.toFixed(3)),
+    threshold: acceptanceThreshold,
+    accepted,
+    nDynamites: bestAlt.nDynamites,
+    colliderIds: bestAlt.blockers.map((b) => b?.id ?? null),
+  });
+  if(!accepted) return null;
 
   return bestAlt;
 }
@@ -27533,6 +27552,45 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
               });
             }
           }
+
+          // Diagnostic snapshot RIGHT before placeBlueDynamiteAt. Captures the
+          // actual plannedMove state in flight: landingX/Y, vx/vy, target of
+          // the dynamite, augmented-plan flags, and corridor-check verdict.
+          // If user reports "dynamite goes one way, plane flies another",
+          // this is the ground truth to diff against.
+          const diagLanding = {
+            x: Number.isFinite(plannedMove.landingX) ? Number(plannedMove.landingX.toFixed(1)) : null,
+            y: Number.isFinite(plannedMove.landingY) ? Number(plannedMove.landingY.toFixed(1)) : null,
+          };
+          const diagVxVy = {
+            vx: Number.isFinite(plannedMove.vx) ? Number(plannedMove.vx.toFixed(4)) : null,
+            vy: Number.isFinite(plannedMove.vy) ? Number(plannedMove.vy.toFixed(4)) : null,
+          };
+          const diagCurrentCorridor = (targetGeometry && typeof doesMoveUseDynamiteCorridor === "function")
+            ? doesMoveUseDynamiteCorridor({
+                plane: plannedMove.plane,
+                vx: plannedMove.vx,
+                vy: plannedMove.vy,
+              }, targetGeometry)
+            : null;
+          logAiDecision("dynamite_about_to_place", {
+            planeId: plannedMove.plane?.id ?? null,
+            colliderId: target?.colliderId ?? null,
+            spriteId: target?.spriteId ?? null,
+            dynamiteTarget: { x: Number(targetX.toFixed(1)), y: Number(targetY.toFixed(1)) },
+            plannedLanding: diagLanding,
+            planeVxVy: diagVxVy,
+            planeStart: {
+              x: Number(plannedMove.plane.x.toFixed(1)),
+              y: Number(plannedMove.plane.y.toFixed(1)),
+            },
+            routeClass: plannedMove.routeClass || null,
+            dynamiteReplanned: plannedMove.dynamiteReplanned === true,
+            dynamiteAugmentedPlan: plannedMove.dynamiteAugmentedPlan === true,
+            corridorCheckRightNow: diagCurrentCorridor,
+            executionSource,
+            candidateReason: candidate?.reason || null,
+          });
 
           executed = placeBlueDynamiteAt(targetX, targetY);
           if(executed){


### PR DESCRIPTION
## Summary

Я делал 7 PR'ов (#2752–#2758) пытаясь починить рассинхрон «динамит в одном направлении, ход в другом». Все вслепую — без логов из браузера я не могу определить какие из моих гипотез верны. Этот PR делает **диагностический шаг** + **аккуратное ослабление**:

## Изменения

### 1. Augmented planner: порог 1.10 → 1.01

`findAiDynamiteAugmentedAlternativePlanAsync` принимал alternative plan только если `adjustedScore > currentScore × 1.10` (10% порог). Это отсеивало слишком много валидных альтернатив. Снижено до `× 1.01` — любое улучшение.

Также добавлены логи:
- `dynamite_augmented_plan_no_alternative` (когда никакой альтернативы не нашлось — показывает `dynamiteCharges`, `targetsConsidered`).
- `dynamite_augmented_plan_evaluation` (когда найдена — показывает `bestAdjustedScore`, `currentScore`, `threshold`, `accepted` флаг, `nDynamites`, `colliderIds[]`).

### 2. Диагностический snapshot прямо перед `placeBlueDynamiteAt`

Новое событие `dynamite_about_to_place` с:
- `planeId`, `dynamiteTarget {x, y}` (куда ставим бомбу).
- `plannedLanding {x, y}`, `planeVxVy {vx, vy}` (куда самолёт собирается лететь).
- `planeStart {x, y}`, `routeClass`.
- `dynamiteReplanned`, `dynamiteAugmentedPlan` (флаги обновился ли план).
- `corridorCheckRightNow` (true/false — реальная проверка `doesMoveUseDynamiteCorridor` в момент установки).

Это ground truth о том что **реально** происходит при установке динамита.

## Что нужно от тебя

После следующего повтора бага:

1. F12 → Console.
2. Filter: `dynamite_about_to_place` или `[AI]`.
3. Скопировать вывод последних ~15–20 событий и прислать сюда.

С этим я смогу точно определить:
- Сработал ли augmented planner (если нет — почему: нет dynamite зарядов? нет alternatives? threshold не пройден?).
- Совпадают ли `dynamiteTarget` и направление `planeVxVy * dur` от `planeStart` (если расходятся — нашли точку рассинхрона).
- Проходит ли `corridorCheckRightNow` (если false — план с самого начала не идёт сквозь, ни scheduler-replan, ни inline guard, ни augmented planner не сработали).

## Test plan

- [x] `node --check script.js` проходит.
- [x] Оба prelaunch smoke прохода.
- [ ] **Browser**: после следующего повтора бага — собрать логи `dynamite_*` и прислать.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_