### PR TITLE
AI шаг 2: приоритетный маршрут на максимум целей (грузы+самолёты, рикошеты)

### DIFF
--- a/script.js
+++ b/script.js
@@ -15790,6 +15790,104 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
         };
       };
 
+    // Is `enemy` swept by the flown path (perpendicular within the danger width)?
+    const isEnemyOnPredictedPath = (enemy, path) => {
+      if(!enemy || !Array.isArray(path) || path.length < 2) return false;
+      for(let i = 0; i < path.length - 1; i += 1){
+        const d = getDistanceFromPointToSegment(enemy.x, enemy.y, path[i].x, path[i].y, path[i + 1].x, path[i + 1].y);
+        if(d <= AI_SWEEP_ENEMY_HIT_TOLERANCE_PX) return true;
+      }
+      return false;
+    };
+
+    // Priority "dominate" route: simulate real trajectories (incl. wall ricochets)
+    // and pick the launch that sweeps the MOST targets (cargo + enemy planes,
+    // combined). Returns a move whose landingX/landingY encode the LAUNCH vector
+    // (dir × power) — physics then flies the bounces — plus multiTargetCount.
+    const buildBestMultiTargetSweepCandidate = async (plane, maxFlightDistancePx) => {
+      const effRange = getPlaneEffectiveRangePx(plane);
+      if(!(effRange > 0)) return null;
+      const sweepCargos = readyCargo
+        .filter(Boolean)
+        .map((cargo) => ({ cargo, center: getCargoVisualCenter(cargo), d: dist(plane, getCargoVisualCenter(cargo)) }))
+        .sort((a, b) => a.d - b.d)
+        .slice(0, 8);
+      const sweepEnemies = enemyPlanes
+        .filter((e) => e && e.isAlive !== false)
+        .map((enemy) => ({ enemy, d: dist(plane, enemy) }))
+        .sort((a, b) => a.d - b.d)
+        .slice(0, 4);
+      if(sweepCargos.length + sweepEnemies.length < AI_MULTI_TARGET_PAIR_MIN) return null;
+
+      const directions = [];
+      const pushDir = (tx, ty) => {
+        const dx = tx - plane.x, dy = ty - plane.y;
+        const len = Math.hypot(dx, dy);
+        if(len <= 1e-6) return;
+        directions.push({ nx: dx / len, ny: dy / len, anchor: true });
+      };
+      for(const c of sweepCargos) pushDir(c.center.x, c.center.y);
+      for(const e of sweepEnemies) pushDir(e.enemy.x, e.enemy.y);
+      // Coarse angle sweep for ricochet-only routes that bounce into a cluster.
+      for(let deg = 0; deg < 360; deg += AI_SWEEP_ANGLE_STEP_DEG){
+        const rad = deg * Math.PI / 180;
+        directions.push({ nx: Math.cos(rad), ny: Math.sin(rad), anchor: false });
+      }
+
+      let best = null;
+      let simBudget = 0;
+      for(const dir of directions){
+        const scales = dir.anchor ? AI_SWEEP_ANCHOR_SCALES : [1];
+        for(const scale of scales){
+          if((simBudget++ & 7) === 7){
+            await aiCoopMaybeYield();
+            if(!isAiTurnStillApplicable()) return null;
+          }
+          const sim = simulateAIShot(plane, { dx: dir.nx, dy: dir.ny, scale }, { maxBounces: AI_SWEEP_MAX_BOUNCES });
+          if(!sim || !Array.isArray(sim.predictedPath) || sim.predictedPath.length < 2) continue;
+          let cargoHit = 0, enemyHit = 0;
+          for(const c of sweepCargos){ if(doesCargoIntersectBeneficialZoneAlongPath(c.cargo, plane, sim.predictedPath)) cargoHit += 1; }
+          for(const e of sweepEnemies){ if(isEnemyOnPredictedPath(e.enemy, sim.predictedPath)) enemyHit += 1; }
+          const count = cargoHit + enemyHit;
+          if(count < AI_MULTI_TARGET_PAIR_MIN) continue;
+          const travel = Number.isFinite(sim.travelDistance) ? sim.travelDistance : Number.POSITIVE_INFINITY;
+          const better = !best
+            || count > best.count
+            || (count === best.count && sim.bounceCount < best.bounceCount)
+            || (count === best.count && sim.bounceCount === best.bounceCount && travel < best.travel);
+          if(better){
+            best = { nx: dir.nx, ny: dir.ny, scale, count, cargoHit, enemyHit, bounceCount: sim.bounceCount, travel, end: sim.predictedPath[sim.predictedPath.length - 1] };
+          }
+        }
+      }
+      if(!best) return null;
+
+      const travelPx = Math.max(1, effRange * best.scale);
+      const landingX = plane.x + best.nx * travelPx;
+      const landingY = plane.y + best.ny * travelPx;
+      const end = best.end || { x: landingX, y: landingY };
+      const landingRisk = (typeof getImmediateResponseThreatMeta === "function" && typeof getFallbackCandidateResponseRisk === "function")
+        ? getFallbackCandidateResponseRisk(getImmediateResponseThreatMeta({ ...aiExecutionContext, plane }, end.x, end.y, null))
+        : 0;
+      const ricochet = best.bounceCount > 0;
+      return {
+        plane,
+        landingX,
+        landingY,
+        targetPoint: { x: end.x, y: end.y },
+        decisionReason: ricochet ? "simple_step2_multi_target_ricochet" : "simple_step2_multi_target_direct",
+        goalName: "simple_step2_multi_target",
+        whyChosen: `sweep_${best.count}_targets_${best.cargoHit}c_${best.enemyHit}e_bounces_${best.bounceCount}`,
+        routeClass: ricochet ? "ricochet" : "direct",
+        bounceCount: best.bounceCount,
+        multiTargetCount: best.count,
+        multiTargetCargo: best.cargoHit,
+        multiTargetEnemy: best.enemyHit,
+        landingRisk,
+        travel: best.travel,
+      };
+    };
+
     const buildBestPlanForPlane = async (launchReadyPlane) => {
       const effectiveFlightRangeCells = getEffectiveFlightRangeCells(launchReadyPlane);
       const maxFlightDistancePx = Math.max(1, effectiveFlightRangeCells * CELL_SIZE);
@@ -15829,6 +15927,33 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       // near-zero-cost microtask unless the 6ms frame budget is exceeded.
       await aiCoopMaybeYield();
       if(!isAiTurnStillApplicable()) return null;
+
+      // === Priority layer: dominate multi-target route (cargo + enemies, incl.
+      // ricochets). Additive — only fires when a fat route exists; otherwise the
+      // existing attack/cargo/center logic below runs unchanged. ===
+      aiThinkingTimingStageStart("multi_target_sweep");
+      const sweepCandidate = await buildBestMultiTargetSweepCandidate(launchReadyPlane, maxFlightDistancePx);
+      aiThinkingTimingStageEnd("multi_target_sweep");
+      if(!isAiTurnStillApplicable()) return null;
+      if(sweepCandidate && sweepCandidate.multiTargetCount >= AI_MULTI_TARGET_DOMINATE_MIN){
+        // >=3 targets: TOP priority, landing safety intentionally ignored.
+        logAiDecision("multi_target_dominate_route", {
+          planeId: launchReadyPlane?.id ?? null,
+          targetCount: sweepCandidate.multiTargetCount,
+          cargo: sweepCandidate.multiTargetCargo,
+          enemy: sweepCandidate.multiTargetEnemy,
+          routeClass: sweepCandidate.routeClass,
+          bounceCount: sweepCandidate.bounceCount,
+          landingRisk: Number((sweepCandidate.landingRisk ?? 0).toFixed(3)),
+        });
+        return {
+          ...sweepCandidate,
+          planTier: 0,
+          planDistance: Number.isFinite(sweepCandidate.travel) ? sweepCandidate.travel : 0,
+          hasDirectEnemy: (sweepCandidate.multiTargetEnemy || 0) > 0,
+          readyCargoCount: readyCargo.length,
+        };
+      }
 
       const prioritizedEnemiesForPlane = enemyPlanes
         .map((enemy) => ({ enemy, enemyDistance: dist(launchReadyPlane, enemy) }))
@@ -16067,6 +16192,26 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
             });
           }
         }
