### PR TITLE
ИИ: cargo planner пробует top-3 груза, а не только nearest

### DIFF
--- a/script.js
+++ b/script.js
@@ -15560,9 +15560,11 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
     const buildBestPlanForPlane = async (launchReadyPlane) => {
       const effectiveFlightRangeCells = getEffectiveFlightRangeCells(launchReadyPlane);
       const maxFlightDistancePx = Math.max(1, effectiveFlightRangeCells * CELL_SIZE);
-      const nearestCargo = readyCargo
+      const sortedCargos = readyCargo
         .map((cargo) => ({ cargo, center: getCargoVisualCenter(cargo), d: dist(launchReadyPlane, getCargoVisualCenter(cargo)) }))
-        .sort((a, b) => a.d - b.d)[0] || null;
+        .sort((a, b) => a.d - b.d)
+        .slice(0, 3);
+      const nearestCargo = sortedCargos[0] || null;
 
       const centerZoneNearest = getNearestPointInCenterControlZone(launchReadyPlane);
       const centerDx = centerZoneNearest.x - launchReadyPlane.x;
@@ -15629,7 +15631,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
         planDistance = selectedPlan ? Math.hypot(selectedPlan.landingX - launchReadyPlane.x, selectedPlan.landingY - launchReadyPlane.y) : Number.POSITIVE_INFINITY;
       }
 
