### PR TITLE
docs: правило про отдельные PR для AI-агентов (CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# Project conventions for AI agents
+
+These rules apply to every Claude Code / Claude Agent session working in this repository.
+
+## Pull request discipline
+
+**One logical change = one branch = one PR. Always.**
+
+- When you finish a piece of work and the user asks you to ship it, create a **new branch** and open a **new PR**. Do not extend an already-open PR with a follow-up commit unless the user explicitly told you to push to that branch.
+- This applies in particular to:
+  - Bug fixes that come up while working on a feature → new branch, new PR.
+  - Diagnostic / logging / observability additions → new branch, new PR.
+  - Tuning / threshold adjustments after a feature lands → new branch, new PR.
+  - Reverts → new branch, new PR.
+- **Exception**: when an open PR receives review feedback and the user (or a reviewer) asks for the fix on that PR, push to its branch — that is the normal review cycle.
+- If you are unsure whether a change is "the same PR" or "a new PR", default to **new PR**. The user prefers small focused PRs over large merged-purpose ones.
+
+## Branch naming
+
+- Use `claude/<short-kebab-description>` for new branches you create.
+- One topic per branch name; do not bundle unrelated work even under the same branch.
+
+## When in doubt
+
+Ask via `AskUserQuestion` before pushing a follow-up to an existing PR's branch.


### PR DESCRIPTION
## Summary

Добавляет CLAUDE.md с правилом для всех будущих AI-сессий: **один логический change = одна ветка = один PR**. Без явного запроса не пушить follow-up коммиты в уже открытую PR-ветку.

Claude Code (и Claude Agent SDK) автоматически читает `CLAUDE.md` проекта в каждой сессии — значит правило будет применяться всеми будущими агентами без напоминаний.

## Что покрывает

- Bug fixes / диагностика / тюнинг порогов / revert'ы → новый branch + новый PR.
- Исключение: review feedback на уже открытый PR — нормально пушить в ту же ветку.
- При неуверенности — спросить через AskUserQuestion.

## Test plan

- [ ] При следующей сессии Claude Code в этом репо проверить что CLAUDE.md загружается (видно в системном промпте).

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_