### PR TITLE
AI: тянуться к грузу + умный заход в центр (фолбек последнего самолёта)

### DIFF
--- a/script.js
+++ b/script.js
@@ -15589,6 +15589,58 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       };
     };
 
+    // Center-control move that doesn't just nose a short stub into the wall.
+    // Tries the direct hop (existing behaviour) AND ricochet/gap routes toward
+    // the true center anchor — planPathToPoint returns only wall-safe routes, so
+    // a bounce that actually reaches the center beats a stub that stops at the
+    // wall face. Picks whichever lands closest to the center anchor.
+    const buildCenterApproachMove = (plane, directCenterTarget, maxFlightDistancePx) => {
+      const anchor = getCenterControlAnchor();
+      const candidates = [];
+      const directMove = buildMoveTowardTarget(plane, directCenterTarget, maxFlightDistancePx, {
+        decisionReason: "simple_step2_center_control",
+        goalName: "simple_step2_center",
+        whyChosen: "no_realistic_direct_enemy_hit_center_preferred",
+      });
+      if(directMove) candidates.push({ ...directMove, routeClass: "direct", bounceCount: 0 });
+      if(Number.isFinite(anchor?.x) && Number.isFinite(anchor?.y)){
+        for(const rc of ["ricochet", "gap"]){
+          const m = planPathToPoint(plane, anchor.x, anchor.y, {
+            goalName: "simple_step2_center",
+            decisionReason: `simple_step2_center_control_${rc}`,
+            routeClass: rc,
+          });
+          const landing = m ? getAiMoveLandingPoint({ plane, ...m }) : null;
+          if(!m || !landing) continue;
+          const finalDistPx = Math.hypot(landing.x - plane.x, landing.y - plane.y);
+          // Same min-move gate as buildMoveTowardTarget (no sub-5-cell stutter).
+          if(finalDistPx < CELL_SIZE * 5) continue;
+          candidates.push({
+            plane,
+            landingX: landing.x,
+            landingY: landing.y,
+            targetPoint: anchor,
+            decisionReason: `simple_step2_center_control_${rc}`,
+            goalName: "simple_step2_center",
+            whyChosen: `center_control_via_${rc}_avoids_wall`,
+            routeClass: rc,
+            bounceCount: Number.isFinite(m.bounceCount) ? m.bounceCount : 0,
+          });
+        }
+      }
+      if(!candidates.length) return null;
+      // Best center control = lands closest to the center anchor; tie-break by
+      // fewer bounces, then by more ground covered.
+      candidates.sort((a, b) => {
+        const da = Math.hypot(a.landingX - anchor.x, a.landingY - anchor.y);
+        const db = Math.hypot(b.landingX - anchor.x, b.landingY - anchor.y);
+        if(Math.abs(da - db) > CELL_SIZE * 0.5) return da - db;
+        if((a.bounceCount || 0) !== (b.bounceCount || 0)) return (a.bounceCount || 0) - (b.bounceCount || 0);
+        return Math.hypot(b.landingX - plane.x, b.landingY - plane.y) - Math.hypot(a.landingX - plane.x, a.landingY - plane.y);
+      });
+      return candidates[0];
+    };
+
     const buildGuaranteedAdvanceMove = (plane) => {
       const profile = getAiFlightRangeProfile(plane);
       const maxFlightDistancePx = Math.max(1, Number.isFinite(profile?.flightDistancePx) ? profile.flightDistancePx : (CELL_SIZE * 6));
@@ -15847,11 +15899,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       }
 
       if(!selectedPlan){
-        selectedPlan = buildMoveTowardTarget(launchReadyPlane, centerTarget, maxFlightDistancePx, {
-          decisionReason: "simple_step2_center_control",
-          goalName: "simple_step2_center",
-          whyChosen: "no_realistic_direct_enemy_hit_center_preferred",
-        });
+        selectedPlan = buildCenterApproachMove(launchReadyPlane, centerTarget, maxFlightDistancePx);
         planTier = 3;
         planDistance = selectedPlan ? Math.hypot(selectedPlan.landingX - launchReadyPlane.x, selectedPlan.landingY - launchReadyPlane.y) : Number.POSITIVE_INFINITY;
       }
@@ -15869,11 +15917,16 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
 
         let bestCargoCandidate = null;
         let bestCargoEntry = null;
