### PR TITLE
ИИ: mine-aware прицел при offensive ударе (дальний от мины край)

### DIFF
--- a/script.js
+++ b/script.js
@@ -38997,6 +38997,35 @@ function isDirectFinisherScenario(plane, enemy, options = {}){
   return Math.hypot(enemy.x - plane.x, enemy.y - plane.y) <= effectiveRangePx;
 }
 
+// When the AI attacks an enemy that has one of *our own* defensive mines right
+// next to it, aiming dead-center makes the attacker skim the mine and self-
+// detonate. The enemy hitbox is ~36px wide (±18 from center), so we can aim at
+// the edge of the enemy *furthest from the mine* and still score the kill while
+// keeping the flight path away from our own mine. Returns the aim point.
+function computeMineAwareAimPoint(plane, enemy){
+  const fallback = { x: enemy.x, y: enemy.y };
+  const ownColor = plane?.color;
+  if(!ownColor || !Array.isArray(mines) || !Number.isFinite(enemy?.x)) return fallback;
+  let nearestMine = null;
+  let nearestD = Number.POSITIVE_INFINITY;
+  for(const m of mines){
+    if(!m || m.owner !== ownColor) continue;
+    if(!Number.isFinite(m.x) || !Number.isFinite(m.y)) continue;
+    const d = Math.hypot(m.x - enemy.x, m.y - enemy.y);
+    if(d < nearestD){ nearestD = d; nearestMine = m; }
+  }
+  // Only nudge when the mine is in the danger band around the enemy: close
+  // enough that a center-aimed pass would clip its trigger radius.
+  const riskBand = MINE_TRIGGER_RADIUS + 18 + 6;
+  if(!nearestMine || nearestD > riskBand) return fallback;
+  const away = normalizeMineVector(enemy.x - nearestMine.x, enemy.y - nearestMine.y);
+  if(!away) return fallback;
+  // 12px < half-hitbox (18), so the attacker still overlaps the enemy center
+  // on the pass, but the aim point (and thus the path) leans away from the mine.
+  const AIM_EDGE_OFFSET = 12;
+  return { x: enemy.x + away.x * AIM_EDGE_OFFSET, y: enemy.y + away.y * AIM_EDGE_OFFSET };
+}
+
 function findDirectFinisherMove(aiPlanes, enemies, options = {}){
   if(!Array.isArray(aiPlanes) || !Array.isArray(enemies)) return null;
 
@@ -39047,7 +39076,8 @@ function findDirectFinisherMove(aiPlanes, enemies, options = {}){
     for(const enemy of enemies){
       if(!isDirectFinisherScenario(plane, enemy)) continue;
 
-      const move = planPathToPoint(plane, enemy.x, enemy.y, {
+      const aim = computeMineAwareAimPoint(plane, enemy);
+      const move = planPathToPoint(plane, aim.x, aim.y, {
         prioritizeDirectFinisher: true,
         targetEnemy: enemy,
       });


### PR DESCRIPTION
## Summary

Реализация идеи тестера: «целиться в дальний от мины край самолёта, в который попадаем — у нас есть люфт».

Когда AI летит сбивать врага, рядом с которым стоит **наша** defensive mine, прицел в центр заставляет атакующего скользить по мине и детонировать. Хитбокс врага ~36px (±18 от центра), так что можно целиться в **край врага, дальний от мины** — kill сохраняется, а путь держится дальше от мины.

Это **launch-side** фикс (куда летит атакующий), дополняет `own_ricochet_path` гейт из #2801: тот не ставит мину на наш путь, этот уводит путь от уже стоящей мины.

## Реализация

`computeMineAwareAimPoint(plane, enemy)`:
- находит ближайшую **свою** мину к target enemy;
- если она в danger-band (`MINE_TRIGGER_RADIUS + 18 + 6 = 48px`) — смещает aim на **12px к краю врага в сторону ОТ мины**;
- 12 < half-hitbox 18 → атакующий всё ещё перекрывает центр врага на пролёте, kill сохраняется.

Применено в `findDirectFinisherMove` (основной offensive path):
```js
const aim = computeMineAwareAimPoint(plane, enemy);
const move = planPathToPoint(plane, aim.x, aim.y, {...}); // было enemy.x, enemy.y
```

Соответствует примеру тестера: крайний левый враг + мина справа → away-вектор влево → целимся в левый край → держимся левее мины.

## Test plan

- [x] `node --check script.js`
- [x] Оба smoke-теста зелёные
- [ ] **Тестер:** партия →
  - Поставить мину сбоку от врага, дать AI сбить его → атакующий **не** должен детонировать на своей мине.
  - Проверить что врага по-прежнему сбивает (не промахивается из-за смещения).
  - Если начнёт промахиваться — уменьшу `AIM_EDGE_OFFSET` с 12 до 8-10.

## Risk

- При смещении 12px AI может промахнуться по очень мелким/движущимся целям. Mitigation — offset < half-hitbox с запасом 6px.
- Применено только в `findDirectFinisherMove`. Если взрывы при атаке остаются через другой path (`planDirectAttackOrPreparationMove`) — расширим туда же.

## Связь с идеей #2

Это **частично** закладывает фундамент под TODO «мина сбоку от врага при ударе» (CLAUDE.md): теперь атакующий умеет держаться от своей мины. Полная фича #2 (проактивно **ставить** мину сбоку перед ударом) — всё ещё отдельный будущий PR.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_