### PR TITLE
Add "AI is thinking" goat hoof animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,14 @@
             <div id="mantisIndicator" class="turn-indicator" style="display:none;"></div>
             <div id="goatIndicator" class="turn-indicator" style="display:none;"></div>
 
+            <!-- "AI is thinking" goat hoof: peeks in from the left only while the
+                 AI deliberates past a threshold, fidgets (stroking-its-beard
+                 squeeze), then jerks back out the moment the move is ready. -->
+            <div id="aiThinkHoof" aria-hidden="true">
+              <div class="ai-think-hoof__frame ai-think-hoof__frame--close"></div>
+              <div class="ai-think-hoof__frame ai-think-hoof__frame--open"></div>
+            </div>
+
             <!-- End Game Window -->
             <div id="endGameButtons" role="dialog" aria-labelledby="endGamePrompt">
               <p id="endGamePrompt" class="visually-hidden">Play Again?</p>

--- a/script.js
+++ b/script.js
@@ -15169,11 +15169,17 @@ const aiThinkHoof = (() => {
     endHandler = () => onSlideOutEnd(node);
     node.addEventListener("animationend", endHandler);
   }
+  function isGoatTurn(){
+    // The goat is the top-left (blue) player; the sparrow is green. Only the
+    // goat gets the hoof, so skip arming on the sparrow's (green) AI turns.
+    try { return turnColors[turnIndex] === "blue"; } catch (_) { return false; }
+  }
   function arm(){
     const node = getEl();
     if(!node) return;
     if(armTimer){ clearTimeout(armTimer); armTimer = 0; }
     if(phase !== "idle"){ detachEnd(node); setPhaseClass(node, null); phase = "idle"; }
+    if(!isGoatTurn()) return;
     phase = "armed";
     armTimer = setTimeout(() => { armTimer = 0; enter(); }, AI_THINK_HOOF_THRESHOLD_MS);
   }

--- a/script.js
+++ b/script.js
@@ -15115,6 +15115,76 @@ function getAiTurnTimingSnapshot(){
   };
 }
 
