### PR TITLE
ИИ: убрать остаточные desync в DYNAMITE augmented planner (ricochet + NaN blockers)

### DIFF
--- a/script.js
+++ b/script.js
@@ -22715,6 +22715,16 @@ async function findAiDynamiteAugmentedAlternativePlanAsync(plane, color, context
     }
     if(blockers.length === 0 || blockers.length > maxDynamites) continue;
 
+    // All blockers must have finite center coords — sequence builder at
+    // script.js:15469 silently drops blockers with NaN cx/cy, leaving the
+    // trajectory believing N walls were removed while only <N dynamites fire.
+    const allBlockersHaveValidCenters = blockers.every((b) => {
+      const bx = Number.isFinite(b?.cx) ? b.cx : (Number.isFinite(b?.centerX) ? b.centerX : null);
+      const by = Number.isFinite(b?.cy) ? b.cy : (Number.isFinite(b?.centerY) ? b.centerY : null);
+      return Number.isFinite(bx) && Number.isFinite(by);
+    });
+    if(!allBlockersHaveValidCenters) continue;
+
     const blockerIds = blockers.map((b) => b.id);
 
     // Plan a direct path with these blockers temporarily removed from the world.
@@ -22738,6 +22748,13 @@ async function findAiDynamiteAugmentedAlternativePlanAsync(plane, color, context
       planAfter = null;
     }
     if(!planAfter || !Number.isFinite(planAfter.vx) || !Number.isFinite(planAfter.vy)) continue;
+
+    // Reject ricochet trajectories: blockers were collected on the straight
+    // plane→target line, but planPathToPoint can return a ricochet path
+    // (routeClass:"direct" is just a label — attack_parallel auto-ricochet
+    // probe at script.js:37805-37822 still fires). Sequence entries would
+    // aim at straight-line blockers while flight bounces past other walls.
+    if(Number.isFinite(planAfter.bounceCount) && planAfter.bounceCount > 0) continue;
 
     const totalDist = Number.isFinite(planAfter.totalDist)
       ? planAfter.totalDist


### PR DESCRIPTION
## Summary

После #2767 поведение AI с динамитом стало правильным в большинстве случаев, но пользователь наблюдает два остаточных desync-симптома. Этот PR закрывает оба точечно.

**Stacked PR**: base = `claude/fix-ai-freeze-issue-M8eQo` (на котором PR #2767). Diff показывает только новые правки. После merge #2767 в main, base можно сменить на main.

## Симптом 1 — «взрыв одно — летит другое»

**Root cause:** `findAiDynamiteAugmentedAlternativePlanAsync` собирает blockers по **прямой линии** plane→target (script.js:22709-22715), но `planPathToPoint` может вернуть **ricochet** trajectory:
- `routeClass: "direct"` — это просто label.
- Реальная ricochet-ветка включается через `attack_parallel_ricochet_probe` (script.js:37805-37822), которая срабатывает когда `decisionReason` содержит attack-related text. Для нашего `decisionReason: "dynamite_augmented_enemy"` — срабатывает.

Sequence получает dynamite entries по straight-line координатам blockers, самолёт летит ricochet'ом — визуальный desync.

**Fix B (script.js:22742+):**
```js
if(Number.isFinite(planAfter.bounceCount) && planAfter.bounceCount > 0) continue;
```
Отвергаем альтернативы где trajectory строится через отскоки. `planAfter.bounceCount` reliably set in `findBestSimulatedShot` (script.js:38045) и preserved через `finalizePlannedMove` (script.js:14811).

## Симптом 2 — «думает что взорвал 2, реально 1, врезается»

**Root cause:** scheduler consumer на script.js:15469 тихо пропускает blocker с NaN `cx`/`cy` (rare data anomaly из `getSpriteColliderCenter` script.js:45450 при corrupt sprite). `planAfter` уже рассчитан с N blockers удалёнными, в sequence попадает <N entries.

**Fix A (script.js:22718+):**
```js
const allBlockersHaveValidCenters = blockers.every((b) => { ... });
if(!allBlockersHaveValidCenters) continue;
```
Валидируем все blockers ДО `planPathToPoint`. Если хоть один невалиден — `continue`, другие target-кандидаты в цикле остаются в гонке.

## Инвариант сохранён

Оба фикса через `continue` в цикле — никаких null-returns из `findAiDynamiteAugmentedAlternativePlanAsync`. Это критично: null-return из этой функции открывает legacy code-path в scheduler, где dynamite-aim остаётся от pre-планировщика, а trajectory обновляется legacy replan'ом — классический desync (был источник регрессии #2766, причина revert'а).

Pre-планировщик, legacy `buildDynamiteReplannedMoveAsync`, scheduler consumer, accept gate и flag-safety guard из #2767 — не трогаются.

## Что теряем (намеренно)

- Альтернативы где AI бы хотел использовать dynamite + ricochet в одной трajectory. Эти и есть desynced случаи.
- Альтернативы с corrupted collider data. Анomaly rare; другие target-кандидаты остаются.

## Test plan

- [x] `node --check script.js`
- [x] `node scripts/smoke-ai-prelaunch-real-inventory-execution.js`
- [x] `node scripts/smoke-ai-prelaunch-selected-sequence-execution.js`
- [ ] Браузер — 4 кейса:
  - Multi-target straight-line (главный): AI взрывает стены, летит прямо через них.
  - Ricochet rejection: alt с bounce'ом пропускается, нет «взрыв одно — лет другое».
  - Регрессия — PR #2767 кейс с 3-cargo за прямыми стенами всё ещё работает.
  - NaN blockers (если воспроизводится) — anti-desync защита превентивная.
- [ ] Телеметрия: `nDynamites` в `dynamite_augmented_plan_evaluation` теперь должен точно совпадать с количеством entries в `selectedInventorySequence`.

## Diff scope
- 1 файл (`script.js`), +17 строк.
- 0 удалено.
- Zero impact на pre-planner, legacy replan, scheduler consumer, accept gate, flag-safety guard.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_