-      if(nearestCargo){
+      if(sortedCargos.length > 0){
         // Yield before the cargo-route enumeration (collectAiCargoRouteCandidates calls sync
         // planPathToPoint multiple times and is the second heavy sync chunk per plane).
         await aiCoopMaybeYield();
@@ -15639,40 +15641,53 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
           enemies: enemyPlanes,
           homeBase: getBaseAnchor(launchReadyPlane.color),
         };
-        const cargoRouteCandidates = collectAiCargoRouteCandidates(launchReadyPlane, nearestCargo.cargo, cargoContext);
-        const bestCargoCandidate = cargoRouteCandidates
-          .filter((candidate) => {
-            const riskInfo = candidate?.riskInfo;
-            const favorableInfo = candidate?.favorableInfo;
-            const acceptedByBaseRisk = Boolean(riskInfo?.isSafePath) && Number.isFinite(riskInfo?.totalRisk) && riskInfo.totalRisk <= AI_CARGO_RISK_ACCEPTANCE;
-            const acceptedByFavorableOverride = Boolean(riskInfo?.isSafePath) && favorableInfo?.isFavorableCargo === true;
-            return acceptedByBaseRisk || acceptedByFavorableOverride;
-          })
-          .sort((a, b) => {
-            const aCargoScore = (
-              (a?.favorableInfo?.isFavorableCargo ? 1.5 : 0)
-              + Math.min(2.5, Math.max(0, (a?.usefulCarryAfterPickup || 0) / Math.max(1, CELL_SIZE * 0.7)))
-              + Math.min(1.2, Math.max(0, getAiCargoRicochetPreferenceBonus(a) / Math.max(1, CELL_SIZE * 0.18)))
-              - Math.min(2.2, Math.max(0, a?.riskInfo?.totalRisk || 0) * 2.2)
-            );
-            const bCargoScore = (
-              (b?.favorableInfo?.isFavorableCargo ? 1.5 : 0)
-              + Math.min(2.5, Math.max(0, (b?.usefulCarryAfterPickup || 0) / Math.max(1, CELL_SIZE * 0.7)))
-              + Math.min(1.2, Math.max(0, getAiCargoRicochetPreferenceBonus(b) / Math.max(1, CELL_SIZE * 0.18)))
-              - Math.min(2.2, Math.max(0, b?.riskInfo?.totalRisk || 0) * 2.2)
-            );
-            if(Math.abs(aCargoScore - bCargoScore) > 1e-6){
-              return bCargoScore - aCargoScore;
-            }
-            return (a?.move?.totalDist || Number.POSITIVE_INFINITY) - (b?.move?.totalDist || Number.POSITIVE_INFINITY);
-          })[0] || null;
 
-        if(bestCargoCandidate?.move){
+        let bestCargoCandidate = null;
+        let bestCargoEntry = null;
+        for(const cargoEntry of sortedCargos){
+          await aiCoopMaybeYield();
+          if(!isAiTurnStillApplicable()) return null;
+          const cargoRouteCandidates = collectAiCargoRouteCandidates(launchReadyPlane, cargoEntry.cargo, cargoContext);
+          const candidate = cargoRouteCandidates
+            .filter((c) => {
+              const riskInfo = c?.riskInfo;
+              const favorableInfo = c?.favorableInfo;
+              const acceptedByBaseRisk = Boolean(riskInfo?.isSafePath) && Number.isFinite(riskInfo?.totalRisk) && riskInfo.totalRisk <= AI_CARGO_RISK_ACCEPTANCE;
+              const acceptedByFavorableOverride = Boolean(riskInfo?.isSafePath) && favorableInfo?.isFavorableCargo === true;
+              return acceptedByBaseRisk || acceptedByFavorableOverride;
+            })
+            .sort((a, b) => {
+              const aCargoScore = (
+                (a?.favorableInfo?.isFavorableCargo ? 1.5 : 0)
+                + Math.min(2.5, Math.max(0, (a?.usefulCarryAfterPickup || 0) / Math.max(1, CELL_SIZE * 0.7)))
+                + Math.min(1.2, Math.max(0, getAiCargoRicochetPreferenceBonus(a) / Math.max(1, CELL_SIZE * 0.18)))
+                - Math.min(2.2, Math.max(0, a?.riskInfo?.totalRisk || 0) * 2.2)
+              );
+              const bCargoScore = (
+                (b?.favorableInfo?.isFavorableCargo ? 1.5 : 0)
+                + Math.min(2.5, Math.max(0, (b?.usefulCarryAfterPickup || 0) / Math.max(1, CELL_SIZE * 0.7)))
+                + Math.min(1.2, Math.max(0, getAiCargoRicochetPreferenceBonus(b) / Math.max(1, CELL_SIZE * 0.18)))
+                - Math.min(2.2, Math.max(0, b?.riskInfo?.totalRisk || 0) * 2.2)
+              );
+              if(Math.abs(aCargoScore - bCargoScore) > 1e-6){
+                return bCargoScore - aCargoScore;
+              }
+              return (a?.move?.totalDist || Number.POSITIVE_INFINITY) - (b?.move?.totalDist || Number.POSITIVE_INFINITY);
+            })[0] || null;
+
+          if(candidate?.move){
+            bestCargoCandidate = candidate;
+            bestCargoEntry = cargoEntry;
+            break;
+          }
+        }
+
+        if(bestCargoCandidate?.move && bestCargoEntry){
           const cargoMove = {
             plane: launchReadyPlane,
             landingX: launchReadyPlane.x + (bestCargoCandidate.move.vx || 0) * FIELD_FLIGHT_DURATION_SEC,
             landingY: launchReadyPlane.y + (bestCargoCandidate.move.vy || 0) * FIELD_FLIGHT_DURATION_SEC,
-            targetPoint: nearestCargo.center,
+            targetPoint: bestCargoEntry.center,
             decisionReason: "simple_step2_pickup_cargo",
             goalName: "simple_step2_cargo",
             whyChosen: bestCargoCandidate.usedRicochet
@@ -15687,7 +15702,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
 
           const cargoPlanDistance = Number.isFinite(bestCargoCandidate.move.totalDist)
             ? bestCargoCandidate.move.totalDist
-            : nearestCargo.d;
+            : bestCargoEntry.d;
           const shouldPreferCargoOverAttack = !bestAttackCandidate || cargoPlanDistance <= planDistance + CELL_SIZE * 0.25;
 
           if(shouldPreferCargoOverAttack){


### PR DESCRIPTION
## Что меняется

`buildBestPlanForPlane` (script.js:15563-15565) брал ТОЛЬКО `nearestCargo` (sort + [0]) и пробовал к нему 5 route targets. Если все 5 маршрутов проваливались — cargo planner возвращал null → AI откатывался на center control.

Теперь берём top-3 ближайших груза, перебираем подряд, `break` на первом у которого есть acceptable route.

## Почему

Реальный кейс из дампа `aiLastMoveDebug`:

- Plane (34, 108), 3 наших живых, 2 врага, **6 грузов** в зоне (47-193, 269-421)
- Ближайший груз (47, 286) — путь к нему блокирован препятствиями
- Cargo planner для (47,286) получил все 5 reject'ов: `pickup_cargo_direct` → `narrow_corridor_early_stop__attempt_budget_exceeded` + `blocked_path__direct_only`, `toward_home_base` → `insufficient_progress`, `side_wall_ricochet_left/right` → `direct_blocked`
- AI откатился на `simple_step2_center` с totalDist 105px (~1.7 клетки вниз)
- **Остальные 5 грузов AI даже не пытался** под другим углом

Пользователь справедливо отметил: «он просто подтащился к центру. зачем? почему? так не должно быть. это выглядит глупо».

## Cost

- До 3x вызовов `collectAiCargoRouteCandidates` per plane per turn
- Между итерациями стоит `aiCoopMaybeYield` чтобы не зажирать кадр
- В большинстве ходов цикл завершится на первой итерации (если nearest достижим), так что overhead = 0
- Только когда nearest проваливается, идёт 2-я и 3-я итерация — там где сейчас AI просто сдавался

## Тесты

- `node --check script.js` ✅
- `node scripts/smoke-ai-prelaunch-real-inventory-execution.js` ✅
- `node scripts/smoke-ai-prelaunch-selected-sequence-execution.js` ✅

## Test plan

- [ ] Сыграть партию на карте с препятствиями между планом и ближайшими грузами
- [ ] Проверить через `aiLastMoveDebug` что когда плейн не идёт за nearest, теперь идёт за 2-м/3-м грузом, а не на center control

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_