### PR TITLE
ИИ defensive mines: on-demand aiMineDebug() + CLAUDE.md PR-discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,24 +2,23 @@
 
 These rules apply to every Claude Code / Claude Agent session working in this repository.
 
-## Pull request discipline
+## PR workflow
 
-**One logical change = one branch = one PR. Always.**
+**Каждое решение об изменении, принятое в обсуждении = отдельный PR.**
 
-- When you finish a piece of work and the user asks you to ship it, create a **new branch** and open a **new PR**. Do not extend an already-open PR with a follow-up commit unless the user explicitly told you to push to that branch.
-- This applies in particular to:
-  - Bug fixes that come up while working on a feature → new branch, new PR.
-  - Diagnostic / logging / observability additions → new branch, new PR.
-  - Tuning / threshold adjustments after a feature lands → new branch, new PR.
-  - Reverts → new branch, new PR.
-- **Exception**: when an open PR receives review feedback and the user (or a reviewer) asks for the fix on that PR, push to its branch — that is the normal review cycle.
-- If you are unsure whether a change is "the same PR" or "a new PR", default to **new PR**. The user prefers small focused PRs over large merged-purpose ones.
+Когда мы что-то обсудили и пришли к решению о коде — реализуй, открой **новый PR** и закончи цикл. Если в продолжении разговора возникает ещё одно изменение (даже по той же теме) — это **новый PR с новой веткой**, а не follow-up push в ветку уже открытого PR.
+
+Не комбинируй «часть оформлена как PR, часть допушена в его же ветку как follow-up». Это рушит обзор изменений и историю.
+
+### НЕ дроби одну задачу на несколько PR
+
+Если внутри одного решения нужно сделать несколько связанных правок (фикс + тест + комментарий) — это всё **один** PR. Не плоди по отдельной ветке за каждый файл.
+
+### Когда push в открытую ветку допустим
+
+- **Review feedback** на уже открытый PR — нормально пушить в его ветку (это и есть review-цикл).
+- Если сомневаешься, push в открытую ветку или новый PR — **спрашивай** через AskUserQuestion.
 
 ## Branch naming
 
-- Use `claude/<short-kebab-description>` for new branches you create.
-- One topic per branch name; do not bundle unrelated work even under the same branch.
-
-## When in doubt
-
-Ask via `AskUserQuestion` before pushing a follow-up to an existing PR's branch.
+- `claude/<short-kebab-description>`. Одна тема — одно имя.

--- a/script.js
+++ b/script.js
@@ -27203,6 +27203,23 @@ function scoreMinePlacementByProjection(placement, ctx, aiColor, projectionCache
   return { score: capped, details: { perEnemy, enemyCount: perEnemy.length } };
 }
 
+// On-demand diagnostic buffer for the defensive-mine planner. Each invocation
+// pushes one summary entry (ring buffer, max 100). Inspect from the browser
+// console with `aiMineDebug()` — returns a JSON string of recent entries.
+// `aiMineDebug({ clear: true })` empties the buffer.
+const AI_MINE_DEBUG_BUFFER = [];
+const AI_MINE_DEBUG_MAX = 100;
+function aiMineDebugRecord(entry){
+  AI_MINE_DEBUG_BUFFER.push({ t: Date.now(), ...entry });
+  if(AI_MINE_DEBUG_BUFFER.length > AI_MINE_DEBUG_MAX) AI_MINE_DEBUG_BUFFER.shift();
+}
+if(typeof window !== "undefined"){
+  window.aiMineDebug = function(opts){
+    if(opts && opts.clear){ AI_MINE_DEBUG_BUFFER.length = 0; return "cleared"; }
+    return JSON.stringify(AI_MINE_DEBUG_BUFFER, null, 2);
+  };
+}
+
 // Layer A — defensive mine planner. Returns:
 //   { placements: [...0..2], rationale, metrics, defensiveMinePlan: true } or null.
 // Hard caps: max 2 per turn, max AI_DEFENSIVE_MINE_MAX_TOTAL_ON_FIELD on field
@@ -27228,7 +27245,7 @@ async function findAiDefensiveMineOpportunityAsync(selectedPlan, context){
       ownMinesOnField,
       cap: AI_DEFENSIVE_MINE_MAX_TOTAL_ON_FIELD,
     });
-    try { console.log("[AI-MINE-DEBUG]", JSON.stringify({ color: aiColor, inv: mineCount, onField: ownMinesOnField, cap: AI_DEFENSIVE_MINE_MAX_TOTAL_ON_FIELD, earlyReject: "max_field_cap" })); } catch (_) {}
+    aiMineDebugRecord({ color: aiColor, inv: mineCount, onField: ownMinesOnField, cap: AI_DEFENSIVE_MINE_MAX_TOTAL_ON_FIELD, earlyReject: "max_field_cap" });
     return null;
   }
 
