### PR TITLE
ИИ: launch-гейт против своей мины (рикошет) — CONSERVATIVE retry

### DIFF
--- a/script.js
+++ b/script.js
@@ -28867,6 +28867,41 @@ function buildFinalMineGateAggressiveFallbackReplan(plannedMove, context = {}, o
   return null;
 }
 
+// Launch-time ricochet-aware own-mine check. The straight start→landing segment
+// used by getMineThreatMetaForSegment ignores that the plane actually flies a
+// bounced path (resolveFlightSurfaceCollision reflects off walls/bricks). A mine
+// on the *bent* part of the real path passes the straight check yet detonates
+// mid-flight on our own mine.
+//
+// CONSERVATIVE retry of PR #2804 (which over-blocked and caused suicides):
+// - maxBounces = 2 (not 4) — covers realistic 1-2 ricochets without long
+//   phantom paths that pretend the plane crosses the whole field.
+// - Used ONLY in the main getFinalAiLaunchMineThreatCheck, NOT in the
+//   getGuaranteedAnyLegalLaunch fallback. If the main gate blocks every
+//   candidate, the fallback will still find *something* with the straight-
+//   line check — worst case the AI lands on a mine, but it never freezes or
+//   suicides into walls.
+function launchPathHitsOwnMineRicochet(plane, startX, startY, endX, endY){
+  if(!plane?.color || typeof simulateEnemyRicochetTrajectory !== "function") return false;
+  if(!Array.isArray(mines) || mines.length === 0) return false;
+  if(![startX, startY, endX, endY].every(Number.isFinite)) return false;
+  const ownMines = mines.filter((m) => m && m.owner === plane.color && Number.isFinite(m.x) && Number.isFinite(m.y));
+  if(ownMines.length === 0) return false;
+  const triggerR = (typeof getMineEffectiveTriggerRadius === "function")
+    ? getMineEffectiveTriggerRadius(plane) : MINE_TRIGGER_RADIUS;
+  const flightRadius = (typeof getPlaneDangerGeometry === "function")
+    ? (getPlaneDangerGeometry(plane)?.radius || CELL_SIZE * 0.3) : CELL_SIZE * 0.3;
+  const traj = simulateEnemyRicochetTrajectory(startX, startY, endX, endY, { maxBounces: 2, radius: flightRadius });
+  if(!Array.isArray(traj) || traj.length < 2) return false;
+  for(let i = 0; i < traj.length - 1; i += 1){
+    for(const m of ownMines){
+      const d = getDistanceFromPointToSegment(m.x, m.y, traj[i].x, traj[i].y, traj[i + 1].x, traj[i + 1].y);
+      if(d <= triggerR) return true;
+    }
+  }
+  return false;
+}
+
 function getFinalAiLaunchMineThreatCheck(plannedMove){
   const plane = plannedMove?.plane || null;
   const durationSec = Number.isFinite(FIELD_FLIGHT_DURATION_SEC) && FIELD_FLIGHT_DURATION_SEC > 0
@@ -28945,12 +28980,15 @@ function getFinalAiLaunchMineThreatCheck(plannedMove){
         { mineOwner: plane.color },
       )
     : null;
-  const blockedByOwnMine = Boolean(ownMineThreatMeta?.pathHit || ownMineThreatMeta?.landingThreat);
+  const ownMineRicochetHit = launchPathHitsOwnMineRicochet(
+    plane, startPoint.x, startPoint.y, landingPoint.x, landingPoint.y
+  );
+  const blockedByOwnMine = Boolean(ownMineThreatMeta?.pathHit || ownMineThreatMeta?.landingThreat) || ownMineRicochetHit;
   if(blockedByOwnMine){
     return {
       ok: false,
       reason: "path_crosses_own_mine",
-      reasonCode: "final_mine_check_rejected_own_mine",
+      reasonCode: ownMineRicochetHit ? "final_mine_check_rejected_own_mine_ricochet" : "final_mine_check_rejected_own_mine",
       threatClass: "critical_self_mine",
       ownMineThreat: true,
       threatMeta: {


### PR DESCRIPTION
## Summary

Вторая попытка после revert #2805. Применяет launch-time рикошет-проверку своих мин **намного аккуратнее**, чтобы избежать суицидов которые вызвал #2804.

## Что изменено по сравнению с #2804

| Параметр | #2804 (плохой) | #2806 (этот) |
|---|---|---|
| `maxBounces` | **4** — длинные phantom-пути | **2** — реалистичные 1-2 отскока |
| `getFinalAiLaunchMineThreatCheck` | Да | Да |
| `getGuaranteedAnyLegalLaunch` | **Да** — fallback тоже блокировался → суицид | **Нет** — fallback гарантированно найдёт launch |

## Почему это безопасно

Худший сценарий: основной гейт блокирует все «хорошие» варианты, fallback `getGuaranteedAnyLegalLaunch` срабатывает с прямой проверкой (как до #2804) — найдёт launch, возможно через изгиб своей мины. То есть **в худшем случае AI вернётся к старому поведению** (изредка взрывается на своей мине), но **никаких суицидов** или «взрывов без мины».

## Test plan

- [x] `node --check script.js`
- [x] Оба smoke-теста зелёные
- [ ] **Тестер:** партия →
  - Никаких суицидов / взрывов без мины (как до #2804).
  - Периодические взрывы на своих минах — должны стать реже (основной гейт ловит большую часть).
  - `aiMineDebug()` не изменится (это launch-side, не placement).
  - В логах console появится `final_mine_check_rejected_own_mine_ricochet` — это новый гейт реально срабатывает.

## Risk

Если **все ещё** слишком жёстко (AI плохо играет, fallback срабатывает часто) → следующий PR сделает SOFT-гейт (penalty в scoring через `estimateMineGateRiskScore`, не hard-block). Если **наоборот** слабо и взрывы регулярны → подниму `maxBounces` до 3 (но не 4).

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_