### PR TITLE
ИИ defensive mines: ослабить own_objective_vicinity buffer 3.0× → 1.5×

### DIFF
--- a/script.js
+++ b/script.js
@@ -27684,7 +27684,15 @@ async function findAiDefensiveMineOpportunityAsync(selectedPlan, context){
         // 3.0× trigger-radius of any in-range own objective anchor — this is
         // the zone where both sides physically converge.
         let nearOwnObjective = false;
-        const anchorBuf = MINE_TRIGGER_RADIUS * 3.0;
+        // Anchor radius tightened from 3.0× to 1.5×. At 3.0× the gate rejected
+        // *every* non-invalid probe in live telemetry (59/85 = 100% of survivors
+        // were inside the anchor zone), because enemy projection probes
+        // naturally cluster near their target objective. 1.5× (~45 px at
+        // MINE_TRIGGER_RADIUS=30) blocks only mines literally on top of an
+        // objective — where our landing point would actually be — while
+        // letting mid-corridor probes survive. own_approach_corridor handles
+        // the wider zone of overlap separately.
+        const anchorBuf = MINE_TRIGGER_RADIUS * 1.5;
         for(const a of ownObjectiveAnchors){
           if(Math.hypot(px - a.x, py - a.y) < anchorBuf){ nearOwnObjective = true; break; }
         }


### PR DESCRIPTION
## Summary

Калибровочный фикс прямо поверх предыдущей итерации. `own_objective_vicinity` оказался слишком жёстким и блокировал мины полностью.

## Симптом

Отчёт `aiMineDebug()` после `claude/ai-mine-tighten-self-trap-guard`:

| ход | probes | placement_invalid | own_objective_vicinity | landing_too_close | **accepted** |
|---|---|---|---|---|---|
| 1 | 144 | 85 | 59 | 0 | **0** |
| 2 | 162 | 103 | 59 | 0 | **0** |
| 3 | 126 | 57 | 47 | 22 | **0** |

В каждом ходу 100% non-invalid probes погибали на `own_objective_vicinity`.

## Причина

Probes из enemy-projection кластеризуются **близко к target objective** (probe на 55% сегмента enemy→cargo находится в ~5-30 px от cargo). Buffer `3.0× MINE_TRIGGER_RADIUS` (~90 px) запрещал мины почти во всей средней половине поля.

## Фикс

`anchorBuf = MINE_TRIGGER_RADIUS * 1.5` (~45 px). Это блокирует только мины **литерально на** objective — где наш landing point был бы — но позволяет mid-corridor probes пройти.

`own_approach_corridor` (3.5×) остаётся как был — он обрабатывает более широкую зону пересечения отдельно.

## Test plan

- [x] `node --check script.js`
- [x] Оба smoke-теста зелёные
- [ ] **Тестер:** партия → `aiMineDebug()`:
  - `own_objective_vicinity` срабатывает <10-15 на ход (не 47-59)
  - `accepted > 0` регулярно
  - AI снова ставит мины, но **не на нашем landing-point**
  - Если self-detonation вернётся — расширим следующим PR другой гейт

## Risk

Минимальный — это одно число. Если `own_objective_vicinity` теперь срабатывает 0 раз — анчоры бесполезны, и след. PR оставит только `own_approach_corridor`. Если срабатывает 5-15 раз — попадание; так и нужно.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_