### PR TITLE
fix: убрать рывки анимации во время спекулятивного вычисления AI [superseded by #2824]

### DIFF
--- a/script.js
+++ b/script.js
@@ -9909,6 +9909,7 @@ async function collectAiCargoRouteCandidatesAsync(plane, cargo, context){
     await aiCoopMaybeYield();
     const routeClassOrder = getAiCargoRouteClassOrder(target);
     for(const routeClass of routeClassOrder){
+      await aiCoopMaybeYield();
       const candidate = buildAiCargoRouteCandidate(plane, cargo, context, target, routeClass);
       if(candidate && candidate.cargoPickedOnPath){
         candidates.push(candidate);
@@ -15187,6 +15188,7 @@ function invalidateAiPlanningState(reason = "unspecified"){
   if(reason === "round_reset" || reason === "game_reset"){
     _speculativeAiCompute = null;
     _pendingSpawnedCargo = null;
+    _speculativeComputeActive = false;
   }
   if(reason === "turn_advanced" || reason === "round_reset" || reason === "game_reset"){
     resetAiTurnTimingState();
@@ -15333,7 +15335,7 @@ async function aiCoopMaybeYield(){
   const nowMs = (typeof performance !== "undefined" && typeof performance.now === "function")
     ? performance.now()
     : Date.now();
-  if(nowMs - aiCoopBudgetStartedAt < AI_COOP_FRAME_BUDGET_MS){
+  if(!_speculativeComputeActive && nowMs - aiCoopBudgetStartedAt < AI_COOP_FRAME_BUDGET_MS){
     aiThinkingTimingNoteYieldOrCheckpoint(nowMs, false);
     return;
   }
@@ -15365,6 +15367,9 @@ function isAiTurnStillApplicable(){
 // границе) — кэш отбрасывается и AI считает заново как обычно.
 let _speculativeAiCompute = null;
 let _pendingSpawnedCargo = null;
+// true while the speculative promise is running; makes aiCoopMaybeYield always yield so that
+// rAF-based animation can paint between every computation unit during player flight.
+let _speculativeComputeActive = false;
 
 // Пересечение отрезка [from→to] с AABB box, расширенным на (padX,padY) с каждой стороны.
 // Зеркалит логику doesCargoIntersectBeneficialZoneAlongSegment, но для произвольного box (самолёт).
@@ -15494,13 +15499,18 @@ async function startSpeculativeAiCompute(launchedPlane, launchVx, launchVy){
 
   const routeResults = new Map();
   const promise = (async () => {
-    for(const aiPlane of bluePlanes){
-      const planeRoutes = new Map();
-      for(const cargo of speculativeCargo){
-        const candidates = await collectAiCargoRouteCandidatesAsync(aiPlane, cargo, context);
-        planeRoutes.set(cargo, candidates);
+    _speculativeComputeActive = true;
+    try {
+      for(const aiPlane of bluePlanes){
+        const planeRoutes = new Map();
+        for(const cargo of speculativeCargo){
+          const candidates = await collectAiCargoRouteCandidatesAsync(aiPlane, cargo, context);
+          planeRoutes.set(cargo, candidates);
+        }
+        routeResults.set(aiPlane, planeRoutes);
       }
-      routeResults.set(aiPlane, planeRoutes);
+    } finally {
+      _speculativeComputeActive = false;
     }
   })();
 
@@ -15572,8 +15582,11 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
 
     // Забираем спекулятивный кэш one-shot (вычислен во время полёта игрока) и валидируем предсказание.
     // Await почти мгновенный, если вычисление успело за время полёта; иначе ждём остаток.
+    // Сбрасываем _speculativeComputeActive ДО await: если спекуляция не успела, остаток считается
+    // с нормальным (6мс) бюджетом, а не forced-yield — иначе he-бюджетный yield замедлит AI-ход.
     const _turnSpeculative = _speculativeAiCompute;
     _speculativeAiCompute = null;
+    _speculativeComputeActive = false;
     let _turnSpecCache = null;
     if(_turnSpeculative){
       try{ await _turnSpeculative.promise; } catch(e){ /* при ошибке считаем заново */ }


### PR DESCRIPTION
## Проблема

Спекулятивное вычисление хода AI (PR #2822) давало рывки самолёту игрока во время полёта. Каждый `buildAiCargoRouteCandidate` вызов (~30мс) блокировал главный поток, а четыре вызова подряд (один `target` × 4 `routeClass`) давали ~120мс sync-блок. За 120мс браузер пропускал 7–8 кадров анимации.

## Изменения

### 1. Флаг `_speculativeComputeActive`

Новая булева переменная, `true` пока выполняется спекулятивный promise. Сбрасывается в `finally` promise'а и принудительно в начале хода AI (`scheduleComputerMoveWithCargoGate`) и при `round_reset`/`game_reset`.

### 2. `aiCoopMaybeYield` — forced yield в спекулятивном режиме

```js
if(!_speculativeComputeActive && nowMs - aiCoopBudgetStartedAt < AI_COOP_FRAME_BUDGET_MS){
  return; // без yield
}
```

Когда `_speculativeComputeActive === true`, проверка бюджета пропускается → каждый `await aiCoopMaybeYield()` всегда делает yield через `requestAnimationFrame`, давая браузеру возможность отрисовать кадр.

### 3. Yield внутри цикла `routeClass`

В `collectAiCargoRouteCandidatesAsync` добавлен `await aiCoopMaybeYield()` перед каждым `buildAiCargoRouteCandidate`:

```
До: outer yield + [4 класса × 30мс = 120мс блок]
После: outer yield + [yield + 30мс] × 4 = кадр анимации между каждым классом
```

### Итоговый ритм во время спекуляции

```
[yield→rAF=16мс] [30мс sync] [yield→rAF] [30мс sync] …
```

~22fps вместо ~7fps. Каждый 30мс sync-блок пропускает ≤2 кадра (вместо 7–8). Вычисление может выйти за пределы полёта игрока (1.51с) — пользователь принял это как допустимое.

### Нормальный ход AI не затронут

При `_speculativeComputeActive === false` поведение `aiCoopMaybeYield` идентично предыдущему. Дополнительный inner-loop yield при нормальном ходе срабатывает только при превышении 6мс бюджета (т.е. после каждых ~2 routeClass), добавляя ~350мс к `cargo_routes` при cache-miss — приемлемо, т.к. cache-miss редок.

## Тест-план

- [ ] Самолёт игрока летит без рывков (ощутимо плавнее, чем до этого фикса)
- [ ] `aiThinkingDebug({limit:5})` — `cargo_routes` остаётся ≈0мс при кэш-хите
- [ ] AI ходит без заметной задержки после приземления игрока
- [ ] При cache-miss (например, игрок подбирает cargo во время полёта) AI пересчитывает нормально

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LzDpaejmtQcrw9HkSYa2m

---
_Generated by [Claude Code](https://claude.ai/code/session_019LzDpaejmtQcrw9HkSYa2m)_