### PR TITLE
ИИ: multi-target bonus + flag-safety guard в DYNAMITE augmented planner

### DIFF
--- a/script.js
+++ b/script.js
@@ -22742,20 +22742,57 @@ async function findAiDynamiteAugmentedAlternativePlanAsync(plane, color, context
     const totalDist = Number.isFinite(planAfter.totalDist)
       ? planAfter.totalDist
       : Math.hypot(planAfter.vx, planAfter.vy) * FIELD_FLIGHT_DURATION_SEC;
-    const baseScore = (typeof getAiPlaneAdjustedScore === "function")
-      ? getAiPlaneAdjustedScore(totalDist, plane)
-      : (Number.isFinite(planAfter.score) ? planAfter.score : 0);
-    const dynamiteCost = blockerIds.length * 0.05;
-    const adjustedScore = baseScore * target.value - dynamiteCost;
 
-    // Path collection / safety stats for alt route — counts what the plane
-    // would visibly touch on a direct segment plane → altLanding. Compared
-    // against the current plan's segment below in accept logic.
+    // Compute landing FIRST, then stats, then score — scoring reads altStats
+    // for the mass-pickup bonus, and flag-safety guard reads altLanding.
     const altDur = Number.isFinite(FIELD_FLIGHT_DURATION_SEC) && FIELD_FLIGHT_DURATION_SEC > 0
       ? FIELD_FLIGHT_DURATION_SEC : 1;
     const altLandingX = plane.x + planAfter.vx * altDur;
     const altLandingY = plane.y + planAfter.vy * altDur;
     const altStats = countTargetsAndSafetyOnSegment(plane, altLandingX, altLandingY, color, context, aliveEnemies);
+
+    // Flag-safety guard. Flag-grab into enemy retaliation range loses the
+    // plane next turn for one pickup. Allow only if landing is clear, OR
+    // if AI has FUEL in inventory (return-trip plausible). "continue" pops
+    // just this flag-target from the bestAlt race; other targets remain,
+    // so the function still returns a non-null alt if any safe target
+    // exists — no desync (legacy null-return was the previous desync source).
+    if(target.kind === "flag" && typeof getImmediateResponseThreatMeta === "function"){
+      const respondThreats = getImmediateResponseThreatMeta(context, altLandingX, altLandingY, null);
+      const threatCount = Number.isFinite(respondThreats?.count) ? respondThreats.count : 0;
+      if(threatCount > 0){
+        const inv = (typeof evaluateInventoryState === "function") ? evaluateInventoryState(color) : null;
+        const fuelCount = Number(inv?.counts?.[INVENTORY_ITEM_TYPES.FUEL] ?? 0);
+        if(fuelCount <= 0){
+          logDynamiteDebug("dynamite_augmented_plan_flag_target_skipped", {
+            planeId: plane?.id ?? null,
+            flagAnchorX: target.x,
+            flagAnchorY: target.y,
+            altLandingX,
+            altLandingY,
+            threatCount,
+            reason: "no_fuel_for_safe_return",
+          });
+          continue;
+        }
+      }
+    }
+
+    const baseScore = (typeof getAiPlaneAdjustedScore === "function")
+      ? getAiPlaneAdjustedScore(totalDist, plane)
+      : (Number.isFinite(planAfter.score) ? planAfter.score : 0);
+
+    // Mass-target bonus: each pickup beyond the first adds 20% of baseScore,
+    // capped at 3 extra. Flags are NOT in totalPickups — flag plans get this
+    // bonus only if they happen to graze enemies/cargo on the way (combo).
+    const extraPickups = Math.min(Math.max(0, altStats.totalPickups - 1), 3);
+    const massPickupBonus = extraPickups * baseScore * 0.20;
+
+    // Scale dynamite cost with baseScore so extra blockers stay meaningful
+    // at distance — was 0.05/blocker (negligible vs baseScore in hundreds).
+    const dynamiteCost = blockerIds.length * baseScore * 0.04;
+
+    const adjustedScore = baseScore * target.value + massPickupBonus - dynamiteCost;
 
     if(!bestAlt || adjustedScore > bestAlt.adjustedScore){
       bestAlt = { target, blockers, plan: planAfter, adjustedScore, nDynamites: blockerIds.length, altLandingX, altLandingY, altStats };


### PR DESCRIPTION
## Summary

После rewrite #2765 multi-dynamite breakthrough работает корректно, но AI почти всегда выбирает захват флага на базе противника и гибнет в ответке. Массовые сценарии (3 enemy / 3 cargo) проигрывают в scoring одинокому флагу.

**Root cause** в `findAiDynamiteAugmentedAlternativePlanAsync`:
- `adjustedScore = baseScore × target.value − dynamiteCost`
- `baseScore` distance-weighted → флаг (на дальней базе) даёт baseScore в ~1.5× больше enemy → 0.85 × 1.5 > 1.0 × 1.0.
- `altStats.totalPickups` (массивность) вычислялся, но НЕ участвовал в выборе `bestAlt` — только в accept gate.
- `dynamiteCost = 0.05/blocker` — пренебрежимо мал относительно baseScore в сотнях.

## Что сделано

Две правки в одном цикле target selection (`script.js:22742-22799`):

**A) Flag-safety guard через `continue` в цикле.** Flag-target пропускается из bestAlt-гонки если landing в зоне ответной атаки И в инвентаре нет FUEL. Другие цели (enemy/cargo/base/safer flag) остаются — augmented planner возвращает alt естественно, никакого desync. (В отличие от прошлой попытки #2766, где null-return из функции открывал старый legacy-replan путь с расхождением dynamite-aim и trajectory.)

**B) Multi-target bonus в scoring + реорг порядка вычислений:**
```js
// порядок: altLanding → altStats → baseScore → adjustedScore
const extraPickups = Math.min(Math.max(0, altStats.totalPickups - 1), 3);
const massPickupBonus = extraPickups * baseScore * 0.20;
const dynamiteCost = blockerIds.length * baseScore * 0.04; // scaled
const adjustedScore = baseScore * target.value + massPickupBonus - dynamiteCost;
```

Первый pickup «бесплатный» (любая цель — pickup); каждый дополнительный +20% baseScore, cap=3 (защита от pathological clusters). Cost масштабирован — лишний динамит без выгоды теперь штрафуется ощутимо.

## Численная проверка

baseScore_enemy ≈ 400, baseScore_flag ≈ 600.

| Сценарий | adjustedScore |
|---|---|
| enemy plan, 3 pickups, 2 dynamites | 528 |
| flag plan, 0 pickups, 2 dynamites | 462 |
| flag plan, 2 pickups (combo) | 582 |
| base plan, 10-cluster cap, 3 dynamites | 312 |

Массовые сценарии побеждают; комбо «флаг + враги по пути» — лучший выбор; pathological 10-cluster на низкоценной базе capпн.

## Что НЕ трогается

- Pre-планировщик `buildAiSelectedPlanInventoryEnhancementsAsync` + sync twin.
- Legacy `buildDynamiteReplannedMoveAsync`.
- Accept gate (`collectsMore`/`sameCollectsButSafer`/`scoreSignificantlyBetter`).
- Scheduler, FUEL injection (точная гарантия FUEL-return — будущая задача).
- **Никаких null-возвратов** из augmented planner.

## Test plan

- [x] `node --check script.js`
- [x] `node scripts/smoke-ai-prelaunch-real-inventory-execution.js`
- [x] `node scripts/smoke-ai-prelaunch-selected-sequence-execution.js`
- [ ] Браузер — 4 кейса:
  - Multi-enemy/cargo предпочитается (главный кейс).
  - Flag-safety guard блокирует suicide flag без FUEL (лог `dynamite_augmented_plan_flag_target_skipped`).
  - Flag разрешён с FUEL в инвентаре.
  - Регрессия — 1-dynamite single-target не сломался.
- [ ] Телеметрия: `bestTargetKind` в логе `dynamite_augmented_plan_evaluation` должен сместиться с почти всегда `flag` к смеси enemy/cargo/flag.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_