### PR TITLE
AI: рикошет-добивание перед фолбеком «в центр»

### DIFF
--- a/script.js
+++ b/script.js
@@ -15691,7 +15691,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
         if(!plane || !enemy) return null;
         if(!Number.isFinite(maxFlightDistancePx) || maxFlightDistancePx <= 0) return null;
         const simulated = await findBestSimulatedShotAsync(plane, enemy, {
-          maxBounces: 3,
+          maxBounces: Number.isFinite(simulationOptions.maxBounces) ? simulationOptions.maxBounces : 3,
           coarseAngleStepDeg: simulationOptions.coarseAngleStepDeg,
           fineAngleStepDeg: simulationOptions.fineAngleStepDeg,
           coarseScaleStep: simulationOptions.coarseScaleStep,
@@ -15797,6 +15797,55 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       let planTier = 1;
       let planDistance = Number.isFinite(bestAttackCandidate?.enemyDistance) ? bestAttackCandidate.enemyDistance : Number.POSITIVE_INFINITY;
 
+      let lastResortAttackFound = false;
+      if(!selectedPlan && prioritizedEnemiesForPlane.length){
+        // No normal (<=3 bounce) shot connected. Before degrading to a dumb straight
+        // "center control" hop, try HARDER for a ricochet on the nearest enemy:
+        // more bounces + finer angle/scale sampling. Cheap because this only runs
+        // when the standard pass found nothing (typically the last plane or two),
+        // and it is capped to the single nearest enemy.
+        const nearestEnemyEntry = prioritizedEnemiesForPlane[0];
+        aiThinkingTimingStageStart("attack_sim_last_resort");
+        await aiCoopMaybeYield();
+        if(!isAiTurnStillApplicable()){ aiThinkingTimingStageEnd("attack_sim_last_resort"); return null; }
+        const lastResortMove = await buildSimulatedEnemyCandidate(
+          launchReadyPlane,
+          nearestEnemyEntry.enemy,
+          maxFlightDistancePx,
+          {
+            maxBounces: 5,
+            coarseAngleStepDeg: 6,
+            fineAngleStepDeg: 2,
+            coarseScaleStep: 0.05,
+            fineScaleStep: 0.02,
+            seedCount: 12,
+            coarsePoolSize: 28,
+          }
+        );
+        aiThinkingTimingStageEnd("attack_sim_last_resort");
+        if(lastResortMove){
+          // Retag for telemetry so the self-analyzer report distinguishes this from a
+          // normal first-pass hit.
+          lastResortMove.decisionReason = lastResortMove.routeClass === "ricochet"
+            ? "simple_step2_ricochet_enemy_last_resort"
+            : "simple_step2_direct_enemy_last_resort";
+          lastResortMove.whyChosen = "last_resort_deep_ricochet_before_center_control";
+          selectedPlan = lastResortMove;
+          planTier = 2; // attack(1) > last-resort attack(2) > center(3); cargo stays 1
+          planDistance = Number.isFinite(nearestEnemyEntry.enemyDistance)
+            ? nearestEnemyEntry.enemyDistance
+            : Number.POSITIVE_INFINITY;
+          lastResortAttackFound = true;
+          logAiDecision("simple_step2_last_resort_attack", {
+            reasonCode: lastResortMove.decisionReason,
+            planeId: launchReadyPlane?.id ?? null,
+            enemyId: nearestEnemyEntry.enemy?.id ?? null,
+            routeClass: lastResortMove.routeClass,
+            bounceCount: lastResortMove.bounceCount ?? null,
+          });
+        }
+      }
+
       if(!selectedPlan){
         selectedPlan = buildMoveTowardTarget(launchReadyPlane, centerTarget, maxFlightDistancePx, {
           decisionReason: "simple_step2_center_control",
@@ -15896,7 +15945,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
         ...selectedPlan,
         planTier,
         planDistance,
-        hasDirectEnemy: Boolean(bestAttackCandidate),
+        hasDirectEnemy: Boolean(bestAttackCandidate) || lastResortAttackFound,
         readyCargoCount: readyCargo.length,
       };
     };

--- a/scripts/smoke-ai-last-resort-ricochet.js
+++ b/scripts/smoke-ai-last-resort-ricochet.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+'use strict';
+
+// Smoke test: AI's last-resort deeper ricochet search.
+//
+// Verifies that when the normal shot simulation (<=3 bounces) finds NO hit on
+// the enemy, the per-plane planner does NOT immediately fall back to the dumb
+// straight "center control" hop. Instead it runs one deeper ricochet search
+// (maxBounces 5, finer sampling) and, if that connects, launches that attack.
+//
+// The selector is the nested closure buildBestPlanForPlane inside
+// scheduleComputerMoveWithCargoGate, so we run the whole scheduler against a
+// mocked context and capture the planned move handed to
+// issueAIMoveFromDoComputerMove. The scheduler body is async (setTimeout ->
+// async fn), so we capture and await that promise.
+
+const fs = require('fs');
+const vm = require('vm');
+
+function extractFunctionSource(source, fnName){
+  const signature = `function ${fnName}(`;
+  const start = source.indexOf(signature);
+  if(start === -1) throw new Error(`Function not found in script.js: ${fnName}`);
+  const signatureEnd = source.indexOf(')', start);
+  const bodyStart = source.indexOf('{', signatureEnd);
+  let depth = 0;
+  for(let i = bodyStart; i < source.length; i += 1){
+    const ch = source[i];
+    if(ch === '{') depth += 1;
+    if(ch === '}') depth -= 1;
+    if(depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`Function body end not found for: ${fnName}`);
+}
+
+function assert(condition, message){
+  if(!condition) throw new Error(message);
+}
+
+const source = fs.readFileSync('script.js', 'utf8');
+const scheduleSrc = extractFunctionSource(source, 'scheduleComputerMoveWithCargoGate');
+
+const bluePlane = { id: 'blue-1', color: 'blue', x: 50, y: 10 };
+const greenEnemy = { id: 'green-1', color: 'green', x: 50, y: 90 };
+
+const capturedMoves = [];
+const simCalls = [];
+let pendingPromise = null;
+let deepPassHits = true; // toggled per scenario below
+
+const context = {
+  Math,
+  Number,
+  Boolean,
+  Array,
+  Object,
+  JSON,
+  console,
+  performance: { now: () => 0 },
+  AI_MOVE_INITIAL_DELAY_MS: 0,
+  AI_MOVE_CARGO_RETRY_DELAY_MS: 0,
+  FIELD_FLIGHT_DURATION_SEC: 1,
+  CELL_SIZE: 10,
+  FIELD_TOP: 0,
+  FIELD_HEIGHT: 100,
+  AI_DEFENSIVE_MINE_ENABLED: false,
+  isGameOver: false,
+  gameMode: 'computer',
+  turnColors: ['blue'],
+  turnIndex: 0,
+  aiLaunchSession: null,
+  aiMoveScheduled: false,
+  aiRoundState: {},
+  points: [bluePlane, greenEnemy],
+  flyingPoints: [],
+  cargoState: [],
+  settings: { flagsMode: false },
+  INVENTORY_ITEM_TYPES: { FUEL: 'fuel', MINE: 'mine', DYNAMITE: 'dynamite' },
+
+  // cooperative-yield + timing instrumentation (no-ops for the test)
+  markAiTurnStarted: () => {},
+  aiCoopResetBudget: () => {},
+  aiCoopMaybeYield: async () => {},
+  isAiTurnStillApplicable: () => true,
+  aiThinkingTimingStageStart: () => {},
+  aiThinkingTimingStageEnd: () => {},
+  aiYieldToNextFrame: async () => {},
+  logAiDecision: () => {},
+
+  // world helpers
+  hasAnimatingCargo: () => false,
+  getBaseAnchor: () => ({ x: 50, y: 100 }),
+  getAvailableFlagsByColor: () => [],
+  isPlaneLaunchStateReady: () => true,
+  isPlaneTargetable: () => true,
+  dist: (a, b) => Math.hypot((a?.x || 0) - (b?.x || 0), (a?.y || 0) - (b?.y || 0)),
+  getCargoVisualCenter: (cargo) => ({ x: cargo.x || 0, y: cargo.y || 0 }),
+  getEffectiveFlightRangeCells: () => 8,
+  getPlaneEffectiveRangePx: () => 80,
+  getAiFlightRangeProfile: () => ({ flightDistancePx: 80 }),
+  // Center target >= 5 cells (CELL_SIZE*5 = 50px) away so the center-control
+  // move is a valid genuine fallback rather than being rejected as too short.
+  getNearestPointInCenterControlZone: () => ({ x: 50, y: 75 }),
+  getNearestReachableCenterControlPoint: () => ({ x: 50, y: 75 }),
+  isPathClear: () => true,
+  getMineThreatMetaForSegment: () => null,
+  buildAiShotSimulationQualityProfile: () => ({
+    coarseAngleStepDeg: 6,
+    fineAngleStepDeg: 2,
+    coarseScaleStep: 0.08,
+    fineScaleStep: 0.03,
+    seedCount: 8,
+    coarsePoolSize: 20,
+    maxEnemyCandidatesPerPlane: 3,
+    profileName: 'smoke',
+  }),
+
+  // The crux: normal pass (maxBounces 3) misses; deep pass (maxBounces 5) hits
+  // via a ricochet.
+  findBestSimulatedShotAsync: async (plane, target, options) => {
+    simCalls.push(options?.maxBounces);
+    if(options?.maxBounces === 5 && deepPassHits){
+      return {
+        score: 0.9,
+        sim: {
+          hitTarget: true,
+          bounceCount: 2,
+          predictedOutcome: 'target_hit_after_ricochet',
+          launchVector: { dx: 0, dy: 1, scale: 0.8 },
+        },
+      };
+    }
+    return null; // normal first pass (and, when deepPassHits is false, the deep pass too)
+  },
+
+  // inventory enhancement -> empty so dynamite/fuel/mine replan sections skip
+  buildAiSelectedPlanInventoryEnhancements: () => [],
+
+  issueAIMoveFromDoComputerMove: (_ctx, plannedMove, meta) => {
+    if(meta?.source === 'simple_step2_selector'){
+      capturedMoves.push(plannedMove);
+      return { selected: true, reason: 'ok' };
+    }
+    return { selected: false, reason: `unexpected_source_${meta?.source}` };
+  },
+
+  setTimeout(fn){ pendingPromise = fn(); return 1; },
+};
+
+vm.createContext(context);
+vm.runInContext(scheduleSrc, context);
+
+async function runScenario(){
+  capturedMoves.length = 0;
+  simCalls.length = 0;
+  pendingPromise = null;
+  context.aiMoveScheduled = false;
+  context.aiLaunchSession = null;
+  context.scheduleComputerMoveWithCargoGate();
+  await pendingPromise;
+  return capturedMoves[0] || null;
+}
+
+(async () => {
+  // Scenario 1: deep ricochet pass connects -> attack instead of center hop.
+  deepPassHits = true;
+  const hitMove = await runScenario();
+
+  assert(simCalls.includes(3), 'Expected a normal shot-sim pass with maxBounces 3.');
+  assert(simCalls.includes(5), 'Expected a last-resort deep shot-sim pass with maxBounces 5.');
+
+  assert(hitMove, 'Expected exactly one simple_step2_selector launch attempt.');
+  assert(hitMove.plane === bluePlane, 'Expected the blue plane to be the launching plane.');
+  assert(
+    hitMove.decisionReason === 'simple_step2_ricochet_enemy_last_resort',
+    `Expected last-resort ricochet decisionReason, got "${hitMove.decisionReason}".`
+  );
+  assert(
+    hitMove.goalName === 'simple_step2_attack_enemy',
+    `Expected attack goal, got "${hitMove.goalName}".`
+  );
+  assert(hitMove.routeClass === 'ricochet', `Expected ricochet routeClass, got "${hitMove.routeClass}".`);
+  assert(hitMove.hasDirectEnemy === true, 'Expected hasDirectEnemy to be true for the last-resort attack.');
+
+  // Scenario 2: deep pass also misses -> the AI must still fall back to the
+  // center-control move (fallback chain intact, not regressed).
+  deepPassHits = false;
+  const fallbackMove = await runScenario();
+
+  assert(simCalls.includes(5), 'Expected the deep pass to still be attempted when it ultimately misses.');
+  assert(fallbackMove, 'Expected a center-control launch when no shot connects.');
+  assert(
+    fallbackMove.decisionReason === 'simple_step2_center_control',
+    `Expected center-control fallback when no shot connects, got "${fallbackMove.decisionReason}".`
+  );
+
+  console.log('Smoke test passed: last-resort ricochet preferred over center hop; center-control fallback intact.');
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Проблема

Когда у ИИ оставался последний самолёт (или пара) и обычная симуляция выстрела (≤3 отскоков) **не находила** попадания по врагу, планировщик сразу сваливался в `simple_step2_center_control` — короткий **прямой** рывок к ближайшей точке центральной зоны, который упирается носом в стену. Это читалось как «тупо полетел в стенку», хотя игрок видел очевидный рикошет по зелёному самолёту.

Из отчёта (turn 8): финальное решение — `goal: simple_step2_center`, `routeClass: direct`, `vx:0, vy:98.47` (прямо вниз ~149px ≈ 5 клеток) → в стену.

## Что сделано

Перед тем как уйти в center-control, делаем **один более глубокий поиск рикошета** (`maxBounces: 5`, мельче шаг угла/мощности) по ближайшему достижимому врагу. Если отскок попадает — бьём им вместо тупого прямого рывка.

- `buildSimulatedEnemyCandidate` теперь учитывает override `maxBounces` (по умолчанию 3 — для существующих вызовов поведение не меняется). `findBestSimulatedShotAsync` уже пробрасывает `maxBounces` вниз, доп. обвязки не нужно.
- Глубокий проход запускается **только** когда обычный проход ничего не нашёл (обычно последний самолёт-два) и ограничен **одним** ближайшим врагом → стоимость ограничена; защищён существующими `aiCoopMaybeYield` / `isAiTurnStillApplicable`.
- Новый порядок приоритета на самолёт: атака(1) / груз(1) > рикошет-добивание(2) > center control(3). Center-control остаётся настоящим последним фолбеком, если и глубокий поиск промахнулся.
- Телеметрия: `simple_step2_(ricochet|direct)_enemy_last_resort` + лог-решение `simple_step2_last_resort_attack` для self-analyzer.

## Не входит в этот PR
Переделка самого center-control в рикошет/дальний манёвр («умный заход в центр») — по решению не делаем в этом PR.

## Проверка

Добавлен `scripts/smoke-ai-last-resort-ricochet.js` (по образцу `smoke-ai-selected-plan-handoff.js`, async-aware):
- **Сценарий 1**: глубокий рикошет попадает → выбран `simple_step2_ricochet_enemy_last_resort` (goal `simple_step2_attack_enemy`, routeClass `ricochet`), а НЕ center-control.
- **Сценарий 2**: глубокий проход тоже промахнулся → ИИ корректно уходит в `simple_step2_center_control` (цепочка фолбеков не сломана).

```
$ node scripts/smoke-ai-last-resort-ricochet.js
Smoke test passed: last-resort ricochet preferred over center hop; center-control fallback intact.
```

Остальные рабочие `smoke-ai-*` проходят. (3 теста — `smoke-ai-selected-plan-handoff`, `smoke-ai-forced-non-skip-last-chance`, `smoke-ai-temporary-item-candidate` — падали **до** этого изменения: устарели после миграции планировщика на async; этим PR не затронуты.)

### Ручная проверка в игре
Свести ИИ к последнему самолёту, врага поставить так, чтобы прямой выстрел был перекрыт кирпичом, а рикошет от стены достаёт. Включить self-analyzer (`window.aiFailFast`) и сделать ход — в отчёте финальное решение должно стать `*_last_resort` рикошетом с реальным вектором в полосу отскока, а не `simple_step2_center_control` с коротким прямым `vy` в стену.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_