+      }
+
+      // 2-target sweep: prefer it over any single-target plan, but stay
+      // safety-aware (only >=3 ignores landing exposure). Subsumes the old
+      // "extend a cargo line to the 3rd" idea — the sweep already maximises
+      // targets (cargo + enemy) on the chosen line, including ricochets.
+      if(sweepCandidate
+        && sweepCandidate.multiTargetCount >= AI_MULTI_TARGET_PAIR_MIN
+        && sweepCandidate.multiTargetCount < AI_MULTI_TARGET_DOMINATE_MIN
+        && (sweepCandidate.landingRisk ?? 0) <= getAiAllowedMoveRisk(aiExecutionContext)){
+        selectedPlan = { ...sweepCandidate };
+        planTier = Math.min(Number.isFinite(planTier) ? planTier : 1, 1);
+        planDistance = Number.isFinite(sweepCandidate.travel) ? sweepCandidate.travel : planDistance;
+        logAiDecision("multi_target_pair_route", {
+          planeId: launchReadyPlane?.id ?? null,
+          cargo: sweepCandidate.multiTargetCargo,
+          enemy: sweepCandidate.multiTargetEnemy,
+          routeClass: sweepCandidate.routeClass,
+          landingRisk: Number((sweepCandidate.landingRisk ?? 0).toFixed(3)),
+        });
       }
 
       if(!selectedPlan) return null;
