### PR TITLE
ИИ: убрать animation freeze в cargo routes (yield между targets)

### DIFF
--- a/script.js
+++ b/script.js
@@ -9872,6 +9872,37 @@ function collectAiCargoRouteCandidates(plane, cargo, context){
   return candidates;
 }
 
+// Async-вариант для hot-path в buildBestPlanForPlane. Yield'ит между route
+// targets (5+ steps), чтобы single-cargo enumeration не блокировала кадр
+// на 400-500мс. Каждый buildAiCargoRouteCandidate сам по себе ~80-150мс,
+// поэтому yield BETWEEN targets разбивает на куски в пределах frame budget.
+async function collectAiCargoRouteCandidatesAsync(plane, cargo, context){
+  const cargoCenter = getCargoVisualCenter(cargo);
+  const directCargoTarget = {
+    name: "pickup_cargo_direct",
+    targetX: cargoCenter.x,
+    targetY: cargoCenter.y,
+    targetKind: "short",
+    preferredRouteClass: null,
+    usedRicochetHint: false,
+  };
+  const allTargets = [directCargoTarget, ...buildAiCargoLongRangeTargets(plane, cargo, context)];
+
+  const candidates = [];
+  for(const target of allTargets){
+    await aiCoopMaybeYield();
+    const routeClassOrder = getAiCargoRouteClassOrder(target);
+    for(const routeClass of routeClassOrder){
+      const candidate = buildAiCargoRouteCandidate(plane, cargo, context, target, routeClass);
+      if(candidate && candidate.cargoPickedOnPath){
+        candidates.push(candidate);
+      }
+    }
+  }
+
+  return candidates;
+}
+
 function updateCargoState(now = performance.now()){
   if(cargoState.length === 0){
     return;
@@ -15251,6 +15282,10 @@ function aiCoopResetBudget(){
   aiCoopBudgetStartedAt = (typeof performance !== "undefined" && typeof performance.now === "function")
     ? performance.now()
     : Date.now();
+  // Diagnostic accuracy: aiThinkingCheckpointAt должен ехать вместе с budget,
+  // иначе sync-chunk measurement включает время setTimeout/await до reset'а
+  // и репортит фейковый "freeze" размером с искусственную задержку.
+  aiThinkingCheckpointAt = aiCoopBudgetStartedAt;
 }
 async function aiCoopMaybeYield(){
   const nowMs = (typeof performance !== "undefined" && typeof performance.now === "function")
@@ -15768,7 +15803,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
         for(const cargoEntry of sortedCargos){
           await aiCoopMaybeYield();
           if(!isAiTurnStillApplicable()){ aiThinkingTimingStageEnd("cargo_routes"); return null; }
-          const cargoRouteCandidates = collectAiCargoRouteCandidates(launchReadyPlane, cargoEntry.cargo, cargoContext);
+          const cargoRouteCandidates = await collectAiCargoRouteCandidatesAsync(launchReadyPlane, cargoEntry.cargo, cargoContext);
           const candidate = cargoRouteCandidates
             .filter((c) => {
               const riskInfo = c?.riskInfo;


### PR DESCRIPTION
## Анализ дампа

Игрок прислал `aiThinkingDebug({limit: 5})`:

| Турн | totalMs | longestSyncMs | cargo_routes total | Симптом |
|---|---|---|---|---|
| 1 | 4046 | 942 (unstaged) | 581+587+599 = 1.8с | 3 фриза по ~580мс |
| 3 | 4947 | 914 (unstaged) | 411×3 = 1.2с | 3 фриза по ~410мс |
| 5 | **7896** | 918 (unstaged) | 1314+1476+1306 = **4.1с** | 9 чанков по 411-502мс |
| 7 | 5613 | 913 (unstaged) | 1285+426 = 1.7с | 2 фриза |
| 9 | 3047 | 912 (unstaged) | 462+478 = 0.94с | 2 фриза |

**Главное:** каждый `collectAiCargoRouteCandidates` вызов = sync-блок 411-502мс. Это **25-30 пропущенных кадров** = визуальный freeze. PR #2815 умножил это на top-3 cargos.

«Unstaged» 912мс — артефакт diagnostic'а: `aiCoopResetBudget()` ресетит budget но не trackingчекпойнт, поэтому setTimeout 300мс + initialization засчитывался в chunk.

## Фиксы

### 1. `collectAiCargoRouteCandidatesAsync` (script.js:9874)
Новый async-вариант с `await aiCoopMaybeYield()` между route targets (5+ steps на cargo). Используется только в hot-path `buildBestPlanForPlane`. Существующий sync-вариант сохранён для 5 неактивных call-site'ов (где он не в hot loop).

### 2. `aiCoopResetBudget()` (script.js:15281)
Теперь синхронно ресетит `aiThinkingCheckpointAt = aiCoopBudgetStartedAt`. Diagnostic больше не репортит setTimeout как фейковый freeze.

## Ожидание

После следующего `aiThinkingDebug`:
- НЕ должно быть chunk'ов > 16мс с `label: "cargo_routes"`
- `unstaged` чанки должны измениться: либо исчезнуть, либо обнажить реальный pre-loop sync block если он есть.

Если cargo_routes останется тяжёлым stage но без больших чанков — это значит мы убрали анимационные просадки, но total время AI всё ещё тратит. Следующий PR — оптимизация САМОГО pathfinding'а (cache, quick-reject).

## Out of scope

- Total time AI thinking — оптимизация planPathToPoint / narrow_corridor.
- 5 неактивных call-site'ов `collectAiCargoRouteCandidates` — они не в hot-path, рефакторить смысла нет.

## Тесты

- `node --check script.js` ✅
- `node scripts/smoke-ai-prelaunch-real-inventory-execution.js` ✅
- `node scripts/smoke-ai-prelaunch-selected-sequence-execution.js` ✅

## Test plan

- [ ] Сыграть несколько ходов AI
- [ ] `aiThinkingDebug({limit: 5})` — проверить что **нет** chunk'ов > 16мс с `label: "cargo_routes"`
- [ ] Визуально — нет ли просадок анимаций при думании AI

https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4B744NGzpd6hnZ9ueJKZL)_