+// "AI is thinking" goat hoof controller. Self-gating: arm() starts a timer on
+// every AI turn; the hoof only slides in if the AI is STILL deliberating after
+// AI_THINK_HOOF_THRESHOLD_MS, so quick moves never summon it. release() clears
+// the timer or retracts the hoof the moment the move is ready. Pure class
+// toggling — the slide/fidget keyframes live in styles.css.
+const AI_THINK_HOOF_THRESHOLD_MS = 1500;
+const aiThinkHoof = (() => {
+  let el = null;
+  let armTimer = 0;
+  let phase = "idle"; // idle | armed | entering | fidgeting | leaving
+  let endHandler = null;
+
+  function getEl(){
+    if(el === null) el = document.getElementById("aiThinkHoof") || false;
+    return el || null;
+  }
+  function detachEnd(node){
+    if(endHandler && node) node.removeEventListener("animationend", endHandler);
+    endHandler = null;
+  }
+  function setPhaseClass(node, cls){
+    node.classList.remove("is-entering", "is-fidgeting", "is-leaving");
+    if(cls) node.classList.add(cls);
+  }
+  function onSlideInEnd(node){
+    detachEnd(node);
+    if(phase !== "entering") return;
+    phase = "fidgeting";
+    setPhaseClass(node, "is-fidgeting");
+  }
+  function onSlideOutEnd(node){
+    detachEnd(node);
+    if(phase !== "leaving") return;
+    phase = "idle";
+    setPhaseClass(node, null); // back to hidden parked state
+  }
+  function enter(){
+    const node = getEl();
+    if(!node) return;
+    phase = "entering";
+    setPhaseClass(node, "is-entering");
+    detachEnd(node);
+    endHandler = () => onSlideInEnd(node);
+    node.addEventListener("animationend", endHandler);
+  }
+  function leave(){
+    const node = getEl();
+    if(!node) return;
+    phase = "leaving";
+    setPhaseClass(node, "is-leaving");
+    detachEnd(node);
+    endHandler = () => onSlideOutEnd(node);
+    node.addEventListener("animationend", endHandler);
+  }
+  function arm(){
+    const node = getEl();
+    if(!node) return;
+    if(armTimer){ clearTimeout(armTimer); armTimer = 0; }
+    if(phase !== "idle"){ detachEnd(node); setPhaseClass(node, null); phase = "idle"; }
+    phase = "armed";
+    armTimer = setTimeout(() => { armTimer = 0; enter(); }, AI_THINK_HOOF_THRESHOLD_MS);
+  }
+  function release(){
+    if(armTimer){ clearTimeout(armTimer); armTimer = 0; }
+    if(phase === "entering" || phase === "fidgeting") leave();
+    else if(phase === "armed") phase = "idle"; // never crossed the threshold
+  }
+  return { arm, release };
+})();
+
 function markAiTurnStarted(reason = "unspecified", now = performance.now()){
   aiTurnTimingState = {
     turnStartedAt: now,
@@ -15126,6 +15196,7 @@ function markAiTurnStarted(reason = "unspecified", now = performance.now()){
     turnNumber: turnAdvanceCount,
   };
   aiThinkingTimingStartTurn(reason, now);
+  aiThinkHoof.arm();
   showAiLaunchPreparationNotice("Компьютер готовится к ходу…");
 }
 
@@ -15148,6 +15219,7 @@ function markAiReleased(reason = "unspecified", now = performance.now()){
   aiTurnTimingState.releasedAt = now;
   aiTurnTimingState.releaseReason = reason;
   aiThinkingTimingFinishTurn(now);
+  aiThinkHoof.release();
 }
 
 function getAiTurnMinReleaseAt(){

--- a/styles.css
+++ b/styles.css
@@ -1985,6 +1985,94 @@ body, button {
   filter: grayscale(0) drop-shadow(0 0 6px rgba(127, 142, 64, 0.6));
 }
 
+/* --- "AI is thinking" goat hoof -----------------------------------------
+   Lives in the #gameContainer 460x800 world (sibling of the goat indicator,
+   so it scales with the board). Resting spot is the asset's final position:
+   x = -15 (15px stays off the left edge so it only half-peeks), y = 85
+   measured from the top of the goat region (goat indicator sits at top:400),
+   i.e. world top: 400 + 85 = 485px. Tweak left/top here to re-aim it; tweak
+   the threshold in script.js (AI_THINK_HOOF_THRESHOLD_MS) to change how long
+   the AI must deliberate before the hoof bothers to appear. */
+#aiThinkHoof {
+  position: absolute;
+  left: -15px;
+  top: 485px;
+  width: 47px;
+  height: 49px;
+  z-index: 36; /* just above the goat indicator (35) */
+  pointer-events: none;
+  visibility: hidden;
+  transform: translateX(-44px); /* parked fully off-screen to the left */
+  will-change: transform;
+}
+
+#aiThinkHoof .ai-think-hoof__frame {
+  position: absolute;
+  inset: 0;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 47px 49px;
+}
+
+#aiThinkHoof .ai-think-hoof__frame--close {
+  background-image: url("ui_gamescreen/gamescreen_outside/goat_close.png");
+  opacity: 1;
+}
+
+#aiThinkHoof .ai-think-hoof__frame--open {
+  background-image: url("ui_gamescreen/gamescreen_outside/goat_open.png");
+  opacity: 0;
+}
+
+/* Entering: stepped slide-in (deliberately jerky, old-school). */
+#aiThinkHoof.is-entering {
+  visibility: visible;
+  animation: aiHoofSlideIn 0.45s steps(1, end) forwards;
+}
+
+@keyframes aiHoofSlideIn {
+  0%   { transform: translateX(-44px); }
+  25%  { transform: translateX(-30px); }
+  50%  { transform: translateX(-18px); }
+  75%  { transform: translateX(-8px); }
+  100% { transform: translateX(0); }
+}
+
+/* Fidgeting: parked at rest, alternating closed/open frames = lateral squeeze
+   (reads as a hoof teasing a beard, not an in-out pump). Opacity animation so
+   it composites and survives the AI's heavy sync chunks. */
+#aiThinkHoof.is-fidgeting {
+  visibility: visible;
+  transform: translateX(0);
+}
+
+#aiThinkHoof.is-fidgeting .ai-think-hoof__frame--open {
+  animation: aiHoofFidget 0.5s steps(1, end) infinite;
+}
+
+@keyframes aiHoofFidget {
+  0%   { opacity: 0; }
+  50%  { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+/* Leaving: stepped slide-out, retracts showing the closed hoof. */
+#aiThinkHoof.is-leaving {
+  visibility: visible;
+  animation: aiHoofSlideOut 0.4s steps(1, end) forwards;
+}
+
+@keyframes aiHoofSlideOut {
+  0%   { transform: translateX(0); }
+  33%  { transform: translateX(-12px); }
+  66%  { transform: translateX(-28px); }
+  100% { transform: translateX(-44px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #aiThinkHoof { display: none; }
+}
+
 
 /* Aiming overlay (full 460x800 frame) */
 #aimCanvas {

--- a/styles.css
+++ b/styles.css
@@ -1986,17 +1986,17 @@ body, button {
 }
 
 /* --- "AI is thinking" goat hoof -----------------------------------------
-   Lives in the #gameContainer 460x800 world (sibling of the goat indicator,
-   so it scales with the board). Resting spot is the asset's final position:
-   x = -15 (15px stays off the left edge so it only half-peeks), y = 85
-   measured from the top of the goat region (goat indicator sits at top:400),
-   i.e. world top: 400 + 85 = 485px. Tweak left/top here to re-aim it; tweak
-   the threshold in script.js (AI_THINK_HOOF_THRESHOLD_MS) to change how long
-   the AI must deliberate before the hoof bothers to appear. */
+   Lives in the #gameContainer 460x800 world (scales with the board). The goat
+   is the TOP-LEFT (blue) player, so the hoof peeks in near the top-left corner.
+   Resting spot is the asset's final position: x = -15 (15px stays off the left
+   edge so it only half-peeks), y = 85 from the top of the frame. Tweak left/top
+   here to re-aim it; tweak the threshold in script.js
+   (AI_THINK_HOOF_THRESHOLD_MS) to change how long the AI must deliberate before
+   the hoof bothers to appear. */
 #aiThinkHoof {
   position: absolute;
   left: -15px;
-  top: 485px;
+  top: 85px;
   width: 47px;
   height: 49px;
   z-index: 36; /* just above the goat indicator (35) */


### PR DESCRIPTION
## Summary
Adds a visual indicator that appears when the AI (goat player) is deliberating on its turn. A goat hoof peeks in from the left edge of the game board, fidgets while thinking, and retracts when the move is ready.

## Changes
- **styles.css**: Added complete styling for the hoof animation system
  - `#aiThinkHoof` container positioned at top-left corner of game board
  - Two frame states (closed/open) for the fidgeting animation
  - Three animation sequences: `aiHoofSlideIn` (entering), `aiHoofFidget` (thinking), `aiHoofSlideOut` (leaving)
  - Respects `prefers-reduced-motion` by hiding the element entirely
  
- **script.js**: Implemented `aiThinkHoof` controller module
  - Self-gating timer: hoof only appears if AI deliberates longer than `AI_THINK_HOOF_THRESHOLD_MS` (1500ms)
  - State machine managing four phases: idle → armed → entering → fidgeting → leaving
  - Integrated with existing AI turn lifecycle via `markAiTurnStarted()` and `markAiReleased()`
  - Only activates for goat (blue) player turns, not sparrow (green) AI
  
- **index.html**: Added DOM structure for the hoof element
  - Two child divs for frame animation (closed/open states)
  - Positioned within `#gameContainer` to scale with the board

## Implementation Details
- Uses CSS class toggling for state transitions; all animations defined in styles.css
- Stepped keyframes create deliberate "jerky" old-school animation feel
- Hoof rests at `x = -15px` (half-peeks off left edge) when visible
- Fidget animation uses opacity toggle on the "open" frame to create a squeezing effect
- Accessibility: marked with `aria-hidden="true"` as pure decorative UI

https://claude.ai/code/session_01QWep6Zsim5uEqa5br7vuHk