### PR TITLE
ИИ defensive mines: sim_self_hit_other_plane — top-2 ближайших corridor'а

### DIFF
--- a/script.js
+++ b/script.js
@@ -27727,13 +27727,20 @@ async function findAiDefensiveMineOpportunityAsync(selectedPlan, context){
               outerOther:
               for(const own of ctx.ownPlanesToAvoid){
                 if(!own || !Number.isFinite(own.x) || !Number.isFinite(own.y)) continue;
-                // Test *every* corridor for this plane, not just the first. The
-                // previous version (`.find`) only checked the first objective
-                // (usually enemy_base) which is irrelevant for planes that
-                // would actually fly to cargo or flag — most placements were
-                // silently passing this gate.
-                const planeCorridors = ownApproachCorridors.filter((c) => c.plane === own);
-                if(planeCorridors.length === 0) continue;
+                // Test up to the 2 *nearest* corridors for this plane. The
+                // previous version tested all (5-8 per plane × 4-5 planes ≈
+                // 20-36 segment checks) which over-pruned — a plane realistically
+                // flies to one objective per turn, not all of them. future_traj_
+                // too_close already covers the most-likely next move (to nearest
+                // cargo/enemy); top-2 by distance here adds a safety margin for
+                // the second-likely objective without flagging every probe.
+                const planeCorridorsAll = ownApproachCorridors.filter((c) => c.plane === own);
+                if(planeCorridorsAll.length === 0) continue;
+                const planeCorridors = planeCorridorsAll
+                  .map((c) => ({ c, d: Math.hypot(c.ex - own.x, c.ey - own.y) }))
+                  .sort((a, b) => a.d - b.d)
+                  .slice(0, 2)
+                  .map((entry) => entry.c);
                 for(const corridor of planeCorridors){
                   const ownMeta = (typeof getMineThreatMetaForSegment === "function")
                     ? getMineThreatMetaForSegment(own.x, own.y, corridor.ex, corridor.ey, own, { mineOwner: aiColor })


### PR DESCRIPTION
## Summary

Калибровочный фикс поверх предыдущей итерации. `sim_self_hit_other_plane` over-pruned, потому что прошлый PR заставил его проверять **все** corridor'ы каждого other plane (5-8 на plane × 4-5 planes = 20-36 segment checks). Мина блокировалась если попадала на путь хотя бы одного из 30+ potential trajectories.

## Симптом из отчёта тестера

| ход | probes | sim_other | accepted |
|---|---|---|---|
| 1 | 90 | **36** | 0 |
| 2 | 144 | 31 | 6 |
| 3 | 72 | **21** | 0 |
| 4 | 126 | 25 | 0 |
| 5 | 54 | **20** | 0 |
| 6 | 63 | 5 | 0 |
| 7 | 108 | 24 | 0 |
| 8 | 81 | **28** | 0 |

Из 8 ходов только в одном AI поставил мин. «Поставил 1 мину, плохонько поставил».

## Фикс

Вместо all corridors — **top-2 по distance** для каждого other plane:

```js
const planeCorridors = planeCorridorsAll
  .map((c) => ({ c, d: Math.hypot(c.ex - own.x, c.ey - own.y) }))
  .sort((a, b) => a.d - b.d)
  .slice(0, 2)
  .map((entry) => entry.c);
```

**Обоснование:** plane реалистично летит к **одному** objective за ход, не ко всем. `future_traj_too_close` уже покрывает первую гипотезу (ближайший cargo/enemy). Top-2:
- первый — куда plane скорее всего полетит
- второй — следующий по приоритету (safety margin)

Это даёт реалистичный preview без блокирования placement'ов на коридорах, по которым plane никогда не полетит этот ход.

## Test plan

- [x] `node --check script.js`
- [x] Оба smoke-теста зелёные
- [ ] **Тестер:** партия → `aiMineDebug()`:
  - `sim_self_hit_other_plane` падает в ~3-4 раза (с 20-36 до 5-10)
  - `accepted > 0` на большинстве ходов
  - AI снова активно ставит мины

## Risk

- Если фикс ослабил **слишком сильно** и AI начнёт взрываться на минах на следующих ходах — расширим top-N до 3 либо поднимем `own_approach_corridor` buffer ещё (отдельным PR).
- Про «уходил в фолбек поведение» — отдельная диагностика, скорее всего НЕ связана с минами (в этой партии `onField` максимум 1).

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_