@@ -19630,6 +19775,23 @@ const AI_CARGO_REACH_RISK_ACCEPTANCE = 1;
 const AI_ATTACK_SCORE_TOLERANCE = 80;
 const AI_LANDING_RISK_DISTANCE_PENALTY = CELL_SIZE * 8;
 const AI_ATTACK_LANDING_RISK_DEMOTE = 0.8;
+// Step 2 (maximize targets on a route). A "dominate" candidate simulates real
+// trajectories (incl. wall ricochets via simulateAIShot) and counts how many
+// targets (cargo + enemy planes, combined) the flown path sweeps. The densest
+// route is the AI's TOP priority — collecting a cargo is +1 to us AND -1 denied
+// to the enemy. This is an ADDITIVE priority layer; when no fat route exists the
+// existing attack/cargo/center logic runs unchanged.
+//   - DOMINATE_MIN: >= this many targets -> top priority, landing safety IGNORED.
+//   - PAIR_MIN: >= this many -> preferred over a single-target plan, safety-aware.
+//   - SWEEP_*: enumeration budget (anchor dirs + a coarse ricochet angle sweep).
+//   - ENEMY_HIT_TOLERANCE_PX: perpendicular distance for "plane sweeps this enemy"
+//     (danger hitbox is 36px wide).
+const AI_MULTI_TARGET_DOMINATE_MIN = 3;
+const AI_MULTI_TARGET_PAIR_MIN = 2;
+const AI_SWEEP_ANGLE_STEP_DEG = 20;
+const AI_SWEEP_MAX_BOUNCES = 2;
+const AI_SWEEP_ANCHOR_SCALES = [1, 0.7];
+const AI_SWEEP_ENEMY_HIT_TOLERANCE_PX = CELL_SIZE; // ~ danger half-width (18) + margin
 const AI_CARGO_RISK_YELLOW_ZONE_MARGIN = 0.12;
 const AI_CARGO_FAVORABLE_DISTANCE = MAX_DRAG_DISTANCE * 0.72;
 const AI_CARGO_IMMEDIATE_THREAT_DISTANCE = ATTACK_RANGE_PX * 0.9;