+        // Per-cargo candidates kept for the relaxed cargo-reach fallback below.
+        // Only fully populated when no SAFE cargo broke the loop early (i.e. the
+        // exact situation where the fallback is needed) — no extra pathfinding.
+        const cachedCargoCandidates = [];
         aiThinkingTimingStageStart("cargo_routes");
         for(const cargoEntry of sortedCargos){
           await aiCoopMaybeYield();
           if(!isAiTurnStillApplicable()){ aiThinkingTimingStageEnd("cargo_routes"); return null; }
           const cargoRouteCandidates = await collectAiCargoRouteCandidatesAsync(launchReadyPlane, cargoEntry.cargo, cargoContext);
+          cachedCargoCandidates.push({ entry: cargoEntry, candidates: cargoRouteCandidates });
           const candidate = cargoRouteCandidates
             .filter((c) => {
               const riskInfo = c?.riskInfo;
@@ -15936,6 +15989,46 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
             selectedPlan = cargoMove;
             planTier = 1;
             planDistance = cargoPlanDistance;
+          }
+        }
+
+        // Relaxed cargo-reach: no enemy shot (normal or last-resort) AND no SAFE
+        // cargo accepted -> lean toward the nearest NAVIGABLE cargo route anyway
+        // instead of holding center ("если врага нет — хотя бы к грузу тянется").
+        if(!bestCargoCandidate && !bestAttackCandidate && !lastResortAttackFound){
+          let reachCandidate = null;
+          let reachEntry = null;
+          for(const { entry, candidates } of cachedCargoCandidates){
+            const best = candidates
+              .filter((c) => c?.move
+                && Boolean(c?.riskInfo?.isSafePath)
+                && (!Number.isFinite(c?.riskInfo?.totalRisk) || c.riskInfo.totalRisk <= AI_CARGO_REACH_RISK_ACCEPTANCE))
+              .sort((a, b) => (a?.move?.totalDist || Number.POSITIVE_INFINITY) - (b?.move?.totalDist || Number.POSITIVE_INFINITY))[0] || null;
+            if(best?.move){
+              reachCandidate = best;
+              reachEntry = entry;
+              break; // sortedCargos is nearest-first
+            }
+          }
+          if(reachCandidate?.move && reachEntry){
+            selectedPlan = {
+              plane: launchReadyPlane,
+              landingX: launchReadyPlane.x + (reachCandidate.move.vx || 0) * FIELD_FLIGHT_DURATION_SEC,
+              landingY: launchReadyPlane.y + (reachCandidate.move.vy || 0) * FIELD_FLIGHT_DURATION_SEC,
+              targetPoint: reachEntry.center,
+              decisionReason: "simple_step2_cargo_reach",
+              goalName: "simple_step2_cargo",
+              whyChosen: "no_enemy_shot_lean_toward_cargo",
+              routeClass: reachCandidate.move.routeClass || reachCandidate.move.candidateClass || "direct",
+              bounceCount: Number.isFinite(reachCandidate.move.bounceCount) ? reachCandidate.move.bounceCount : 0,
+            };
+            planTier = 2; // last-resort attack(2) > cargo-reach(2, mutually exclusive) > center(3)
+            planDistance = Number.isFinite(reachCandidate.move.totalDist) ? reachCandidate.move.totalDist : reachEntry.d;
+            logAiDecision("simple_step2_cargo_reach", {
+              planeId: launchReadyPlane?.id ?? null,
+              routeClass: selectedPlan.routeClass,
+              totalRisk: Number.isFinite(reachCandidate.riskInfo?.totalRisk) ? Number(reachCandidate.riskInfo.totalRisk.toFixed(2)) : null,
+            });
           }
         }
       }
