### PR TITLE
AI шаг 3: не тратить точность (crosshair) на очень коротких выстрелах

### DIFF
--- a/script.js
+++ b/script.js
@@ -27675,6 +27675,12 @@ function logTacticalItemFinalDecision(itemType, details = {}){
   });
 }
 
+// Step 3: below this fraction of flight range a shot is "very short". Crosshair
+// removes angular spread, which barely deflects a short flight, so it is wasted
+// on a short non-precision shot that would land on target anyway. A genuine
+// bounce/ricochet/gap still needs precision even when short, and is exempt.
+const AI_CROSSHAIR_MIN_DISTANCE_RATIO = 0.3;
+
 function shouldAiUseCrosshairForSelectedPlan(context, selectedPlan){
   const plane = selectedPlan?.plane || null;
   if(!plane) return false;
@@ -27694,6 +27700,11 @@ function shouldAiUseCrosshairForSelectedPlan(context, selectedPlan){
     : Math.hypot((selectedPlan?.landingX || 0) - (plane?.x || 0), (selectedPlan?.landingY || 0) - (plane?.y || 0));
   const effectiveRangePx = Math.max(1, getEffectiveFlightRangeCells(plane) * CELL_SIZE);
   const distanceRatio = moveDistance / effectiveRangePx;
+  // Negative guard: don't burn a guaranteed-hit crosshair on a very short,
+  // non-precision shot — the spread can't deflect it enough to matter.
+  if(distanceRatio < AI_CROSSHAIR_MIN_DISTANCE_RATIO && !hasPrecisionRoute && bounceCount <= 0){
+    return false;
+  }
   const mediumOrLongShot = distanceRatio >= 0.45;
   const predictedHitValue = Number.isFinite(selectedPlan?.score) && selectedPlan.score >= 0.25;
   const hasTargetPoint = Number.isFinite(selectedPlan?.targetPoint?.x) && Number.isFinite(selectedPlan?.targetPoint?.y);

--- a/scripts/smoke-ai-crosshair-short-guard.js
+++ b/scripts/smoke-ai-crosshair-short-guard.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+'use strict';
+
+// Smoke test: Step 3 — crosshair short-shot negative guard.
+//
+// shouldAiUseCrosshairForSelectedPlan must NOT request a guaranteed-hit crosshair
+// on a very short, non-precision shot (spread barely deflects it), but must still
+// use it on long shots and on genuine bounce/gap/ricochet routes (precision
+// matters there even when short).
+
+const fs = require('fs');
+const vm = require('vm');
+
+function extractFunctionSource(source, fnName){
+  const signature = `function ${fnName}(`;
+  const start = source.indexOf(signature);
+  if(start === -1) throw new Error(`Function not found in script.js: ${fnName}`);
+  const signatureEnd = source.indexOf(')', start);
+  const bodyStart = source.indexOf('{', signatureEnd);
+  let depth = 0;
+  for(let i = bodyStart; i < source.length; i += 1){
+    const ch = source[i];
+    if(ch === '{') depth += 1;
+    if(ch === '}') depth -= 1;
+    if(depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`Function body end not found for: ${fnName}`);
+}
+
+function assert(condition, message){
+  if(!condition) throw new Error(message);
+}
+
+const source = fs.readFileSync('script.js', 'utf8');
+const fnSrc = extractFunctionSource(source, 'shouldAiUseCrosshairForSelectedPlan');
+
+const plane = { x: 0, y: 0 };
+const context = {
+  Math,
+  Number,
+  CELL_SIZE: 20,
+  AI_CROSSHAIR_MIN_DISTANCE_RATIO: 0.3, // module-scope const in script.js
+  getEffectiveFlightRangeCells: () => 30, // effectiveRangePx = 600
+  getAiSelectedPlanIntentText: (plan) =>
+    `${plan?.goalName || ''} ${plan?.decisionReason || ''} ${plan?.routeClass || ''}`.toLowerCase(),
+};
+vm.createContext(context);
+vm.runInContext(fnSrc, context);
+
+const callFor = (plan) => context.shouldAiUseCrosshairForSelectedPlan(context, plan);
+
+// 1. Very short DIRECT shot at a target with a decent score -> NO crosshair.
+assert(callFor({
+  plane, routeClass: 'direct', goalName: 'attack', decisionReason: 'simple_step2_direct_enemy',
+  bounceCount: 0, planDistance: 100, targetPoint: { x: 0, y: 100 }, score: 0.5,
+}) === false, '1: very short direct shot must NOT use crosshair.');
+
+// 2. Long DIRECT shot at a target -> crosshair.
+assert(callFor({
+  plane, routeClass: 'direct', goalName: 'attack', decisionReason: 'simple_step2_direct_enemy',
+  bounceCount: 0, planDistance: 350, targetPoint: { x: 0, y: 350 }, score: 0.5,
+}) === true, '2: long direct shot should use crosshair.');
+
+// 3. Very short RICOCHET (bounce) -> crosshair (precision needed even when short).
+assert(callFor({
+  plane, routeClass: 'ricochet', goalName: 'attack', decisionReason: 'simple_step2_ricochet_enemy',
+  bounceCount: 1, planDistance: 100, targetPoint: { x: 50, y: 80 }, score: 0.5,
+}) === true, '3: short ricochet must still use crosshair.');
+
+// 4. Very short GAP route (no bounce, but a precision route) -> crosshair.
+assert(callFor({
+  plane, routeClass: 'gap', goalName: 'pickup_cargo', decisionReason: 'simple_step2_pickup_cargo',
+  bounceCount: 0, planDistance: 100, targetPoint: { x: 30, y: 90 }, score: 0.4,
+}) === true, '4: short gap (precision) route must still use crosshair.');
+
+// 5. Medium shot (ratio 0.35, between the short floor and 0.45) at a target ->
+//    still crosshair via target+score (only < floor is suppressed).
+assert(callFor({
+  plane, routeClass: 'direct', goalName: 'attack', decisionReason: 'simple_step2_direct_enemy',
+  bounceCount: 0, planDistance: 210, targetPoint: { x: 0, y: 210 }, score: 0.5,
+}) === true, '5: a medium (>= floor) targeted shot keeps crosshair.');
+
+console.log('Smoke test passed: crosshair short-shot guard suppresses waste, keeps long + precision shots.');


### PR DESCRIPTION
Шаг 3 (простой, негативный гард по инвентарю — точность).

## Проблема
`shouldAiUseCrosshairForSelectedPlan` накладывал гарантированное попадание на **любой** выстрел по цели со score≥0.25 — **без нижнего порога по дистанции** (ветка `hasTargetPoint && predictedHitValue`). На очень коротком выстреле угловой разброс почти не отклоняет полёт → точность тратится впустую (попал бы и так).

## Что сделано
Добавлен порог: ниже `AI_CROSSHAIR_MIN_DISTANCE_RATIO` (0.3 дальности) **непрецизионный** короткий выстрел больше не запрашивает точность.

Исключения (точность нужна даже на коротке) — остаются:
- настоящие маршруты рикошет / gap / bounce / bank (`hasPrecisionRoute`);
- любой выстрел с отскоком (`bounceCount > 0`).

Длинные выстрелы — без изменений. Одна тюнинг-константа `AI_CROSSHAIR_MIN_DISTANCE_RATIO`.

> «Шедевральное» применение точности (на сложных многоцелевых рикошетных маршрутах, в связке с топливом/крыльями) — это Шаг 6, он строится поверх Шага 2 и этого гарда. Здесь только убираем бесполезную трату.

## Проверка
`scripts/smoke-ai-crosshair-short-guard.js` (прямой unit-тест чистой функции):
- короткий прямой выстрел по цели → **без** точности;
- длинный прямой → с точностью;
- короткий рикошет (bounce) → с точностью;
- короткий gap-маршрут → с точностью;
- средний (≥ порога) прицельный → с точностью.

```
$ node scripts/smoke-ai-crosshair-short-guard.js
Smoke test passed: crosshair short-shot guard suppresses waste, keeps long + precision shots.
```

### Ручная проверка (self-analyzer)
Короткий добивающий выстрел вплотную к врагу — в инвентарных решениях больше нет `selected_plan_precision_support` (crosshair) на таких; на длинных/рикошетных остаётся.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_