@@ -27238,7 +27255,7 @@ async function findAiDefensiveMineOpportunityAsync(selectedPlan, context){
   const enemies = livePoints.filter((p) => p && p.color === enemyColor && p.isAlive && !p.burning);
   if(enemies.length === 0){
     logAiDecision("defensive_mine_planner_reject", { reason: "no_enemies" });
-    try { console.log("[AI-MINE-DEBUG]", JSON.stringify({ color: aiColor, inv: mineCount, earlyReject: "no_enemies" })); } catch (_) {}
+    aiMineDebugRecord({ color: aiColor, inv: mineCount, earlyReject: "no_enemies" });
     return null;
   }
 
@@ -27306,7 +27323,7 @@ async function findAiDefensiveMineOpportunityAsync(selectedPlan, context){
 
   if(threats.length === 0){
     logAiDecision("defensive_mine_planner_reject", { reason: "no_threats_with_valid_target" });
-    try { console.log("[AI-MINE-DEBUG]", JSON.stringify({ color: aiColor, inv: mineCount, earlyReject: "no_threats" })); } catch (_) {}
+    aiMineDebugRecord({ color: aiColor, inv: mineCount, earlyReject: "no_threats" });
     return null;
   }
 
@@ -27552,22 +27569,18 @@ async function findAiDefensiveMineOpportunityAsync(selectedPlan, context){
     });
   }
 
-  // v3.2-debug: one-line summary so the user can see which gate dominated.
-  // Floor used for context (strategic prior may boost above raw projection).
-  try {
-    console.log("[AI-MINE-DEBUG]", JSON.stringify({
-      color: aiColor,
-      inv: mineCount,
-      onField: ownMinesOnField,
-      cap: AI_DEFENSIVE_MINE_MAX_TOTAL_ON_FIELD,
-      threats: threats.length,
-      probesExamined,
-      accepted: allCandidates.length,
-      floor: AI_DEFENSIVE_MINE_MIN_SCORE,
-      budgetHit,
-      rejects,
-    }));
-  } catch (_) { /* console may be absent */ }
+  aiMineDebugRecord({
+    color: aiColor,
+    inv: mineCount,
+    onField: ownMinesOnField,
+    cap: AI_DEFENSIVE_MINE_MAX_TOTAL_ON_FIELD,
+    threats: threats.length,
+    probesExamined,
+    accepted: allCandidates.length,
+    floor: AI_DEFENSIVE_MINE_MIN_SCORE,
+    budgetHit,
+    rejects,
+  });
 
   if(allCandidates.length === 0){
     logAiDecision("defensive_mine_planner_reject", {


### PR DESCRIPTION
## Summary

Объединяет два решённых в одном обсуждении изменения (заменяет закрытые PR #2789 и #2790).

### 1. On-demand диагностика мин через `aiMineDebug()`

Раньше планировщик мин шумел в консоль `[AI-MINE-DEBUG]` строками на каждый ход — приходилось искать вручную.

Теперь данные накапливаются в in-memory ring-buffer (100 последних запусков `findAiDefensiveMineOpportunityAsync`). В DevTools-консоли:

```js
aiMineDebug()           // → JSON-строка со всеми записями
aiMineDebug({clear:true}) // → очистить буфер
```

Каждая запись:
```json
{
  "t": 1748254800123,
  "color": "blue",
  "inv": 9,
  "onField": 0,
  "cap": 3,
  "threats": 3,
  "probesExamined": 47,
  "accepted": 0,
  "floor": 1.85,
  "budgetHit": false,
  "rejects": {
    "placement_invalid": 5, "landing_too_close": 12,
    "own_base_too_close": 0, "own_traj_too_close": 18,
    "other_own_too_close": 0, "future_traj_too_close": 0,
    "sim_self_hit": 3, "cluster_with_existing": 0,
    "too_far_from_probe": 1, "score_invalid": 0,
    "score_below_floor": 8
  }
}
```

Поведение AI не меняется — только наблюдаемость.

### 2. CLAUDE.md с PR-discipline rule

Зафиксировано правило для всех будущих AI-сессий: **каждое решённое в обсуждении изменение = отдельный PR**, не дробить одну задачу на несколько PR, не пушить follow-up'ы в открытую PR-ветку без явного запроса.

## Test plan

- [x] `node --check script.js`
- [x] `scripts/smoke-ai-prelaunch-real-inventory-execution.js` зелёный
- [x] `scripts/smoke-ai-prelaunch-selected-sequence-execution.js` зелёный
- [ ] **Пользователь:** играет короткую партию, где «мины не ставятся при полном инвентаре» → F12 → `aiMineDebug()` → копирует JSON → видно какой gate доминирует.

## Risk

- Один объект-инкремент на ход + один push в массив длиной ≤100. Performance negligible.
- `window.aiMineDebug` доступна в проде. Если нежелательно — отдельным PR обернуть в env-флаг.

Closes #2789 и #2790 концептуально (оба закрыты как obsolete).

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_