### PR TITLE
ИИ defensive mines: поднять onField cap с 3 до 6

### DIFF
--- a/script.js
+++ b/script.js
@@ -26913,7 +26913,11 @@ async function buildAiSelectedPlanInventoryEnhancementsAsync(context, selectedPl
 // =========================================================================
 const AI_DEFENSIVE_MINE_ENABLED = true;
 const AI_DEFENSIVE_MINE_MAX_PER_TURN = 2;
-const AI_DEFENSIVE_MINE_MAX_TOTAL_ON_FIELD = 3;
+// Raised 3 → 6 after live diagnostic showed that with 7-10 mines in inventory
+// the planner was hitting `earlyReject: max_field_cap` on most turns —
+// effectively freezing 70%+ of the inventory. 20ms budget + per-candidate
+// gates already protect against the original "saturation" regression.
+const AI_DEFENSIVE_MINE_MAX_TOTAL_ON_FIELD = 6;
 // strategic-v3: raised to compensate for prior multiplier (≤ ×1.35).
 // A placement with no strategic value (multiplier ≈ 1.0) now needs raw ≥ 1.85;
 // a placement on a strategic vector (multiplier ≈ 1.30) passes at raw ≈ 1.42.


### PR DESCRIPTION
## Summary

`AI_DEFENSIVE_MINE_MAX_TOTAL_ON_FIELD`: **3 → 6**.

Диагностический отчёт `aiMineDebug()` показал что при 7-10 минах в инвентаре планировщик стабильно даёт `earlyReject: "max_field_cap"`:

```json
{"inv": 7, "onField": 3, "cap": 3, "earlyReject": "max_field_cap"}
{"inv": 8, "onField": 3, "cap": 3, "earlyReject": "max_field_cap"}
```

То есть 70%+ инвентаря заморожено каплом, который ставился изначально как protection от saturation-регрессии. Эта protection теперь обеспечивается per-candidate gates + 20ms бюджет + cluster-radius, поэтому жёсткий кап избыточен.

## Test plan

- [x] `node --check script.js`
- [x] Оба smoke-теста зелёные
- [ ] **Игрок:** партия в условиях «AI не ставит при 8+ мин» → `aiMineDebug()` → `earlyReject:max_field_cap` должен пропасть до тех пор пока onField не достигнет 6.

## Risk

- Если cap=6 окажется тоже саrurate launch corridor → поднимем cluster radius или вернём вниз. Откат тривиальный.
- На больших полях с 10+ минами в инвентаре всё ещё может быть `earlyReject` — следующим PR можно сделать кап динамическим от inventory size, если игроку этого захочется.

## Дальше

Это quick-fix. Главная проблема, которую игрок отметил на скриншоте — **сама геометрия выбора позиций** (мины ставятся «прямо перед носом», не учитывают рикошеты и стратегические цели врага). Это будет отдельным PR.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_