### PR TITLE
ИИ defensive mines: уменьшить trigger radius 28 → 24

### DIFF
--- a/script.js
+++ b/script.js
@@ -8925,7 +8925,14 @@ const SLIDE_THRESHOLD      = 0.1;
 // Larger hit area for selecting planes with touch/mouse
 const PLANE_TOUCH_RADIUS   = 20;                   // px
 const AA_HIT_RADIUS        = POINT_RADIUS + 5; // slightly larger zone to hit Anti-Aircraft center
-const MINE_TRIGGER_RADIUS  = 28; // v3.2: decoupled from VISUAL_RADIUS+PLANE_DRAW_W/2 (=33). Trigger < hangar-spacing/2 (59/2=29.5) so a mine placed between two parked planes doesn't auto-trigger on neighbors.
+const MINE_TRIGGER_RADIUS  = 24; // v3.3: reduced 28→24 after live-tester feedback —
+// mines too bulky to fit between planes parked on a base; AI also occasionally
+// self-detonated on its own defensive mines. All downstream AI buffers
+// (landing_safe_radius, cluster_radius, anchor_buf, approachBuf) scale from
+// MINE_TRIGGER_RADIUS automatically, so one number recalibrates the whole
+// defensive-mine system. Trade-off: enemies pass slightly closer to mines
+// without detonating. Still < hangar-spacing/2 (59/2=29.5) so a mine between
+// two parked planes does not auto-trigger on neighbors.
 const MINE_PLACEMENT_MIN_DISTANCE = 24; // v3.2: was MINE_SIZE_DEFAULTS.LOGICAL_PX (30). Lowered so 2×24=48 < 59px hangar-gap → mine fits between adjacent parked planes.
 const BOUNCE_FRAMES        = 68;
 // Duration of a full-speed flight on the field (measured in frames)


### PR DESCRIPTION
## Summary

`MINE_TRIGGER_RADIUS`: **28 → 24** (-14%).

## Запрос тестера

> «предлагаю чуть чуть уменьшить зону поражения мин, чтобы было больше возможностей их ставить — например между самолетами на базах чтобы они помещались. самоподрывы случаются.»

## Эффект

**Одно число рекалибрует всю defensive-mine систему** — все downstream AI буферы scale от `MINE_TRIGGER_RADIUS`:

| Буфер | Множитель | Старое | Новое |
|---|---|---|---|
| landing_safe_radius | × 2.0 | 56 | **48** |
| cluster_radius | × 3.0 | 84 | **72** |
| own_approach_corridor (approachBuf) | × 3.5 | 98 | **84** |
| own_objective_vicinity (anchorBuf) | × 1.5 | 42 | **36** |
| trajBuf, ownSafe, futureTrajBuf | × 2.0~2.5 | 56-70 | **48-60** |

Плюс уменьшается зона детонации **для своих** тоже → реже self-trap.

## Инварианты безопасности

- `24 × 2 = 48 < hangar-spacing 59` → мины помещаются между планами на базах.
- `24 = MINE_PLACEMENT_MIN_DISTANCE` → две мины могут стоять впритык не пересекаясь триггерами.

## Trade-off

Враг проходит чуть ближе к мине без детонации (~4 px разница). Но probe placement у нас cell-snapped (CELL_SIZE 0.55 offset) и попадает в меньшую зону для прямых threats — основной hit-rate сохраняется.

## Test plan

- [x] `node --check script.js`
- [x] Оба smoke-теста зелёные
- [ ] **Тестер:** партия →
  - Мины помещаются между планами на базах (визуальная проверка).
  - `accepted > 0` сохраняется.
  - Самоподрывы должны стать редкими или исчезнуть.
  - Если враги легко обходят мины и AI становится беззубым — следующим PR верну до 26 или 28 с уточнением других гейтов.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_