### PR TITLE
AI шаг 1: учёт безопасности точки приземления при атаке

### DIFF
--- a/script.js
+++ b/script.js
@@ -15768,6 +15768,12 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
         const landingY = plane.y + normDy * travelPx;
         if(!Number.isFinite(landingX) || !Number.isFinite(landingY)) return null;
         const bouncedShot = sim.bounceCount > 0;
+        // How exposed is THIS landing? Reuse the same risk mechanic the cargo /
+        // center / finisher paths already use; the target enemy is excluded (we
+        // are killing it, so it's not a post-landing threat).
+        const landingRisk = (typeof getImmediateResponseThreatMeta === "function" && typeof getFallbackCandidateResponseRisk === "function")
+          ? getFallbackCandidateResponseRisk(getImmediateResponseThreatMeta({ ...aiExecutionContext, plane }, landingX, landingY, enemy))
+          : 0;
         return {
           plane,
           landingX,
@@ -15779,6 +15785,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
           routeClass: bouncedShot ? "ricochet" : "direct",
           bounceCount: sim.bounceCount,
           score: simulated.score,
+          landingRisk,
           predictedOutcome: sim.predictedOutcome,
         };
       };
@@ -15840,7 +15847,11 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       }
       aiThinkingTimingStageEnd("attack_sim");
       attackCandidates.sort((a, b) => {
-        if(Math.abs((a.score ?? 0) - (b.score ?? 0)) > 0.0001) return (b.score ?? 0) - (a.score ?? 0);
+        const scoreDiff = (b.score ?? 0) - (a.score ?? 0);
+        // Comparable hit quality -> prefer the less-exposed landing, then closer enemy.
+        if(Math.abs(scoreDiff) > AI_ATTACK_SCORE_TOLERANCE) return scoreDiff;
+        const riskDiff = (a.move?.landingRisk ?? 0) - (b.move?.landingRisk ?? 0);
+        if(Math.abs(riskDiff) > 1e-6) return riskDiff;
         return a.enemyDistance - b.enemyDistance;
       });
       const bestAttackCandidate = attackCandidates[0] || null;
@@ -15848,6 +15859,31 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       let selectedPlan = bestAttackCandidate?.move || null;
       let planTier = 1;
       let planDistance = Number.isFinite(bestAttackCandidate?.enemyDistance) ? bestAttackCandidate.enemyDistance : Number.POSITIVE_INFINITY;