--- a/scripts/smoke-ai-last-resort-ricochet.js
+++ b/scripts/smoke-ai-last-resort-ricochet.js
@@ -50,6 +50,9 @@ const bluePlane = { id: 'blue-1', color: 'blue', x: 50, y: 10 };
 const greenEnemy = { id: 'green-1', color: 'green', x: 50, y: 90 };
 
 const cargoItem = { id: 'cargo-1', state: 'ready', x: 20, y: 60 };
+const cargoA = { id: 'cargo-a', state: 'ready', x: 30, y: 40 };
+const cargoB = { id: 'cargo-b', state: 'ready', x: 30, y: 60 };
+const cargoC = { id: 'cargo-c', state: 'ready', x: 30, y: 80 };
 
 const capturedMoves = [];
 const simCalls = [];
@@ -60,7 +63,11 @@ let centerRicochetAvailable = false; // planPathToPoint ricochet route toward ce
 let unsafeCargoAvailable = false;    // a navigable cargo route that exceeds the safe risk cap
 let normalPassHits = false;          // normal (<=3 bounce) shot connects -> bestAttackCandidate
 let safeCargoAvailable = false;      // a SAFE cargo route (under the risk cap), placed far
-let currentAttackLandingRisk = 0;    // 0..1 exposure of the attack landing (Step 1)
+let currentAttackLandingRisk = 0;    // 0..1 exposure of the attack/sweep landing
+// Step 2 (multi-target sweep) flags:
+let cargoOnPath = false;             // doesCargoIntersectBeneficialZoneAlongPath result
+let enemyOnPath = false;             // enemy within sweep tolerance of the path
+let sweepBounce = false;             // simulated trajectory has a wall ricochet
 
 const context = {
   Math,
@@ -109,6 +116,21 @@ const context = {
   getImmediateResponseThreatMeta: () => ({ __risk: currentAttackLandingRisk }),
   getFallbackCandidateResponseRisk: (meta) => (meta && Number.isFinite(meta.__risk) ? meta.__risk : 0),
   getAiAllowedMoveRisk: () => 0.7,
+
+  // Step 2: multi-target sweep constants + reused geometry/sim fns (module-scope).
+  AI_MULTI_TARGET_DOMINATE_MIN: 3,
+  AI_MULTI_TARGET_PAIR_MIN: 2,
+  AI_SWEEP_ANGLE_STEP_DEG: 90,        // coarse (fewer sims) for the test
+  AI_SWEEP_MAX_BOUNCES: 2,
+  AI_SWEEP_ANCHOR_SCALES: [1],
+  AI_SWEEP_ENEMY_HIT_TOLERANCE_PX: 20,
+  simulateAIShot: (plane, lv) => ({
+    predictedPath: [{ x: plane.x, y: plane.y }, { x: plane.x + (lv.dx || 0) * 10, y: plane.y + (lv.dy || 0) * 10 }],
+    travelDistance: 50,
+    bounceCount: sweepBounce ? 1 : 0,
+  }),
+  doesCargoIntersectBeneficialZoneAlongPath: () => cargoOnPath,
+  getDistanceFromPointToSegment: () => (enemyOnPath ? 5 : 9999),
 
   // world helpers
   hasAnimatingCargo: () => false,
@@ -236,6 +258,10 @@ async function runScenario({
   normalHit = false,
   safeCargo = false,
   attackLandingRisk = 0,
+  cargos = null,
+  sweepCargoOnPath = false,
+  sweepEnemyOnPath = false,
+  sweepRicochet = false,
 } = {}){
   deepPassHits = deep;
   centerRicochetAvailable = ricochetCenter;
@@ -243,7 +269,12 @@ async function runScenario({
   normalPassHits = normalHit;
   safeCargoAvailable = safeCargo;
   currentAttackLandingRisk = attackLandingRisk;
-  context.cargoState = (unsafeCargo || safeCargo) ? [cargoItem] : [];
+  cargoOnPath = sweepCargoOnPath;
+  enemyOnPath = sweepEnemyOnPath;
+  sweepBounce = sweepRicochet;
+  context.cargoState = cargos
+    ? cargos
+    : ((unsafeCargo || safeCargo) ? [cargoItem] : []);
   capturedMoves.length = 0;
   simCalls.length = 0;
   loggedReasons.length = 0;
@@ -341,7 +372,54 @@ async function runScenario({
     'G: a safe-landing attack must NOT be demoted.'
   );
 
-  console.log('Smoke test passed: fallback chain + cargo-reach + smart center + attack landing-safety.');
+  // Step 2 — maximize targets on a route.
+  // Scenario H: 3 cargos swept by one direct route -> DOMINATE (top priority),
+  // landing safety ignored.
+  const dominate = await runScenario({ cargos: [cargoA, cargoB, cargoC], sweepCargoOnPath: true, attackLandingRisk: 0.95 });
+  assert(dominate, 'H: expected a launch.');
+  assert(
+    dominate.decisionReason === 'simple_step2_multi_target_direct',
+    `H: expected a dominate multi-target route, got "${dominate.decisionReason}".`
+  );
+  assert(dominate.goalName === 'simple_step2_multi_target', `H: expected multi-target goal, got "${dominate.goalName}".`);
+  assert(loggedReasons.includes('multi_target_dominate_route'), 'H: expected dominate route logged.');
+
+  // Scenario H2: same but the route ricochets -> labelled as a ricochet sweep.
+  const dominateRic = await runScenario({ cargos: [cargoA, cargoB, cargoC], sweepCargoOnPath: true, sweepRicochet: true });
+  assert(dominateRic, 'H2: expected a launch.');
+  assert(
+    dominateRic.decisionReason === 'simple_step2_multi_target_ricochet',
+    `H2: expected a ricochet sweep, got "${dominateRic.decisionReason}".`
+  );
+  assert(dominateRic.routeClass === 'ricochet', `H2: expected ricochet routeClass, got "${dominateRic.routeClass}".`);
+
+  // Scenario J: 2 cargos + 1 enemy on the path = 3 targets -> DOMINATE (enemies
+  // count toward the total just like cargo).
+  const dominateMixed = await runScenario({ cargos: [cargoA, cargoB], sweepCargoOnPath: true, sweepEnemyOnPath: true });
+  assert(dominateMixed, 'J: expected a launch.');
+  assert(loggedReasons.includes('multi_target_dominate_route'), 'J: expected enemy+cargo to reach the dominate threshold.');
+
+  // Scenario I: exactly 2 cargos, safe landing -> PAIR route preferred over a
+  // single-target plan.
+  const pair = await runScenario({ cargos: [cargoA, cargoB], sweepCargoOnPath: true, attackLandingRisk: 0 });
+  assert(pair, 'I: expected a launch.');
+  assert(loggedReasons.includes('multi_target_pair_route'), 'I: expected a safe 2-target pair route.');
+  assert(
+    pair.goalName === 'simple_step2_multi_target',
+    `I: expected multi-target goal for the pair route, got "${pair.goalName}".`
+  );
+
+  // Scenario I2: a 2-target sweep whose landing is exposed (risk 0.9) -> NOT
+  // chased (pairs stay safety-aware; only >=3 ignores exposure).
+  const pairExposed = await runScenario({ cargos: [cargoA, cargoB], sweepCargoOnPath: true, attackLandingRisk: 0.9 });
+  assert(pairExposed, 'I2: expected a launch.');
+  assert(!loggedReasons.includes('multi_target_pair_route'), 'I2: an exposed 2-target sweep must not be chosen.');
+  assert(
+    pairExposed.goalName !== 'simple_step2_multi_target',
+    'I2: exposed pair must fall back to the existing logic, not a multi-target route.'
+  );
+
+  console.log('Smoke test passed: fallback chain + cargo-reach + smart center + landing-safety + multi-target sweep.');
 })().catch((err) => {
   console.error(err);
   process.exit(1);


### PR DESCRIPTION
Шаг 2 общего плана. Главной целью ИИ становится **сбор максимума целей за один полёт**, где цель = груз ИЛИ вражеский самолёт (считаем вместе). Каждый груз = +1 себе и −1 врагу → жирный маршрут доминирует.

## Что сделано (в `buildBestPlanForPlane`, приоритетный слой ПОВЕРХ существующего)

`buildBestMultiTargetSweepCandidate` через **реальную физику** `simulateAIShot` (с отскоками от стен) считает, сколько целей **реально сметает** траектория:
- перебирает направления запуска (на каждую близкую цель + грубый круговой проход для чисто рикошетных линий) × пара мощностей;
- для каждого — грузы через `doesCargoIntersectBeneficialZoneAlongPath` (умеет многосегментный путь), враги через расстояние точка-путь;
- берёт запуск с **максимумом целей** (при равенстве — меньше отскоков, затем короче);
- `landingX/landingY` кодируют **вектор запуска** (направление×мощность) — физика сама летит рикошет; `routeClass = ricochet`, если были отскоки.

**Приоритет:**
- **≥3 целей → tier 0, верх приоритета, безопасность посадки игнорируется** (по твоему решению — доминирование того стоит);
- **=2 → предпочтительнее любой одиночной цели, но только если посадка не открыта** (на 2 ещё аккуратничаем; игнор риска — только с 3);
- **<2 → ничего не меняется**, работает существующая логика (атака/груз/фолбеки/центр).

Это **поглощает** прежнюю идею «дотянуть линию до 3-го груза» — sweep уже максимизирует цели на выбранной линии, включая рикошеты. Чинит «собрал 2, не долетел до 3-го» и «летит к одной тупой цели, когда в стороне 5 грузов».

**Инвентарь дальше:** топливо (↑дальность → длиннее sweep), крылья (↑ширина захвата → больше целей на линии), точность — это Шаги 3–6, достраиваются поверх этой механики.

## Не трогал
Ядро симуляции выстрела; существующие кандидаты остаются запасными. Только добавлен кандидат + правило приоритета. Тюнинг-константы вынесены (`AI_MULTI_TARGET_DOMINATE_MIN=3`, `AI_MULTI_TARGET_PAIR_MIN=2`, и параметры перебора `AI_SWEEP_*`).

## Проверка
`scripts/smoke-ai-last-resort-ricochet.js` расширен (всё зелёное):
- **H**: 3 груза на линии → dominate (`simple_step2_multi_target_direct`);
- **H2**: то же с отскоком → `simple_step2_multi_target_ricochet`, routeClass ricochet;
- **J**: 2 груза + 1 враг на пути = 3 → dominate (враги считаются наравне с грузами);
- **I**: ровно 2 груза, безопасно → pair-маршрут предпочтён одиночному;
- **I2**: 2 груза, посадка открыта (риск 0.9) → pair **не** берётся (безопасность для 2 сохранена);
- **A–G** (фолбеки/cargo-reach/умный центр/safety Шага 1) — без изменений.

```
$ node scripts/smoke-ai-last-resort-ricochet.js
Smoke test passed: fallback chain + cargo-reach + smart center + landing-safety + multi-target sweep.
```

### Ручная проверка (self-analyzer / `window.aiFailFast`)
Поле с кучей грузов в стороне → ИИ строит маршрут сквозь них (`multi_target_dominate_route`), при необходимости красивым рикошетом, а не летит к одной ближней цели.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_