### PR TITLE
perf(ai): убрать искусственные задержки хода AI (300мс + 900мс)

### DIFF
--- a/script.js
+++ b/script.js
@@ -15070,10 +15070,16 @@ function resetLastPlayerMoveCommitMeta(){
     finishedAtMs: 0,
   };
 }
-const AI_MOVE_INITIAL_DELAY_MS = 300;
+// Без искусственной паузы перед стартом планирования: ход AI занимает ровно столько,
+// сколько считает. setTimeout(0) сохраняет async-границу (тяжёлый compute не блокирует
+// кадр gameDraw, в котором сел самолёт игрока), но не добавляет видимого ожидания.
+const AI_MOVE_INITIAL_DELAY_MS = 0;
 const AI_MOVE_CARGO_RETRY_DELAY_MS = 200;
 const AI_MOVE_CARGO_WAIT_TIMEOUT_MS = 1800;
-const AI_TURN_MIN_RELEASE_BUDGET_MS = 900;
+// Без минимального пола на момент релиза: AI отпускает самолёт, как только готов план
+// и доиграла аим-анимация (telegraphy). minReleaseAt=0 → releaseDueAt = естественная
+// длина прицеливания (см. Math.max(plannedReleaseDueAt, minReleaseAt) в createAiLaunchSession).
+const AI_TURN_MIN_RELEASE_BUDGET_MS = 0;
 function resetAiTurnTimingState(){
   aiTurnTimingState = {
     turnStartedAt: 0,


### PR DESCRIPTION
## Идея

Ход AI должен занимать ровно столько, сколько идёт вычисление и аим-анимация — без искусственного padding'а. Сейчас к каждому ходу AI добавлялись две намеренные задержки, которые не были «думаньем»:

## Изменения

**`AI_MOVE_INITIAL_DELAY_MS: 300 → 0`**
Idle-пауза перед стартом планирования (`setTimeout` в `scheduleComputerMoveWithCargoGate`). Главный поток в эти 300мс простаивал — это была чистая пауза «для вида», не вычисление. `setTimeout(0)` сохраняет async-границу (тяжёлый compute по-прежнему не блокирует кадр `gameDraw`, в котором сел самолёт игрока), но видимого ожидания не добавляет. Smoke-тесты и так гоняются с этим значением = 0.

**`AI_TURN_MIN_RELEASE_BUDGET_MS: 900 → 0`**
Минимальный пол на момент релиза: AI не отпускал самолёт раньше 900мс после посадки игрока, даже если посчитал ход быстро. `minReleaseAt` используется только в `Math.max(plannedReleaseDueAt, minReleaseAt)` внутри `createAiLaunchSession`; `session.minReleaseAt` больше нигде не читается. С 0 `releaseDueAt` равен естественной длине прицеливания.

**Не тронуто:** аим-анимация (telegraphy) — визуальный «прицел» AI остаётся как был.

## Результат

- AI начинает думать сразу после посадки игрока (минус 300мс ожидания)
- При быстром расчёте AB ходит быстро (минус до ~900мс пола), при долгом — столько, сколько считает
- Поведение: «сколько думает, столько и думает»

## Проверка

- `node -c script.js` — синтаксис OK
- Smoke-тесты: 2 проходящих (`prelaunch-real-inventory`, `prelaunch-selected-sequence`) проходят и с правкой; 3 падающих падают **идентично на базовом коммите** (предсуществующие фейлы, не связаны с этим PR)
- В браузере: ход AI ощутимо отзывчивее, аим-анимация на месте

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LzDpaejmtQcrw9HkSYa2m

---
_Generated by [Claude Code](https://claude.ai/code/session_019LzDpaejmtQcrw9HkSYa2m)_