@@ -19482,6 +19575,12 @@ const AI_MODES = Object.freeze({
 
 const AI_EARLY_GAME_TURN_LIMIT = 6;
 const AI_CARGO_RISK_ACCEPTANCE = 0.42;
+// Relaxed acceptance used ONLY as a last resort: when the AI found no enemy shot
+// and no "safe" cargo route, it still leans toward the nearest NAVIGABLE cargo
+// route ("хотя бы к грузу тянется") instead of holding center. 1 = ignore the
+// soft enemy-response risk cap entirely (path must still be navigable). Dial to
+// ~0.7 to only chase cargo when interception risk is moderate.
+const AI_CARGO_REACH_RISK_ACCEPTANCE = 1;
 const AI_CARGO_RISK_YELLOW_ZONE_MARGIN = 0.12;
 const AI_CARGO_FAVORABLE_DISTANCE = MAX_DRAG_DISTANCE * 0.72;
 const AI_CARGO_IMMEDIATE_THREAT_DISTANCE = ATTACK_RANGE_PX * 0.9;

--- a/scripts/smoke-ai-last-resort-ricochet.js
+++ b/scripts/smoke-ai-last-resort-ricochet.js
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 'use strict';
 
-// Smoke test: AI's last-resort deeper ricochet search.
+// Smoke test: AI last-plane fallback chain.
 //
-// Verifies that when the normal shot simulation (<=3 bounces) finds NO hit on
-// the enemy, the per-plane planner does NOT immediately fall back to the dumb
-// straight "center control" hop. Instead it runs one deeper ricochet search
-// (maxBounces 5, finer sampling) and, if that connects, launches that attack.
+// Covers, in priority order, what the per-plane planner does when the normal
+// shot simulation (<=3 bounces) finds NO hit on the enemy:
+//   A. deeper ricochet search (maxBounces 5) connects        -> attack
+//   B. nothing connects, no cargo, no ricochet to center     -> direct center-control
+//   C. no shot, only a navigable-but-risky cargo route        -> cargo_reach
+//   D. no shot, no cargo, a ricochet reaches center closer    -> smart center (ricochet)
 //
 // The selector is the nested closure buildBestPlanForPlane inside
 // scheduleComputerMoveWithCargoGate, so we run the whole scheduler against a
@@ -43,10 +45,14 @@ const scheduleSrc = extractFunctionSource(source, 'scheduleComputerMoveWithCargo
 const bluePlane = { id: 'blue-1', color: 'blue', x: 50, y: 10 };
 const greenEnemy = { id: 'green-1', color: 'green', x: 50, y: 90 };
 
+const cargoItem = { id: 'cargo-1', state: 'ready', x: 20, y: 60 };
+
 const capturedMoves = [];
 const simCalls = [];
 let pendingPromise = null;
-let deepPassHits = true; // toggled per scenario below
+let deepPassHits = true;            // toggled per scenario below
+let centerRicochetAvailable = false; // planPathToPoint ricochet route toward center
+let unsafeCargoAvailable = false;    // a navigable cargo route that exceeds the safe risk cap
 
 const context = {
   Math,
@@ -104,6 +110,35 @@ const context = {
   getNearestReachableCenterControlPoint: () => ({ x: 50, y: 75 }),
   isPathClear: () => true,
   getMineThreatMetaForSegment: () => null,
+
+  // smart-center approach reuse
+  getCenterControlAnchor: () => ({ x: 50, y: 50 }),
+  getAiMoveLandingPoint: (move) => (move && move.plane && Number.isFinite(move.vx) && Number.isFinite(move.vy)
+    ? { x: move.plane.x + move.vx * 1, y: move.plane.y + move.vy * 1 }
+    : null),
+  planPathToPoint: (plane, tx, ty, opts) => {
+    if(opts?.routeClass === 'ricochet' && centerRicochetAvailable){
+      // lands at (50, 62): 52px travel (passes the >=5-cell gate) and closer to
+      // the center anchor (50,50) than the direct stub at (50,75).
+      return { vx: 0, vy: 52, bounceCount: 1, routeClass: 'ricochet' };
+    }
+    return null;
+  },
+
+  // cargo-route reuse
+  AI_CARGO_RISK_ACCEPTANCE: 0.42,
+  AI_CARGO_REACH_RISK_ACCEPTANCE: 1,
+  getAiCargoRicochetPreferenceBonus: () => 0,
+  collectAiCargoRouteCandidatesAsync: async () => (unsafeCargoAvailable
+    ? [{
+        move: { vx: -30, vy: 50, totalDist: 58.3, routeClass: 'ricochet', bounceCount: 1 },
+        riskInfo: { isSafePath: true, totalRisk: 0.9 }, // navigable but exceeds the 0.42 safe cap
+        favorableInfo: { isFavorableCargo: false },
+        usefulCarryAfterPickup: 0,
+        usedRicochet: true,
+      }]
+    : []),
+
   buildAiShotSimulationQualityProfile: () => ({
     coarseAngleStepDeg: 6,
     fineAngleStepDeg: 2,
@@ -150,7 +185,11 @@ const context = {
 vm.createContext(context);
 vm.runInContext(scheduleSrc, context);
 
-async function runScenario(){
+async function runScenario({ deep = false, ricochetCenter = false, unsafeCargo = false } = {}){
+  deepPassHits = deep;
+  centerRicochetAvailable = ricochetCenter;
+  unsafeCargoAvailable = unsafeCargo;
+  context.cargoState = unsafeCargo ? [cargoItem] : [];
   capturedMoves.length = 0;
   simCalls.length = 0;
   pendingPromise = null;
@@ -162,39 +201,51 @@ async function runScenario(){
 }
 
 (async () => {
-  // Scenario 1: deep ricochet pass connects -> attack instead of center hop.
-  deepPassHits = true;
-  const hitMove = await runScenario();
-
-  assert(simCalls.includes(3), 'Expected a normal shot-sim pass with maxBounces 3.');
-  assert(simCalls.includes(5), 'Expected a last-resort deep shot-sim pass with maxBounces 5.');
-
-  assert(hitMove, 'Expected exactly one simple_step2_selector launch attempt.');
-  assert(hitMove.plane === bluePlane, 'Expected the blue plane to be the launching plane.');
+  // Scenario A: deep ricochet pass connects -> attack instead of center hop.
+  const hitMove = await runScenario({ deep: true });
+  assert(simCalls.includes(3), 'A: expected a normal shot-sim pass with maxBounces 3.');
+  assert(simCalls.includes(5), 'A: expected a last-resort deep shot-sim pass with maxBounces 5.');
+  assert(hitMove, 'A: expected exactly one simple_step2_selector launch attempt.');
+  assert(hitMove.plane === bluePlane, 'A: expected the blue plane to be the launching plane.');
   assert(
     hitMove.decisionReason === 'simple_step2_ricochet_enemy_last_resort',
-    `Expected last-resort ricochet decisionReason, got "${hitMove.decisionReason}".`
+    `A: expected last-resort ricochet decisionReason, got "${hitMove.decisionReason}".`
   );
+  assert(hitMove.goalName === 'simple_step2_attack_enemy', `A: expected attack goal, got "${hitMove.goalName}".`);
+  assert(hitMove.routeClass === 'ricochet', `A: expected ricochet routeClass, got "${hitMove.routeClass}".`);
+  assert(hitMove.hasDirectEnemy === true, 'A: expected hasDirectEnemy to be true.');
+
+  // Scenario B: no shot, no cargo, no ricochet route to center -> direct
+  // center-control fallback (chain intact, not regressed).
+  const centerDirect = await runScenario({ deep: false });
+  assert(simCalls.includes(5), 'B: expected the deep pass to still be attempted.');
+  assert(centerDirect, 'B: expected a center-control launch when no shot connects.');
   assert(
-    hitMove.goalName === 'simple_step2_attack_enemy',
-    `Expected attack goal, got "${hitMove.goalName}".`
+    centerDirect.decisionReason === 'simple_step2_center_control',
+    `B: expected direct center-control fallback, got "${centerDirect.decisionReason}".`
   );
-  assert(hitMove.routeClass === 'ricochet', `Expected ricochet routeClass, got "${hitMove.routeClass}".`);
-  assert(hitMove.hasDirectEnemy === true, 'Expected hasDirectEnemy to be true for the last-resort attack.');
 
-  // Scenario 2: deep pass also misses -> the AI must still fall back to the
-  // center-control move (fallback chain intact, not regressed).
-  deepPassHits = false;
-  const fallbackMove = await runScenario();
-
-  assert(simCalls.includes(5), 'Expected the deep pass to still be attempted when it ultimately misses.');
-  assert(fallbackMove, 'Expected a center-control launch when no shot connects.');
+  // Scenario C: no enemy shot, cargo route exists but exceeds the SAFE risk cap
+  // -> lean toward cargo ("cargo_reach") instead of holding center.
+  const cargoReach = await runScenario({ deep: false, unsafeCargo: true });
+  assert(cargoReach, 'C: expected a launch when an unsafe cargo route exists.');
   assert(
-    fallbackMove.decisionReason === 'simple_step2_center_control',
-    `Expected center-control fallback when no shot connects, got "${fallbackMove.decisionReason}".`
+    cargoReach.decisionReason === 'simple_step2_cargo_reach',
+    `C: expected cargo_reach when no shot and only an unsafe cargo route, got "${cargoReach.decisionReason}".`
   );
+  assert(cargoReach.goalName === 'simple_step2_cargo', `C: expected cargo goal, got "${cargoReach.goalName}".`);
 
-  console.log('Smoke test passed: last-resort ricochet preferred over center hop; center-control fallback intact.');
+  // Scenario D: no shot, no cargo, a ricochet route lands closer to center than
+  // the direct stub -> smart center prefers the ricochet.
+  const centerRicochet = await runScenario({ deep: false, ricochetCenter: true });
+  assert(centerRicochet, 'D: expected a center-control launch.');
+  assert(
+    centerRicochet.decisionReason === 'simple_step2_center_control_ricochet',
+    `D: expected smart center to pick the ricochet route, got "${centerRicochet.decisionReason}".`
+  );
+  assert(centerRicochet.routeClass === 'ricochet', `D: expected ricochet routeClass, got "${centerRicochet.routeClass}".`);
+
+  console.log('Smoke test passed: last-resort ricochet + cargo-reach + smart center; center-control fallback intact.');
 })().catch((err) => {
   console.error(err);
   process.exit(1);


### PR DESCRIPTION
## Контекст

Продолжение #2828 (рикошет-добивание). Две правки поведения ИИ с последним самолётом, когда удара по врагу нет.

## 1. Тянуться к грузу, если врага не достать

Грузовой планировщик принимал маршрут только под мягким порогом риска перехвата (`AI_CARGO_RISK_ACCEPTANCE = 0.42`) — поэтому далёкий груз или груз рядом с врагом отвергался, и ИИ держал центр.

Теперь: когда **нет удара по врагу** (ни обычного, ни last-resort) **и** нет «безопасного» груза — ИИ всё равно тянется к ближайшему **проходимому** маршруту к грузу («если врага нет — хотя бы к грузу тянется»), тег `simple_step2_cargo_reach`.

- Порог вынесен в новую константу `AI_CARGO_REACH_RISK_ACCEPTANCE` (по умолчанию `1` = игнорировать мягкий порог риска; путь всё равно должен быть проходим). Легко убавить до ~0.7, если в плейтесте слишком жадно.
- Переиспользует уже посчитанные кандидаты грузовых маршрутов — **без доп. pathfinding**.

> ⚠️ Развилку «насколько рисково тянуться» хотел уточнить вопросом, но инструмент подтверждения в тот момент падал с transport-ошибкой. Поставил дефолт = «тянуться, даже если рисково» (ровно по формулировке «хотя бы тянется»); это одна константа — скажи, если убавить.

## 2. Умный заход в центр

`buildCenterApproachMove` заменяет прямой-только хоп: помимо direct он спрашивает у `planPathToPoint` маршруты **ricochet/gap** к центру (по построению не влетают в стену) и выбирает тот, что приземляется **ближе к центру**. Вместо «носом в стену и встал» самолёт отскакивает от неё и реально доходит до центра. Если рикошет-маршрута нет — тот же прямой ход, что и раньше (плюс теперь покрыт случай, когда `centerTarget` был `null`).

## Приоритет на самолёт
атака / безопасный груз (1) > last-resort рикошет ИЛИ cargo-reach (2) > умный center control (3).

## Проверка

`scripts/smoke-ai-last-resort-ricochet.js` расширен до 4 сценариев:
- **A**: глубокий рикошет попал → атака;
- **B**: ничего не попало, груза/рикошет-в-центр нет → прямой `simple_step2_center_control` (цепочка фолбеков цела);
- **C**: удара нет, есть проходимый, но рисковый груз → `simple_step2_cargo_reach` (не центр);
- **D**: удара/груза нет, рикошет к центру ближе прямого → `simple_step2_center_control_ricochet`.

```
$ node scripts/smoke-ai-last-resort-ricochet.js
Smoke test passed: last-resort ricochet + cargo-reach + smart center; center-control fallback intact.
```

Остальные рабочие `smoke-ai-*` проходят (те же 3 теста, что падали и до изменений из-за миграции планировщика на async, — не затронуты).

### Ручная проверка (self-analyzer / `window.aiFailFast`)
Последний самолёт, удара по врагу нет, груз в рисковом углу → финальное решение `simple_step2_cargo_reach`. Убрать груз, центр за стеной → `simple_step2_center_control_ricochet` с реальным вектором отскока, а не короткий прямой `vy`-обрубок в стену.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_