+
+      if(bestAttackCandidate?.move){
+        const attackLandingRisk = Number.isFinite(bestAttackCandidate.move.landingRisk) ? bestAttackCandidate.move.landingRisk : 0;
+        // Soft: a more exposed landing makes the attack "effectively farther", so a
+        // comparable SAFE cargo (also tier 1) can win the distance comparison below.
+        if(attackLandingRisk > 0 && Number.isFinite(planDistance)){
+          planDistance += attackLandingRisk * AI_LANDING_RISK_DISTANCE_PENALTY;
+        }
+        // Death-trap guard: a weak (non-ricochet) shot whose landing is near-certain
+        // death is demoted out of tier 1 so a safe cargo / smart-center can win.
+        // If no safer option exists the attack still fires (tier 2 > center) — this
+        // is a demotion, not a veto, so aggression is preserved.
+        const allowedRisk = getAiAllowedMoveRisk(aiExecutionContext);
+        const isInvestedShot = (bestAttackCandidate.move.bounceCount || 0) > 0;
+        if(attackLandingRisk > Math.max(allowedRisk, AI_ATTACK_LANDING_RISK_DEMOTE) && !isInvestedShot){
+          planTier = 2;
+          logAiDecision("attack_landing_exposed_demoted", {
+            planeId: launchReadyPlane?.id ?? null,
+            enemyId: bestAttackCandidate.enemy?.id ?? null,
+            landingRisk: Number(attackLandingRisk.toFixed(3)),
+            allowedRisk: Number(allowedRisk.toFixed(3)),
+            score: Number((bestAttackCandidate.score ?? 0).toFixed(1)),
+          });
+        }
+      }
 
       let lastResortAttackFound = false;
       if(!selectedPlan && prioritizedEnemiesForPlane.length){
@@ -19581,6 +19617,19 @@ const AI_CARGO_RISK_ACCEPTANCE = 0.42;
 // soft enemy-response risk cap entirely (path must still be navigable). Dial to
 // ~0.7 to only chase cargo when interception risk is moderate.
 const AI_CARGO_REACH_RISK_ACCEPTANCE = 1;
+// Step 1 (attack landing-point safety). The simple_step2 attack picker now
+// factors how EXPOSED the landing is, reusing getImmediateResponseThreatMeta +
+// getFallbackCandidateResponseRisk (0..1 response risk).
+//   - SCORE_TOLERANCE: sim-score band treated as "comparable hit quality"; within
+//     it, the safer landing wins (scoreAISimulatedCandidate ~1200 for a clean hit).
+//   - LANDING_RISK_DISTANCE_PENALTY: soft px added to a risky attack's effective
+//     distance so a comparable SAFE cargo can win the tier-1 distance comparison.
+//   - LANDING_RISK_DEMOTE: a near-certain-death landing (and below this, weak)
+//     demotes the attack out of tier 1 so a safe alternative is preferred; when
+//     none exists the attack still fires (demotion, not veto -> aggression kept).
+const AI_ATTACK_SCORE_TOLERANCE = 80;
+const AI_LANDING_RISK_DISTANCE_PENALTY = CELL_SIZE * 8;
+const AI_ATTACK_LANDING_RISK_DEMOTE = 0.8;
 const AI_CARGO_RISK_YELLOW_ZONE_MARGIN = 0.12;
 const AI_CARGO_FAVORABLE_DISTANCE = MAX_DRAG_DISTANCE * 0.72;
 const AI_CARGO_IMMEDIATE_THREAT_DISTANCE = ATTACK_RANGE_PX * 0.9;

--- a/scripts/smoke-ai-last-resort-ricochet.js
+++ b/scripts/smoke-ai-last-resort-ricochet.js
@@ -9,6 +9,10 @@
 //   B. nothing connects, no cargo, no ricochet to center     -> direct center-control
 //   C. no shot, only a navigable-but-risky cargo route        -> cargo_reach
 //   D. no shot, no cargo, a ricochet reaches center closer    -> smart center (ricochet)
+// Plus Step 1 (attack landing-point safety):
+//   E. exposed attack landing + safe cargo  -> safe cargo wins (attack demoted)
+//   F. exposed attack landing, no safer option -> attack still fires (aggression kept)
+//   G. safe attack landing -> attack chosen, not demoted (no false positives)
 //
 // The selector is the nested closure buildBestPlanForPlane inside
 // scheduleComputerMoveWithCargoGate, so we run the whole scheduler against a
@@ -49,10 +53,14 @@ const cargoItem = { id: 'cargo-1', state: 'ready', x: 20, y: 60 };
 
 const capturedMoves = [];
 const simCalls = [];
+const loggedReasons = [];
 let pendingPromise = null;
 let deepPassHits = true;            // toggled per scenario below
 let centerRicochetAvailable = false; // planPathToPoint ricochet route toward center
 let unsafeCargoAvailable = false;    // a navigable cargo route that exceeds the safe risk cap
+let normalPassHits = false;          // normal (<=3 bounce) shot connects -> bestAttackCandidate
+let safeCargoAvailable = false;      // a SAFE cargo route (under the risk cap), placed far
+let currentAttackLandingRisk = 0;    // 0..1 exposure of the attack landing (Step 1)
 
 const context = {
   Math,
@@ -91,7 +99,16 @@ const context = {
   aiThinkingTimingStageStart: () => {},
   aiThinkingTimingStageEnd: () => {},
   aiYieldToNextFrame: async () => {},
-  logAiDecision: () => {},
+  logAiDecision: (reason) => { loggedReasons.push(reason); },
+
+  // Step 1: landing-point safety constants + risk fns (module-scope in script.js,
+  // so they must be supplied to the extracted-function VM context).
+  AI_ATTACK_SCORE_TOLERANCE: 80,
+  AI_LANDING_RISK_DISTANCE_PENALTY: 160,
+  AI_ATTACK_LANDING_RISK_DEMOTE: 0.8,
+  getImmediateResponseThreatMeta: () => ({ __risk: currentAttackLandingRisk }),
+  getFallbackCandidateResponseRisk: (meta) => (meta && Number.isFinite(meta.__risk) ? meta.__risk : 0),
+  getAiAllowedMoveRisk: () => 0.7,
 
   // world helpers
   hasAnimatingCargo: () => false,
@@ -129,15 +146,29 @@ const context = {
   AI_CARGO_RISK_ACCEPTANCE: 0.42,
   AI_CARGO_REACH_RISK_ACCEPTANCE: 1,
   getAiCargoRicochetPreferenceBonus: () => 0,
-  collectAiCargoRouteCandidatesAsync: async () => (unsafeCargoAvailable
-    ? [{
+  collectAiCargoRouteCandidatesAsync: async () => {
+    if(safeCargoAvailable){
+      // SAFE but FARTHER (totalDist 200 > the attack's 80) so it only wins once
+      // an exposed-landing attack is penalised/demoted (Step 1).
+      return [{
+        move: { vx: 0, vy: 100, totalDist: 200, routeClass: 'direct', bounceCount: 0 },
+        riskInfo: { isSafePath: true, totalRisk: 0.1 },
+        favorableInfo: { isFavorableCargo: false },
+        usefulCarryAfterPickup: 0,
+        usedRicochet: false,
+      }];
+    }
+    if(unsafeCargoAvailable){
+      return [{
         move: { vx: -30, vy: 50, totalDist: 58.3, routeClass: 'ricochet', bounceCount: 1 },
         riskInfo: { isSafePath: true, totalRisk: 0.9 }, // navigable but exceeds the 0.42 safe cap
         favorableInfo: { isFavorableCargo: false },
         usefulCarryAfterPickup: 0,
         usedRicochet: true,
-      }]
-    : []),
+      }];
+    }
+    return [];
+  },
 
   buildAiShotSimulationQualityProfile: () => ({
     coarseAngleStepDeg: 6,
@@ -154,6 +185,19 @@ const context = {
   // via a ricochet.
   findBestSimulatedShotAsync: async (plane, target, options) => {
     simCalls.push(options?.maxBounces);
+    if(options?.maxBounces === 3 && normalPassHits){
+      // direct (no-bounce) hit -> bestAttackCandidate exists; landing exposure is
+      // driven by currentAttackLandingRisk via the threat-meta mock.
+      return {
+        score: 1150,
+        sim: {
+          hitTarget: true,
+          bounceCount: 0,
+          predictedOutcome: 'target_hit_direct',
+          launchVector: { dx: 0, dy: 1, scale: 0.5 },
+        },
+      };
+    }
     if(options?.maxBounces === 5 && deepPassHits){
       return {
         score: 0.9,
@@ -185,13 +229,24 @@ const context = {
 vm.createContext(context);
 vm.runInContext(scheduleSrc, context);
 
-async function runScenario({ deep = false, ricochetCenter = false, unsafeCargo = false } = {}){
+async function runScenario({
+  deep = false,
+  ricochetCenter = false,
+  unsafeCargo = false,
+  normalHit = false,
+  safeCargo = false,
+  attackLandingRisk = 0,
+} = {}){
   deepPassHits = deep;
   centerRicochetAvailable = ricochetCenter;
   unsafeCargoAvailable = unsafeCargo;
-  context.cargoState = unsafeCargo ? [cargoItem] : [];
+  normalPassHits = normalHit;
+  safeCargoAvailable = safeCargo;
+  currentAttackLandingRisk = attackLandingRisk;
+  context.cargoState = (unsafeCargo || safeCargo) ? [cargoItem] : [];
   capturedMoves.length = 0;
   simCalls.length = 0;
+  loggedReasons.length = 0;
   pendingPromise = null;
   context.aiMoveScheduled = false;
   context.aiLaunchSession = null;
@@ -245,7 +300,48 @@ async function runScenario({ deep = false, ricochetCenter = false, unsafeCargo =
   );
   assert(centerRicochet.routeClass === 'ricochet', `D: expected ricochet routeClass, got "${centerRicochet.routeClass}".`);
 
-  console.log('Smoke test passed: last-resort ricochet + cargo-reach + smart center; center-control fallback intact.');
+  // Step 1 — attack landing-point safety.
+  // Scenario E: a normal hit whose landing is near-certain death (risk 0.95),
+  // with a SAFE (but farther) cargo available -> the exposed attack is penalised/
+  // demoted and the safe cargo wins.
+  const exposedWithCargo = await runScenario({ normalHit: true, attackLandingRisk: 0.95, safeCargo: true });
+  assert(exposedWithCargo, 'E: expected a launch.');
+  assert(
+    exposedWithCargo.decisionReason === 'simple_step2_pickup_cargo',
+    `E: expected the safe cargo to win over an exposed attack, got "${exposedWithCargo.decisionReason}".`
+  );
+  assert(
+    loggedReasons.includes('attack_landing_exposed_demoted'),
+    'E: expected the exposed attack to be demoted (logged).'
+  );
+
+  // Scenario F: same death-trap attack but NO safer option -> the attack STILL
+  // fires (demotion is not a veto; aggression preserved).
+  const exposedNoAlt = await runScenario({ normalHit: true, attackLandingRisk: 0.95 });
+  assert(exposedNoAlt, 'F: expected a launch.');
+  assert(
+    exposedNoAlt.decisionReason === 'simple_step2_direct_enemy',
+    `F: expected the attack to still fire when no safer option exists, got "${exposedNoAlt.decisionReason}".`
+  );
+  assert(
+    loggedReasons.includes('attack_landing_exposed_demoted'),
+    'F: expected the exposed attack to be demoted (logged) even though it still fires.'
+  );
+
+  // Scenario G: a normal hit with a SAFE landing (risk 0.1) -> attack chosen
+  // normally, NOT demoted (no false positives).
+  const safeAttack = await runScenario({ normalHit: true, attackLandingRisk: 0.1 });
+  assert(safeAttack, 'G: expected a launch.');
+  assert(
+    safeAttack.decisionReason === 'simple_step2_direct_enemy',
+    `G: expected the safe attack to be chosen, got "${safeAttack.decisionReason}".`
+  );
+  assert(
+    !loggedReasons.includes('attack_landing_exposed_demoted'),
+    'G: a safe-landing attack must NOT be demoted.'
+  );
+
+  console.log('Smoke test passed: fallback chain + cargo-reach + smart center + attack landing-safety.');
 })().catch((err) => {
   console.error(err);
   process.exit(1);


### PR DESCRIPTION
Первый шаг общего плана по качеству ИИ (от простого к сложному, по одному PR).

## Проблема (non-inventory #2)
Выбор атаки в `simple_step2` сортировал выстрелы **только** по score симуляции и дистанции до врага и **никак не смотрел**, насколько открыта точка приземления. Поэтому ИИ «бьёт и подставляется» даже когда есть вариант безопаснее — хотя сам механизм оценки риска приземления (`getImmediateResponseThreatMeta` + `getFallbackCandidateResponseRisk`) уже используется в путях cargo / center / finisher. Просто в атаку он не был заведён.

## Что сделано (всё внутри `buildBestPlanForPlane`, переиспользуя существующее)
- `buildSimulatedEnemyCandidate` теперь считает `landingRisk` (0..1) для своей точки приземления (целевой враг исключён — мы его сбиваем, он не угроза после посадки).
- **Сортировка кандидатов атаки**: в пределах допуска по score (сопоставимое качество попадания) выигрывает менее открытая посадка, затем — ближний враг.
- **Мягкий штраф**: рискованная посадка увеличивает «эффективную дистанцию» атаки, чтобы сопоставимый **безопасный груз** (тоже tier 1) мог выиграть сравнение.
- **Гард «ловушки»**: слабый (без рикошета) выстрел с почти гарантированной гибелью на посадке вытесняется из tier 1 — тогда безопасный груз / умный центр могут победить. **Если безопасной альтернативы нет — атака всё равно идёт** (это понижение приоритета, не вето; агрессия сохранена). Лог `attack_landing_exposed_demoted`.

Три тюнинг-константы: `AI_ATTACK_SCORE_TOLERANCE`, `AI_LANDING_RISK_DISTANCE_PENALTY`, `AI_ATTACK_LANDING_RISK_DEMOTE`.

## Чего сознательно НЕ трогал
Ядро симуляции выстрела (`simulateAIShot` / `scoreAISimulatedCandidate`) — чтобы не задеть горячий путь, общий с другими вызывающими. Выбор более безопасной посадки **для того же одного врага** (на уровне симуляции) отложен; шаг 1 работает на уровне выбора кандидата.

## Проверка
`scripts/smoke-ai-last-resort-ricochet.js` расширен до 7 сценариев (4 прежних + 3 новых):
- **E**: открытая посадка атаки + безопасный (дальше) груз → груз побеждает, атака понижена;
- **F**: открытая посадка атаки, безопасной альтернативы нет → атака всё равно стреляет (агрессия сохранена);
- **G**: безопасная посадка → атака выбрана, **не** понижена (нет ложных срабатываний).

```
$ node scripts/smoke-ai-last-resort-ricochet.js
Smoke test passed: fallback chain + cargo-reach + smart center + attack landing-safety.
```
Остальные рабочие `smoke-ai-*` проходят (те же 3 устаревших после async-миграции — не затронуты).

### Ручная проверка (self-analyzer / `window.aiFailFast`)
Ход, где единственный выстрел сажает самолёт вплотную к другому врагу: в отчёте — более безопасный выбор / запись `attack_landing_exposed_demoted`, а не самоубийственная посадка.

---
## Дальше по плану (следующие шаги, по одному PR)
2. мультицель в атаке (сбивать несколько на маршруте) · 3. гард точности на коротких · 4. умные широкие крылья · 5. топливо «удар-и-отход» · 6. мультигруз + шедевральные комбо точности.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_