### PR TITLE
Revert PR #2804: launch-рикошет-гейт сломал поведение

### DIFF
--- a/script.js
+++ b/script.js
@@ -28867,35 +28867,6 @@ function buildFinalMineGateAggressiveFallbackReplan(plannedMove, context = {}, o
   return null;
 }
 
-// Launch-time ricochet-aware own-mine check. The straight start→landing segment
-// used by getMineThreatMetaForSegment ignores that the plane actually flies a
-// bounced path (resolveFlightSurfaceCollision reflects off walls/bricks). A mine
-// on the *bent* part of the real path passes the straight check yet detonates
-// mid-flight on our own mine — this is the persistent self-detonation the
-// placement-side gates couldn't fix. Simulate the real ricochet path (same
-// helper the defensive-mine planner uses) and report whether any own mine sits
-// within the plane's trigger radius of any segment.
-function launchPathHitsOwnMineRicochet(plane, startX, startY, endX, endY){
-  if(!plane?.color || typeof simulateEnemyRicochetTrajectory !== "function") return false;
-  if(!Array.isArray(mines) || mines.length === 0) return false;
-  if(![startX, startY, endX, endY].every(Number.isFinite)) return false;
-  const ownMines = mines.filter((m) => m && m.owner === plane.color && Number.isFinite(m.x) && Number.isFinite(m.y));
-  if(ownMines.length === 0) return false;
-  const triggerR = (typeof getMineEffectiveTriggerRadius === "function")
-    ? getMineEffectiveTriggerRadius(plane) : MINE_TRIGGER_RADIUS;
-  const flightRadius = (typeof getPlaneDangerGeometry === "function")
-    ? (getPlaneDangerGeometry(plane)?.radius || CELL_SIZE * 0.3) : CELL_SIZE * 0.3;
-  const traj = simulateEnemyRicochetTrajectory(startX, startY, endX, endY, { maxBounces: 4, radius: flightRadius });
-  if(!Array.isArray(traj) || traj.length < 2) return false;
-  for(let i = 0; i < traj.length - 1; i += 1){
-    for(const m of ownMines){
-      const d = getDistanceFromPointToSegment(m.x, m.y, traj[i].x, traj[i].y, traj[i + 1].x, traj[i + 1].y);
-      if(d <= triggerR) return true;
-    }
-  }
-  return false;
-}
-
 function getFinalAiLaunchMineThreatCheck(plannedMove){
   const plane = plannedMove?.plane || null;
   const durationSec = Number.isFinite(FIELD_FLIGHT_DURATION_SEC) && FIELD_FLIGHT_DURATION_SEC > 0
@@ -28974,15 +28945,12 @@ function getFinalAiLaunchMineThreatCheck(plannedMove){
         { mineOwner: plane.color },
       )
     : null;
-  const ownMineRicochetHit = launchPathHitsOwnMineRicochet(
-    plane, startPoint.x, startPoint.y, landingPoint.x, landingPoint.y
-  );
-  const blockedByOwnMine = Boolean(ownMineThreatMeta?.pathHit || ownMineThreatMeta?.landingThreat) || ownMineRicochetHit;
+  const blockedByOwnMine = Boolean(ownMineThreatMeta?.pathHit || ownMineThreatMeta?.landingThreat);
   if(blockedByOwnMine){
     return {
       ok: false,
       reason: "path_crosses_own_mine",
-      reasonCode: ownMineRicochetHit ? "final_mine_check_rejected_own_mine_ricochet" : "final_mine_check_rejected_own_mine",
+      reasonCode: "final_mine_check_rejected_own_mine",
       threatClass: "critical_self_mine",
       ownMineThreat: true,
       threatMeta: {
@@ -35597,11 +35565,6 @@ function getGuaranteedAnyLegalLaunch(context){
           if(ownMineMeta && (ownMineMeta.pathHit || ownMineMeta.landingThreat)){
             continue;
           }
-        }
-        // Same ricochet blind-spot as the main launch gate: the straight check
-        // above misses mines on the bounced part of the real flight path.
-        if(launchPathHitsOwnMineRicochet(plane, plane.x, plane.y, landingX, landingY)){
-          continue;
         }
 
         return normalizeFailSafeLaunchCandidate({


### PR DESCRIPTION
## Summary

**Срочный revert** #2804. После мерджа того PR тестер: «стало хуже, ИИ играет в самоубийство; в одном случае взорвался вообще без мины». Это новый класс симптомов, которого до фикса не было — поведение явно регрессировало.

## Гипотеза почему стало хуже

`launchPathHitsOwnMineRicochet` с `maxBounces=4` строит длинный bounced-путь, пересекающий много поля. Любая своя мина в этом расширенном пути блокирует launch. Когда **все** кандидаты блокированы (типично при 3-6 минах на поле), AI сваливается в всё худшие fallback'и → визуально выглядит как суицид. «Взрыв без мины» — возможно crash в стену в каком-то особо плохом fallback-исходе.

## Возврат

Откатываемся к состоянию до #2804. Взрывы на своих минах были и снова будут, но **суицидов не будет**.

## Корень проблемы остаётся открытым

Архитектурно фикс правильный (рикошет-aware гейт), но реализация слишком жёсткая. Возможные следующие подходы (отдельным PR после анализа):
1. **maxBounces 4 → 1-2** — проверять только первый-второй отскок, остальное считать слишком далёким.
2. **SOFT-гейт вместо HARD** — учитывать риск рикошета в **scoring** трёх candidate launches, не блокировать жёстко. Чтобы fallback'у всегда было куда падать.
3. **Не применять к `getGuaranteedAnyLegalLaunch`** — он реально последний резерв, лучше пусть взорвётся на своей мине чем застрянет.

Но прежде чем экспериментировать — нужно понять что именно тестер видит в «суициде» и «взрыве без мины». Возможно проблема глубже.

## Test plan

- [x] `node --check script.js`
- [x] Оба smoke-теста зелёные
- [ ] **Тестер:** мерджит revert → партия → суицидное поведение должно исчезнуть, AI вернётся к старому поведению (с самоподрывами на минах, но без других регрессов).

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_