### PR TITLE
Restrict map editor entity interactions to brick control mode

### DIFF
--- a/script.js
+++ b/script.js
@@ -3855,6 +3855,7 @@ function applyMapEditorEntityMoveFromPointerEvent(event){
 
 function onCanvasMapEditorEntityPointerDown(event){
   if(selectedRuleset !== "mapeditor") return false;
+  if(mapEditorControlMode !== "bricks") return false;
   const { x: designX, y: designY } = getPointerDesignCoords(event);
   const { x: boardX, y: boardY } = designToBoardCoords(designX, designY);
   const entity = findMapEditorEntityAtBoardPoint(boardX, boardY);
@@ -18218,7 +18219,7 @@ function onCanvasPointerMove(e){
     document.body.style.cursor = "grabbing";
     return;
   }
-  if(selectedRuleset === "mapeditor"){
+  if(selectedRuleset === "mapeditor" && mapEditorControlMode === "bricks"){
     const { x: designX, y: designY } = getPointerDesignCoords(e);
     const { x: boardX, y: boardY } = designToBoardCoords(designX, designY);
     const hoverEntity = findMapEditorEntityAtBoardPoint(boardX, boardY);


### PR DESCRIPTION
## Summary
This change restricts map editor entity selection and interaction to only occur when the map editor is in "bricks" control mode, preventing unintended entity manipulation when other control modes are active.

## Key Changes
- Added a guard clause in `onCanvasMapEditorEntityPointerDown()` to return early if `mapEditorControlMode` is not "bricks"
- Updated the condition in `onCanvasPointerMove()` to check both `selectedRuleset === "mapeditor"` AND `mapEditorControlMode === "bricks"` before processing entity hover detection

## Implementation Details
These changes ensure that entity-related pointer events (mouse down and hover) are only processed when the user is actively in brick placement/editing mode. This prevents conflicts with other map editor control modes that may have their own pointer event handling logic.

https://claude.ai/code/session_01EfvhjrQbdAAgqACTGzdwMA