### PR TITLE
ИИ defensive mines: расширить own-safety буферы для multi-turn защиты

### DIFF
--- a/script.js
+++ b/script.js
@@ -27646,10 +27646,15 @@ async function findAiDefensiveMineOpportunityAsync(selectedPlan, context){
         // sizing the safe zone for buffed planes → self-detonation.
         const effRadius = (typeof getMineEffectiveTriggerRadius === "function")
           ? getMineEffectiveTriggerRadius(plane) : MINE_TRIGGER_RADIUS;
-        const landingSafe = Math.max(AI_DEFENSIVE_MINE_LANDING_SAFE_RADIUS, effRadius * 2.0);
-        const trajBuf = Math.max(AI_DEFENSIVE_MINE_OWN_TRAJ_BUFFER, effRadius * 2.5);
-        const ownSafe = Math.max(AI_DEFENSIVE_MINE_OWN_SAFE_RADIUS, effRadius * 2.5);
-        const futureTrajBuf = Math.max(AI_DEFENSIVE_MINE_OWN_FUTURE_TRAJ_BUFFER, effRadius * 2.5);
+        // v3.3 multi-turn safety: buffers raised because self-detonation still
+        // observed after PR #2795/#2797/#2798/#2799. Cause: AI plane that's
+        // *not yet flying* this turn lands within trigger radius of a
+        // freshly-placed mine on a later turn. Wider exclusion now reserves
+        // landing-zone slack for the next 1-2 turns.
+        const landingSafe = Math.max(AI_DEFENSIVE_MINE_LANDING_SAFE_RADIUS, effRadius * 3.0); // was 2.0×
+        const trajBuf = Math.max(AI_DEFENSIVE_MINE_OWN_TRAJ_BUFFER, effRadius * 3.0); // was 2.5×
+        const ownSafe = Math.max(AI_DEFENSIVE_MINE_OWN_SAFE_RADIUS, effRadius * 3.5); // was 2.5×
+        const futureTrajBuf = Math.max(AI_DEFENSIVE_MINE_OWN_FUTURE_TRAJ_BUFFER, effRadius * 3.0); // was 2.5×
         const landingDist = Math.hypot(px - ctx.landing.x, py - ctx.landing.y);
         if(landingDist < landingSafe) { rejects.landing_too_close += 1; continue; }
         if(aiBase && Number.isFinite(aiBase.x)


### PR DESCRIPTION
## Summary

Тестер: «ии всё еще взрывается на своих минах» после серии PR (#2795/#2797/#2798/#2799). Причина — multi-turn проблема: текущие own-safety буферы рассчитаны на same-turn геометрию, на следующих турнах planes движутся и попадают в trigger radius уже стоящих мин.

## Изменения (одна группа буферов)

| Буфер | Старое | Новое (×effRadius=24) |
|---|---|---|
| landingSafe | 2.0× = 48 | **3.0× = 72** |
| trajBuf | 2.5× = 60 | **3.0× = 72** |
| ownSafe | 2.5× = 60 | **3.5× = 84** |
| futureTrajBuf | 2.5× = 60 | **3.0× = 72** |

Чуть менее свободы для placement, но существенно больше slack для следующих 1-2 турнов.

## Test plan

- [x] `node --check script.js`
- [x] Оба smoke-теста зелёные
- [ ] **Тестер:** партия →
  - `accepted > 0` сохраняется (если станет 0 регулярно — снизим до 3.0×/2.5× в следующем PR)
  - **Самоподрывы должны исчезнуть или стать редкими**
  - `aiMineDebug()`: `other_own_too_close` / `own_traj_too_close` / `future_traj_too_close` могут возрасти — это нормально, гейты теперь шире

## Risk

Над-prune. Если AI станет беззубым (мин почти не ставит) → снижу буферы до 3.0× и 2.5× с уточнением.

## Не входит в этот PR

Идея тестера про **мину сбоку от вражеского самолёта при offensive ударе** — это новая тактическая фича (offensive-defensive комбо). Отдельным PR после стабилизации self-trap'a.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_