### PR TITLE
Hoof: commit to a fixed 3-squeeze gesture, slower exit

### DIFF
--- a/script.js
+++ b/script.js
@@ -15115,59 +15115,63 @@ function getAiTurnTimingSnapshot(){
   };
 }
 
-// "AI is thinking" goat hoof controller. Self-gating: arm() starts a timer on
-// every AI turn; the hoof only slides in if the AI is STILL deliberating after
-// AI_THINK_HOOF_THRESHOLD_MS, so quick moves never summon it. release() clears
-// the timer or retracts the hoof the moment the move is ready. Pure class
-// toggling — the slide/fidget keyframes live in styles.css.
+// "AI is thinking" goat hoof controller. arm() starts a timer on every goat
+// (blue) AI turn. If the AI is STILL deliberating after AI_THINK_HOOF_THRESHOLD_MS
+// (i.e. aiming hasn't started yet), the hoof commits to a FIXED, self-contained
+// gesture — slide in -> exactly 3 squeezes -> slide out — and always plays it to
+// the end. A short move (released before the threshold) is the only thing that
+// cancels it, so the hoof never appears just to retract immediately as a
+// half-read stub. Phases hand off via animationend; keyframes live in styles.css.
 const AI_THINK_HOOF_THRESHOLD_MS = 3500;
 const aiThinkHoof = (() => {
   let el = null;
   let armTimer = 0;
   let phase = "idle"; // idle | armed | entering | fidgeting | leaving
-  let endHandler = null;
+  let wired = false;
 
   function getEl(){
     if(el === null) el = document.getElementById("aiThinkHoof") || false;
     return el || null;
   }
-  function detachEnd(node){
-    if(endHandler && node) node.removeEventListener("animationend", endHandler);
-    endHandler = null;
-  }
   function setPhaseClass(node, cls){
     node.classList.remove("is-entering", "is-fidgeting", "is-leaving");
     if(cls) node.classList.add(cls);
   }
-  function onSlideInEnd(node){
-    detachEnd(node);
-    if(phase !== "entering") return;
-    phase = "fidgeting";
-    setPhaseClass(node, "is-fidgeting");
-  }
-  function onSlideOutEnd(node){
-    detachEnd(node);
-    if(phase !== "leaving") return;
-    phase = "idle";
-    setPhaseClass(node, null); // back to hidden parked state
+  function wire(node){
+    if(wired) return;
+    wired = true;
+    // One persistent router: each phase's animation hands off to the next.
+    node.addEventListener("animationend", (e) => {
+      switch(e.animationName){
+        case "aiHoofSlideIn":
+          if(phase !== "entering") return;
+          phase = "fidgeting";
+          setPhaseClass(node, "is-fidgeting"); // CSS iteration count = 3 squeezes
+          break;
+        case "aiHoofFidgetOpen": // fires once, after the 3rd squeeze completes
+          if(phase !== "fidgeting") return;
+          leave();
+          break;
+        case "aiHoofSlideOut":
+          if(phase !== "leaving") return;
+          phase = "idle";
+          setPhaseClass(node, null); // back to hidden parked state
+          break;
+      }
+    });
   }
   function enter(){
     const node = getEl();
     if(!node) return;
+    wire(node);
     phase = "entering";
     setPhaseClass(node, "is-entering");
-    detachEnd(node);
-    endHandler = () => onSlideInEnd(node);
-    node.addEventListener("animationend", endHandler);
   }
   function leave(){
     const node = getEl();
     if(!node) return;
     phase = "leaving";
     setPhaseClass(node, "is-leaving");
-    detachEnd(node);
-    endHandler = () => onSlideOutEnd(node);
-    node.addEventListener("animationend", endHandler);
   }
   function isGoatTurn(){
     // The goat is the top-left (blue) player; the sparrow is green. Only the
@@ -15178,15 +15182,19 @@ const aiThinkHoof = (() => {
     const node = getEl();
     if(!node) return;
     if(armTimer){ clearTimeout(armTimer); armTimer = 0; }
-    if(phase !== "idle"){ detachEnd(node); setPhaseClass(node, null); phase = "idle"; }
+    // A new AI turn supersedes any leftover gesture still on screen.
+    if(phase !== "idle"){ setPhaseClass(node, null); phase = "idle"; }
     if(!isGoatTurn()) return;
     phase = "armed";
     armTimer = setTimeout(() => { armTimer = 0; enter(); }, AI_THINK_HOOF_THRESHOLD_MS);
   }
   function release(){
-    if(armTimer){ clearTimeout(armTimer); armTimer = 0; }
-    if(phase === "entering" || phase === "fidgeting") leave();
-    else if(phase === "armed") phase = "idle"; // never crossed the threshold
+    // Only a short move (released before the threshold) cancels the hoof. Once
+    // the gesture has committed it always completes on its own — never a stub.
+    if(phase === "armed"){
+      if(armTimer){ clearTimeout(armTimer); armTimer = 0; }
+      phase = "idle";
+    }
   }
   return { arm, release };
 })();

--- a/styles.css
+++ b/styles.css
@@ -2051,11 +2051,11 @@ body, button {
    Slow, calm rhythm: the closed (rest) frame is held longer than the open
    squeeze, so it reads as unhurried beard-stroking, not a nervous twitch. */
 #aiThinkHoof.is-fidgeting .ai-think-hoof__frame--close {
-  animation: aiHoofFidgetClose 1.5s steps(1, end) infinite;
+  animation: aiHoofFidgetClose 1.5s steps(1, end) 3;
 }
 
 #aiThinkHoof.is-fidgeting .ai-think-hoof__frame--open {
-  animation: aiHoofFidgetOpen 1.5s steps(1, end) infinite;
+  animation: aiHoofFidgetOpen 1.5s steps(1, end) 3;
 }
 
 @keyframes aiHoofFidgetClose {
@@ -2071,7 +2071,7 @@ body, button {
 /* Leaving: stepped slide-out, retracts showing the closed hoof. */
 #aiThinkHoof.is-leaving {
   visibility: visible;
-  animation: aiHoofSlideOut 0.4s steps(1, end) forwards;
+  animation: aiHoofSlideOut 0.75s steps(1, end) forwards;
 }
 
 @keyframes aiHoofSlideOut {


### PR DESCRIPTION
Live-test feedback on the thinking-hoof timing:
- The hoof used to fidget until the move was ready and retract on release, so a move finishing just after the threshold produced an unreadable single-squeeze stub. The gesture is now fully committed once it starts: slide in -> exactly 3 squeezes (CSS iteration count) -> slide out, always played to the end. Phases hand off via an animationName router.
- release() now only cancels the still-armed timer (a short move never even extracts the hoof, including when aiming has already begun); it no longer interrupts a gesture in progress.
- Slow the slide-out 0.4s -> 0.75s to match the calmer entry/fidget rhythm.


Claude-Session: https://claude.ai/code/session_01QWep6Zsim5uEqa5br7vuHk