### PR TITLE
ИИ: расширить isHighValueNarrowCorridorGoal на основные классы целей

### DIFF
--- a/script.js
+++ b/script.js
@@ -38253,7 +38253,19 @@ function planPathToPoint(plane, tx, ty, options = {}){
       const isHighValueNarrowCorridorGoal = goalNameForNarrowCorridor.includes("attack")
         || goalNameForNarrowCorridor.includes("eliminate")
         || goalNameForNarrowCorridor.includes("flag")
-        || goalNameForNarrowCorridor.includes("cargo");
+        || goalNameForNarrowCorridor.includes("cargo")
+        || goalNameForNarrowCorridor.includes("enemy")
+        || goalNameForNarrowCorridor.includes("base")
+        || goalNameForNarrowCorridor.includes("center")
+        || goalNameForNarrowCorridor.includes("direct")
+        || goalNameForNarrowCorridor.includes("finisher")
+        || goalNameForNarrowCorridor.includes("intercept")
+        || goalNameForNarrowCorridor.includes("advance")
+        || goalNameForNarrowCorridor.includes("opening")
+        || goalNameForNarrowCorridor.includes("defense")
+        || goalNameForNarrowCorridor.includes("ricochet")
+        || goalNameForNarrowCorridor.includes("pickup")
+        || goalNameForNarrowCorridor.includes("progress");
       const narrowCorridorDensityBoost = Math.max(0, Math.min(52, Math.round(routeNearbyColliderCount * 1.7)));
       const narrowCorridorGoalBoost = isHighValueNarrowCorridorGoal ? 26 : 0;
       const narrowCorridorNoProgressRejectLimit = isHighValueNarrowCorridorGoal ? 8 : 6;


### PR DESCRIPTION
## Что меняется

`isHighValueNarrowCorridorGoal` (script.js:38253) теперь покрывает реальные классы целей, а не только `attack/eliminate/flag/cargo`.

Добавлено в матчер: `enemy`, `base`, `center`, `direct`, `finisher`, `intercept`, `advance`, `opening`, `defense`, `ricochet`, `pickup`, `progress`.

## Почему

Из анализа `aiLastMoveDebug()` дампов: цели вроде `simple_step2_center`, `direct_finisher`, `emergency_base_*`, `cautious_progress_to_enemy_base`, `opening_center_control` и `attack_enemy_plane` (как `goalName` без слова "attack" в части decisionReason'ов) — **не попадали** в high-value матчер. Они получали:

- `narrowCorridorGoalBoost = 0` (вместо +26 к budget)
- `narrowCorridorNoProgressRejectLimit = 6` (вместо 8)

На плотных полях `narrowCorridorAttemptBudgetLimit` (96-146) исчерпывался без найденного пути → `narrow_corridor_early_stop__attempt_budget_exceeded` → planner возвращал degenerate near-zero move → `ai_min_launch_scale_applied` инфлирует до 5 клеток в произвольном направлении → «полетел в стенку».

## Что не меняется

- Алгоритм поиска не трогаем.
- Clamp `[96, 236]` сохранён — лишние попытки только когда поиск иначе бы сдался.
- Все нецелевые `planPathToPoint` без `meta.goalName/decisionReason` остаются на base budget (truly opportunistic searches).

## Тесты

- `node --check script.js` ✅
- `node scripts/smoke-ai-prelaunch-real-inventory-execution.js` ✅
- `node scripts/smoke-ai-prelaunch-selected-sequence-execution.js` ✅

## Test plan

- [ ] Сыграть партию, проверить визуально что коротких «в стенку» ходов стало меньше
- [ ] Через `aiLastMoveDebug({limit: 10})` проверить что `narrow_corridor_early_stop__attempt_budget_exceeded` сократился
- [ ] Убедиться что атакующие ходы (`simple_step2_attack_enemy`) не деградировали

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_