### PR TITLE
ИИ: видимые DYNAMITE-диагностики в console (logDynamiteDebug helper)

### DIFF
--- a/script.js
+++ b/script.js
@@ -15482,7 +15482,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
             }
           }
 
-          logAiDecision("dynamite_augmented_plan_selected", {
+          logDynamiteDebug("dynamite_augmented_plan_selected", {
             planeId: selectedPlan.plane?.id ?? null,
             source: "scheduler_dynamite_augmented_plan",
             ...selectedPlan.aiDynamiteAugmentedPlanMeta,
@@ -15560,7 +15560,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
         // executeCommittedInventoryAction will run a final sync replan
         // attempt and align the plan when possible.
         const softSkipDynamite = (eventName, extra) => {
-          logAiDecision(eventName, {
+          logDynamiteDebug(eventName, {
             planeId: selectedPlan.plane?.id ?? null,
             colliderId: dynEntry.target?.colliderId ?? null,
             finalDestination: dynEntry.finalDestination || null,
@@ -15635,7 +15635,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
               originalDistToDest: Number(distOldToDest.toFixed(1)),
               replannedDistToDest: Number(distNewToDest.toFixed(1)),
             };
-            logAiDecision("dynamite_launch_replanned", {
+            logDynamiteDebug("dynamite_launch_replanned", {
               planeId: selectedPlan.plane?.id ?? null,
               source: "scheduler_dynamite_replan",
               ...selectedPlan.aiDynamiteReplanMeta,
@@ -19375,6 +19375,21 @@ function logAiDecision(reason, details = {}){
   }
 }
 
+// Force-detailed logger for DYNAMITE diagnostics. logAiDecision uses a
+// compact payload by default (filters fields), so user-facing console
+// only shows reasonCode. This helper emits the RAW details next to it
+// so diagnostic snapshots (dynamite_about_to_place, augmented plan
+// evaluation, etc.) are inspectable without flipping the global debug
+// flag. Browser filter: search "dynamite" in DevTools console.
+function logDynamiteDebug(reason, details = {}){
+  try { logAiDecision(reason, details); } catch(_logErr) {}
+  try {
+    if(typeof console !== "undefined" && typeof console.log === "function"){
+      console.log(`[dynamite-debug] ${reason}`, details);
+    }
+  } catch(_consoleErr) {}
+}
+
 function normalizeAiReasonText(reasonText = ""){
   if(typeof reasonText === "string") return reasonText.toLowerCase();
   if(reasonText && typeof reasonText === "object"){
@@ -22668,7 +22683,7 @@ async function findAiDynamiteAugmentedAlternativePlanAsync(plane, color, context
   }
 
   if(!bestAlt){
-    logAiDecision("dynamite_augmented_plan_no_alternative", {
+    logDynamiteDebug("dynamite_augmented_plan_no_alternative", {
       planeId: plane?.id ?? null,
       dynamiteCharges,
       targetsConsidered: targets.length,
@@ -22682,7 +22697,7 @@ async function findAiDynamiteAugmentedAlternativePlanAsync(plane, color, context
   const currentScore = Number.isFinite(currentPlan?.score) ? currentPlan.score : 0;
   const acceptanceThreshold = 1.01;
   const accepted = bestAlt.adjustedScore > currentScore * acceptanceThreshold;
-  logAiDecision("dynamite_augmented_plan_evaluation", {
+  logDynamiteDebug("dynamite_augmented_plan_evaluation", {
     planeId: plane?.id ?? null,
     bestTargetKind: bestAlt.target.kind,
     bestAdjustedScore: Number(bestAlt.adjustedScore.toFixed(3)),
@@ -27533,7 +27548,7 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
                 source: "executeCommittedInventoryAction_inline_sync",
                 inlineReplanLanding: { x: Number(newLx.toFixed(1)), y: Number(newLy.toFixed(1)) },
               };
-              logAiDecision("dynamite_inline_replan_applied", {
+              logDynamiteDebug("dynamite_inline_replan_applied", {
                 planeId: plannedMove.plane?.id ?? null,
                 colliderId: target?.colliderId ?? null,
                 replannedLanding: { x: Number(newLx.toFixed(1)), y: Number(newLy.toFixed(1)) },
@@ -27543,7 +27558,7 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
             } else {
               // Replan didn't find a corridor-aligned path. Keep current plan,
               // place dynamite anyway (strategic_setup intent).
-              logAiDecision("dynamite_inline_replan_skipped_strategic_setup", {
+              logDynamiteDebug("dynamite_inline_replan_skipped_strategic_setup", {
                 planeId: plannedMove.plane?.id ?? null,
                 colliderId: target?.colliderId ?? null,
                 spriteId: target?.spriteId ?? null,
@@ -27573,7 +27588,7 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
                 vy: plannedMove.vy,
               }, targetGeometry)
             : null;
-          logAiDecision("dynamite_about_to_place", {
+          logDynamiteDebug("dynamite_about_to_place", {
             planeId: plannedMove.plane?.id ?? null,
             colliderId: target?.colliderId ?? null,
             spriteId: target?.spriteId ?? null,


### PR DESCRIPTION
## Summary

Из скриншотов после PR #2761 видно: события `dynamite_about_to_place` и `dynamite_augmented_plan_evaluation` появляются в console **с одним только полем `reasonCode`**. Все остальные детали (target, plannedLanding, vx/vy, scores, флаги) теряются.

**Причина:** `logAiDecision` использует `buildAiDecisionCompactPayload`, который жёстко фильтрует поля. Глобальный `AI_DECISION_DEEP_DEBUG_FLAG = false` (`const`, не переключается через window).

## Fix

Helper `logDynamiteDebug(reason, details)`:
- Вызывает обычный `logAiDecision` (для буфера `window.__AI_DECISION_LOG_BUFFER`).
- **Дополнительно** делает `console.log("[dynamite-debug] <reason>", <raw_details>)` — raw object со всеми полями виден в DevTools.

Перевёл 10 ключевых DYNAMITE-диагностических вызовов на этот helper:
- `dynamite_about_to_place`
- `dynamite_augmented_plan_evaluation`
- `dynamite_augmented_plan_no_alternative`
- `dynamite_augmented_plan_selected`
- `dynamite_launch_replanned`
- `dynamite_inline_replan_applied`
- `dynamite_inline_replan_skipped_strategic_setup`
- `dynamite_replan_skipped_unreachable`
- `dynamite_replan_skipped_no_corridor_usage`
- `dynamite_replan_skipped_no_improvement`

## После мержа

В консоли искать строки `[dynamite-debug]` — там видны полные объекты со всеми полями. Самое важное:

1. `[dynamite-debug] dynamite_augmented_plan_evaluation` — `accepted`, `bestAdjustedScore`, `currentScore`, `threshold`, `colliderIds`.
2. `[dynamite-debug] dynamite_about_to_place` — `dynamiteTarget`, `plannedLanding`, `planeVxVy`, `corridorCheckRightNow`, `dynamiteReplanned`, `dynamiteAugmentedPlan`.
3. Любые `dynamite_inline_replan_*` — что сделал inline guard в финальный момент.

Скриншот этих событий после повтора бага → точный диагноз.

## Test plan

- [x] `node --check script.js` проходит.
- [x] Оба prelaunch smoke прохода.
- [ ] **Browser**: после повтора бага → `[dynamite-debug]` строки в console показывают полные детали → прислать сюда.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_