### PR TITLE
ИИ: вернуть MINE_TRIGGER_RADIUS 24→28 — расхождение с реальным trigger

### DIFF
--- a/script.js
+++ b/script.js
@@ -8925,14 +8925,20 @@ const SLIDE_THRESHOLD      = 0.1;
 // Larger hit area for selecting planes with touch/mouse
 const PLANE_TOUCH_RADIUS   = 20;                   // px
 const AA_HIT_RADIUS        = POINT_RADIUS + 5; // slightly larger zone to hit Anti-Aircraft center
-const MINE_TRIGGER_RADIUS  = 24; // v3.3: reduced 28→24 after live-tester feedback —
-// mines too bulky to fit between planes parked on a base; AI also occasionally
-// self-detonated on its own defensive mines. All downstream AI buffers
-// (landing_safe_radius, cluster_radius, anchor_buf, approachBuf) scale from
-// MINE_TRIGGER_RADIUS automatically, so one number recalibrates the whole
-// defensive-mine system. Trade-off: enemies pass slightly closer to mines
-// without detonating. Still < hangar-spacing/2 (59/2=29.5) so a mine between
-// two parked planes does not auto-trigger on neighbors.
+const MINE_TRIGGER_RADIUS  = 28; // v3.4: restored 24→28 after diagnosing the
+// "AI corrected its route around a mine, but not enough" symptom. Root cause:
+// runtime detonation uses getMineEffectiveTriggerRadius(plane) which returns
+// MINE_VISUAL_RADIUS + halfSpan ≈ 31.5 px — completely independent of this
+// constant. Lowering MINE_TRIGGER_RADIUS to 24 (PR #2799) didn't make mines
+// physically smaller, it just shrank the AI's *safety margin*: AI thought 24+9=
+// 33 px was safe, but actual trigger fires at 31.5 → margin only 1.5 px,
+// literally a wingtip away from self-detonation. With 28 the margin is 28+9=37
+// vs 31.5 → 5.5 px of slack, a much more forgiving buffer for ricochet drift.
+// "Mines between parked planes" wish from PR #2799 was never affected by this
+// constant anyway: isMinePlacementValid's tooCloseToPlane check uses the
+// *effective* trigger, not this constant — so parked-plane spacing stays the
+// same. All downstream AI buffers (landing_safe, cluster, approach, anchor)
+// scale from this constant and now leave proper slack around the real trigger.
 const MINE_PLACEMENT_MIN_DISTANCE = 24; // v3.2: was MINE_SIZE_DEFAULTS.LOGICAL_PX (30). Lowered so 2×24=48 < 59px hangar-gap → mine fits between adjacent parked planes.
 const BOUNCE_FRAMES        = 68;
 // Duration of a full-speed flight on the field (measured in frames)


### PR DESCRIPTION
## Summary

Точный ответ на вопрос тестера «знает ли AI верные размеры мин?» — **не знает**, и это объясняет случай «прицелился, поправился, но недостаточно».

## Корень

**Реальный trigger detonation** в runtime (`handleMineForPlane:42718`):
```js
mineTriggerRadius = getMineEffectiveTriggerRadius(p)
                  = MINE_VISUAL_RADIUS + halfSpan
                  = 15 + ~16.5
                  ≈ 31.5 px
```

**НЕ ЗАВИСИТ от константы `MINE_TRIGGER_RADIUS`.**

**AI safety distance** при mine-avoid:
```js
safeDist = mineDist - MINE_TRIGGER_RADIUS - CELL_SIZE*0.3
         = mineDist - 24 - 9
```

То есть AI отодвигает маршрут на **33 px** от мины думая что это безопасно. Реальный trigger — **31.5**. **Маржа 1.5 px** — буквально краешком крыла, как и описал тестер.

## Почему #2799 ухудшил

PR #2799 уменьшил `MINE_TRIGGER_RADIUS` 28 → 24, считая что это «уменьшит зону детонации». На самом деле:
- Реальная зона детонации **не изменилась** (она через `getMineEffectiveTriggerRadius` ≈ 31.5).
- Уменьшился только **AI safety buffer**, который теперь слишком тонкий.

## Фикс

`MINE_TRIGGER_RADIUS` 24 → 28. Safety margin становится `28 + 9 - 31.5 = 5.5 px` вместо 1.5 px. AI не задевает мины «краешком».

**Запрос #2799** («мины между планами на базах помещаются») никогда не зависел от этой константы — `isMinePlacementValid:tooCloseToPlane` использует *effective* trigger (31.5), не константу. С 24 или с 28 мины не помещаются впритык к парканым планам.

## Test plan

- [x] `node --check script.js`
- [x] Оба smoke-теста зелёные
- [ ] **Тестер:** партия →
  - Случаи «отодвинулся, но недостаточно» должны исчезнуть.
  - Рикошетные взрывы (отдельный класс) — следим, при необходимости расширим PR #2806.

## Полное решение на будущее

Использовать `getMineEffectiveTriggerRadius(plane)` везде в AI buffer'ах (placement gates, safety distances) вместо константы. Это уберёт несоответствие полностью и автоматически учтёт WINGS buff для buffed планов. Большая работа — отдельным PR если константная правка окажется недостаточной.

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_