### PR TITLE
ИИ: launch-гейт против своей мины учитывает рикошеты (корень самоподрывов)

### DIFF
--- a/script.js
+++ b/script.js
@@ -28867,6 +28867,35 @@ function buildFinalMineGateAggressiveFallbackReplan(plannedMove, context = {}, o
   return null;
 }
 
+// Launch-time ricochet-aware own-mine check. The straight start→landing segment
+// used by getMineThreatMetaForSegment ignores that the plane actually flies a
+// bounced path (resolveFlightSurfaceCollision reflects off walls/bricks). A mine
+// on the *bent* part of the real path passes the straight check yet detonates
+// mid-flight on our own mine — this is the persistent self-detonation the
+// placement-side gates couldn't fix. Simulate the real ricochet path (same
+// helper the defensive-mine planner uses) and report whether any own mine sits
+// within the plane's trigger radius of any segment.
+function launchPathHitsOwnMineRicochet(plane, startX, startY, endX, endY){
+  if(!plane?.color || typeof simulateEnemyRicochetTrajectory !== "function") return false;
+  if(!Array.isArray(mines) || mines.length === 0) return false;
+  if(![startX, startY, endX, endY].every(Number.isFinite)) return false;
+  const ownMines = mines.filter((m) => m && m.owner === plane.color && Number.isFinite(m.x) && Number.isFinite(m.y));
+  if(ownMines.length === 0) return false;
+  const triggerR = (typeof getMineEffectiveTriggerRadius === "function")
+    ? getMineEffectiveTriggerRadius(plane) : MINE_TRIGGER_RADIUS;
+  const flightRadius = (typeof getPlaneDangerGeometry === "function")
+    ? (getPlaneDangerGeometry(plane)?.radius || CELL_SIZE * 0.3) : CELL_SIZE * 0.3;
+  const traj = simulateEnemyRicochetTrajectory(startX, startY, endX, endY, { maxBounces: 4, radius: flightRadius });
+  if(!Array.isArray(traj) || traj.length < 2) return false;
+  for(let i = 0; i < traj.length - 1; i += 1){
+    for(const m of ownMines){
+      const d = getDistanceFromPointToSegment(m.x, m.y, traj[i].x, traj[i].y, traj[i + 1].x, traj[i + 1].y);
+      if(d <= triggerR) return true;
+    }
+  }
+  return false;
+}
+
 function getFinalAiLaunchMineThreatCheck(plannedMove){
   const plane = plannedMove?.plane || null;
   const durationSec = Number.isFinite(FIELD_FLIGHT_DURATION_SEC) && FIELD_FLIGHT_DURATION_SEC > 0
@@ -28945,12 +28974,15 @@ function getFinalAiLaunchMineThreatCheck(plannedMove){
         { mineOwner: plane.color },
       )
     : null;
-  const blockedByOwnMine = Boolean(ownMineThreatMeta?.pathHit || ownMineThreatMeta?.landingThreat);
+  const ownMineRicochetHit = launchPathHitsOwnMineRicochet(
+    plane, startPoint.x, startPoint.y, landingPoint.x, landingPoint.y
+  );
+  const blockedByOwnMine = Boolean(ownMineThreatMeta?.pathHit || ownMineThreatMeta?.landingThreat) || ownMineRicochetHit;
   if(blockedByOwnMine){
     return {
       ok: false,
       reason: "path_crosses_own_mine",
-      reasonCode: "final_mine_check_rejected_own_mine",
+      reasonCode: ownMineRicochetHit ? "final_mine_check_rejected_own_mine_ricochet" : "final_mine_check_rejected_own_mine",
       threatClass: "critical_self_mine",
       ownMineThreat: true,
       threatMeta: {
@@ -35565,6 +35597,11 @@ function getGuaranteedAnyLegalLaunch(context){
           if(ownMineMeta && (ownMineMeta.pathHit || ownMineMeta.landingThreat)){
             continue;
           }
+        }
+        // Same ricochet blind-spot as the main launch gate: the straight check
+        // above misses mines on the bounced part of the real flight path.
+        if(launchPathHitsOwnMineRicochet(plane, plane.x, plane.y, landingX, landingY)){
+          continue;
         }
 
         return normalizeFailSafeLaunchCandidate({


### PR DESCRIPTION
## Summary

**Истинный корень** регулярных самоподрывов AI на своих минах. Все предыдущие итерации (#2795/#2797/#2798/#2799/#2800/#2801) чинили **placement** мин — но телеметрия показала что placement-гейты почти не срабатывают (`own_ricochet_path`, `own_approach_corridor`, `sim_self_hit` ≈ 0), а взрывы продолжаются. Значит мины ставятся нормально, а проблема — в **launch-гейте**.

## Цепочка (подтверждена анализом)

1. Самолёт летит **рикошетящей** траекторией (`resolveFlightSurfaceCollision` отражает от стен/кирпичей).
2. Детонация мины проверяется каждый кадр и срабатывает на **своих** минах тоже.
3. **НО** `getFinalAiLaunchMineThreatCheck` и `getGuaranteedAnyLegalLaunch` проверяли свою мину только против **прямого отрезка** start→landing (`getMineThreatMetaForSegment`). Мина на изгибе реального рикошетного пути проходит проверку → детонация в полёте.

Та же слепота к рикошету, что чинили на placement в #2801 — но на launch-стороне.

## Фикс

Новый helper `launchPathHitsOwnMineRicochet(plane, sx,sy,ex,ey)`:
- симулирует реальный bounced-путь через `simulateEnemyRicochetTrajectory` (до 4 отскоков, radius = геометрия самолёта),
- проверяет каждый сегмент против всех **своих** мин (`getDistanceFromPointToSegment <= triggerRadius`).

Применён в обеих точках финализации launch:
1. **`getFinalAiLaunchMineThreatCheck`** — основной гейт (все обычные launch-пути). Новый `reasonCode: final_mine_check_rejected_own_mine_ricochet`.
2. **`getGuaranteedAnyLegalLaunch`** — timeout/fallback резерв.

Чужие мины остаются приемлемы.

## Test plan

- [x] `node --check script.js`
- [x] Оба smoke-теста зелёные
- [ ] **Тестер:** партия где AI раньше регулярно взрывался →
  - самоподрывы должны прекратиться (или стать единичным edge-case)
  - если AI «застывает» (все launch блокируются своими минами) — снизим `maxBounces` до 3 или ограничим проверку ближними минами

## Risk

- **Над-блокировка launch:** если мин много в коридорах, рикошет-пути могут пересекать свои мины во всех направлениях → AI не может запуститься. Mitigation: в `getGuaranteedAnyLegalLaunch` остаётся sweep по 360°/scale, что-то найдётся; если нет — он вернёт null и сработает следующий fallback. Следим по `timeout_deadline` в логах.
- Производительность: helper зовётся на финальной валидации (не в горячем цикле), ~4-сегментная симуляция × N своих мин. Незаметно.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_