### PR TITLE
ИИ: tiebreaker сохраняет primary score — fix fallback regression после #2769

### DIFF
--- a/script.js
+++ b/script.js
@@ -40537,7 +40537,14 @@ function pickSaferLanding(pool, ctx){
     });
   }
 
-  return best;
+  // Preserve primary's score in the returned candidate so cross-enemy
+  // attack ranking (script.js:15165-15168) and attack-vs-cargo comparisons
+  // don't shift — this is a strict tiebreaker on landing, not on score.
+  // Without this, returning best.score (which can be ~5-25 below primary's)
+  // makes downstream switch to a different enemy or to a cargo plan, since
+  // attackCandidates.sort uses move.score.
+  if(best === pool[0]) return pool[0];
+  return { ...best, score: pool[0].score };
 }
 
 function findBestSimulatedShot(plane, target, options = {}){


### PR DESCRIPTION
## Summary

После PR #2769 (`post-shot landing tiebreaker`) пользователь заметил что AI откатывается на fallback-поведения (мины, топтание) вместо сбора грузов и хороших атак. Этот PR — точечный fix.

**Stacked PR**: base = `claude/ai-post-shot-landing-safety` (#2769). Diff показывает только +8 строк fix-а.

## Root cause

`pickSaferLanding` (после #2769) возвращал candidate с **меньшим** primary score (~5-25 ниже primary), и этот score проступал в downstream:

1. **`attackCandidates.sort` (script.js:15165-15168)** сортирует кандидатов **разных врагов** по `move.score`. Раньше для enemy A `primary=1182` побеждал enemy B `primary=1180`. После #2769 для A я возвращал `score=1175` (safer landing) → теперь B побеждает A. **AI менял цель атаки**, а не только landing — побочный эффект, которого я не учёл.

2. **`shouldPreferCargoOverAttack`** и другие сравнения тоже видели worse score → cargo/center/mine fallback чаще выбирался.

Результат: AI «тупел» — не та цель + чаще fallback.

## Fix (script.js:40540+)

```js
// Preserve primary's score in the returned candidate so cross-enemy
// attack ranking and attack-vs-cargo comparisons don't shift — this
// is a strict tiebreaker on landing, not on score.
if(best === pool[0]) return pool[0];
return { ...best, score: pool[0].score };
```

Возвращаем best candidate с подменённым `score = pool[0].score`:
- **sim сохраняется от best** (impactPoint, launchVector — реальный безопасный shot).
- **score сохраняется от primary** (no downstream ranking change).
- Реальная отстрелка идёт по best (за стенку), downstream видит primary's score.

Это и есть strict tiebreaker в чистом виде — outside-this-function поведение идентично pre-#2769.

## Test plan

- [x] `node --check script.js`
- [x] `node scripts/smoke-ai-prelaunch-real-inventory-execution.js`
- [x] `node scripts/smoke-ai-prelaunch-selected-sequence-execution.js`
- [ ] Браузер: подтвердить что AI снова собирает грузы / атакует правильные цели; tiebreaker по-прежнему выбирает safer landing при равных атаках (лог `attack_landing_safety_swap`).

## Diff scope
- 1 файл (`script.js`), +8/-1.
- Single point change в `pickSaferLanding` return statement.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_