### PR TITLE
Tune AI thinking hoof: rarer, calmer, fix closed-frame ghosting

### DIFF
--- a/script.js
+++ b/script.js
@@ -15120,7 +15120,7 @@ function getAiTurnTimingSnapshot(){
 // AI_THINK_HOOF_THRESHOLD_MS, so quick moves never summon it. release() clears
 // the timer or retracts the hoof the moment the move is ready. Pure class
 // toggling — the slide/fidget keyframes live in styles.css.
-const AI_THINK_HOOF_THRESHOLD_MS = 1500;
+const AI_THINK_HOOF_THRESHOLD_MS = 3500;
 const aiThinkHoof = (() => {
   let el = null;
   let armTimer = 0;

--- a/styles.css
+++ b/styles.css
@@ -2027,7 +2027,7 @@ body, button {
 /* Entering: stepped slide-in (deliberately jerky, old-school). */
 #aiThinkHoof.is-entering {
   visibility: visible;
-  animation: aiHoofSlideIn 0.45s steps(1, end) forwards;
+  animation: aiHoofSlideIn 0.8s steps(1, end) forwards;
 }
 
 @keyframes aiHoofSlideIn {
@@ -2046,14 +2046,26 @@ body, button {
   transform: translateX(0);
 }
 
-#aiThinkHoof.is-fidgeting .ai-think-hoof__frame--open {
-  animation: aiHoofFidget 0.5s steps(1, end) infinite;
+/* Both frames run in counter-phase so exactly one is ever visible — otherwise
+   the narrower closed hoof shows through from behind the spread-open one.
+   Slow, calm rhythm: the closed (rest) frame is held longer than the open
+   squeeze, so it reads as unhurried beard-stroking, not a nervous twitch. */
+#aiThinkHoof.is-fidgeting .ai-think-hoof__frame--close {
+  animation: aiHoofFidgetClose 1.5s steps(1, end) infinite;
 }
 
-@keyframes aiHoofFidget {
-  0%   { opacity: 0; }
-  50%  { opacity: 1; }
-  100% { opacity: 0; }
+#aiThinkHoof.is-fidgeting .ai-think-hoof__frame--open {
+  animation: aiHoofFidgetOpen 1.5s steps(1, end) infinite;
+}
+
+@keyframes aiHoofFidgetClose {
+  0%, 64.9% { opacity: 1; }
+  65%, 100% { opacity: 0; }
+}
+
+@keyframes aiHoofFidgetOpen {
+  0%, 64.9% { opacity: 0; }
+  65%, 100% { opacity: 1; }
 }
 
 /* Leaving: stepped slide-out, retracts showing the closed hoof. */


### PR DESCRIPTION
Addresses live-test feedback:
- Closed frame stayed visible behind the spread-open frame during fidget (different silhouettes). Now both frames animate in counter-phase so exactly one shows at a time.
- Raise threshold 1500ms -> 3500ms so the hoof only appears on genuinely long deliberations instead of almost every move.
- Slow the motion: slide-in 0.45s -> 0.8s and fidget 0.5s -> 1.5s per cycle with the closed/rest frame held longer, so it reads as unhurried beard-stroking rather than a nervous twitch. Slide-out left as-is.


Claude-Session: https://claude.ai/code/session_01QWep6Zsim5uEqa5br7vuHk