### PR TITLE
ИИ: hard-reject DYNAMITE если план не идёт сквозь + fix scoring augmented

### DIFF
--- a/script.js
+++ b/script.js
@@ -22673,7 +22673,17 @@ async function findAiDynamiteAugmentedAlternativePlanAsync(plane, color, context
     }
     if(!planAfter || !Number.isFinite(planAfter.vx) || !Number.isFinite(planAfter.vy)) continue;
 
-    const baseScore = Number.isFinite(planAfter.score) ? planAfter.score : 0;
+    // Use getAiPlaneAdjustedScore on totalDist to get a score that's on the
+    // SAME scale as selectedPlan.score (which is also computed via
+    // getAiPlaneAdjustedScore(totalDist, plane)). Browser logs from prior
+    // runs showed planAfter.score on a completely different scale (-0.1 vs
+    // currentScore 1200), so the planner was never accepting alternatives.
+    const totalDist = Number.isFinite(planAfter.totalDist)
+      ? planAfter.totalDist
+      : Math.hypot(planAfter.vx, planAfter.vy) * FIELD_FLIGHT_DURATION_SEC;
+    const baseScore = (typeof getAiPlaneAdjustedScore === "function")
+      ? getAiPlaneAdjustedScore(totalDist, plane)
+      : (Number.isFinite(planAfter.score) ? planAfter.score : 0);
     const dynamiteCost = blockerIds.length * 0.05; // 5% penalty per charge spent
     const adjustedScore = baseScore * target.value - dynamiteCost;
 
@@ -27607,20 +27617,41 @@ function maybeUseInventoryBeforeLaunch(context, plannedMove, options = {}){
             candidateReason: candidate?.reason || null,
           });
 
-          executed = placeBlueDynamiteAt(targetX, targetY);
-          if(executed){
-            setAiDynamiteIntentFromCandidate(
-              {
-                colliderId: target?.colliderId ?? null,
-                spriteId: target?.spriteId ?? null,
-                x: targetX,
-                y: targetY,
-              },
-              candidate?.reason || "dynamite_route_opening",
-              plannedMove,
-              candidate?.dynamiteExpectedRoute || null,
-              candidate?.dynamiteUseClass || null,
-            );
+          // HARD REJECT: only place dynamite if the planned flight actually
+          // uses the corridor through this collider. If corridorCheckRightNow
+          // is false here, neither scheduler-replan nor inline guard nor the
+          // augmented planner managed to align the plan with the dynamite —
+          // placing the charge anyway would produce the exact user-reported
+          // bug ("dynamite one way, plane the other"). Skip placement, keep
+          // the charge in inventory.
+          if(diagCurrentCorridor === true){
+            executed = placeBlueDynamiteAt(targetX, targetY);
+            if(executed){
+              setAiDynamiteIntentFromCandidate(
+                {
+                  colliderId: target?.colliderId ?? null,
+                  spriteId: target?.spriteId ?? null,
+                  x: targetX,
+                  y: targetY,
+                },
+                candidate?.reason || "dynamite_route_opening",
+                plannedMove,
+                candidate?.dynamiteExpectedRoute || null,
+                candidate?.dynamiteUseClass || null,
+              );
+            }
+          } else {
+            logDynamiteDebug("dynamite_hard_reject_no_corridor", {
+              planeId: plannedMove.plane?.id ?? null,
+              colliderId: target?.colliderId ?? null,
+              spriteId: target?.spriteId ?? null,
+              dynamiteTarget: { x: Number(targetX.toFixed(1)), y: Number(targetY.toFixed(1)) },
+              plannedLanding: diagLanding,
+              routeClass: plannedMove.routeClass || null,
+              reason: "plan_does_not_use_corridor_through_collider",
+            });
+            // executed stays false ⇒ removeItemFromInventory below is skipped ⇒
+            // dynamite charge remains in the AI's inventory for later use.
           }
         }
         if(executed){


### PR DESCRIPTION
## Summary

Из твоих логов после PR #2762 — точная диагностика:

**Augmented planner scoring mismatch:**
```
bestAdjustedScore: -0.1   vs   currentScore: 1200    accepted: false
bestAdjustedScore: -0.05  vs   currentScore: 1072    accepted: false
```
`planPathToPoint(...).score` (что я использовал) — на **совершенно другой шкале**, чем `selectedPlan.score`. Augmented planner никогда не принимал альтернативы.

**Hard fact из `dynamite_about_to_place`:**
```
dynamiteTarget:    (260, 230)         ← бомба наверху
plannedLanding:    (474, 596)         ← самолёт летит вниз-вправо
routeClass:        "ricochet"
corridorCheckRightNow: false           ← план НЕ идёт сквозь
dynamiteReplanned:  false
dynamiteAugmentedPlan: false
```

Ни scheduler-replan, ни inline guard, ни augmented planner — **не выровняли** план. Но soft-skip из #2756 всё равно позволял ставить динамит → ровно тот баг что ты видишь.

## Fix

### 1. Augmented planner scoring fix

Вместо `planAfter.score` (raw) использовать `getAiPlaneAdjustedScore(totalDist, plane)` — **та же шкала** что `selectedPlan.score`. Теперь сравнение alternative vs current на одной шкале.

### 2. Hard reject в `executeCommittedInventoryAction`

Прямо перед `placeBlueDynamiteAt` уже вычисляется `corridorCheckRightNow` через `doesMoveUseDynamiteCorridor`. Гейт:

```
if(corridorCheckRightNow === true)  → placeBlueDynamiteAt + setIntent
else                                → НЕ ставим, charge остаётся в инвентаре
                                      log dynamite_hard_reject_no_corridor
```

Strategic_setup из #2756 (мягкий skip) — отключён. Это и было причиной твоей жалобы.

## Эффект

- Динамит ставится **только** если план реально идёт сквозь brick (current plan / scheduler-replan / inline replan / augmented planner привели к `corridorCheckRightNow=true`).
- Augmented planner теперь работает с правильным scoring — может предложить переключиться на лучшую цель если динамит откроет путь.

## Что просить от тебя после мержа

Если повторится — пришли логи `[dynamite-debug] dynamite_augmented_plan_evaluation` и `[dynamite-debug] dynamite_hard_reject_no_corridor`. По ним станет ясно: либо AI всё ещё находит план без динамита **объективно лучше** (тогда нужно крутить threshold/value weights), либо где-то ещё рассинхрон.

## Test plan

- [x] `node --check script.js`.
- [x] Оба prelaunch smoke прохода.
- [ ] **Browser**: ИИ не должен ставить динамит когда план не идёт сквозь. Если ставит — план **обязательно** проходит через bomb position.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_