### PR TITLE
AI шаг 3: точность (crosshair) только на максимальной дальности

### DIFF
--- a/script.js
+++ b/script.js
@@ -27765,40 +27765,33 @@ function logTacticalItemFinalDecision(itemType, details = {}){
   });
 }
 
-// Step 3: below this fraction of flight range a shot is "very short". Crosshair
-// removes angular spread, which barely deflects a short flight, so it is wasted
-// on a short non-precision shot that would land on target anyway. A genuine
-// bounce/ricochet/gap still needs precision even when short, and is exempt.
-const AI_CROSSHAIR_MIN_DISTANCE_RATIO = 0.3;
+// Step 3: crosshair (guaranteed hit) only matters near MAX range, where the
+// launch's angular spread actually deflects the flight enough to miss. Below
+// this fraction of flight range the spread is too small to matter, so a
+// crosshair is wasted there — including on short ricochets/gaps. Per design:
+// "only on maximal shots, or 80-90% of max when needed; everything else is
+// pointless." 0.8 = lowest acceptable; raise toward 0.9 for max-only.
+const AI_CROSSHAIR_MIN_DISTANCE_RATIO = 0.8;
 
 function shouldAiUseCrosshairForSelectedPlan(context, selectedPlan){
   const plane = selectedPlan?.plane || null;
   if(!plane) return false;
   const routeClass = `${selectedPlan?.routeClass || "direct"}`.toLowerCase();
   const goalText = getAiSelectedPlanIntentText(selectedPlan);
-  const usefulIntent = [
-    "attack", "enemy", "cargo", "pickup", "flag", "center",
-    "advance", "approach", "pressure", "direct", "ricochet",
-    "gap", "safe", "reposition", "best_effort", "fallback",
-  ].some((word) => goalText.includes(word));
-  const hasPrecisionRoute = ["ricochet", "bounce", "bank", "gap"].some((route) =>
-    routeClass.includes(route) || goalText.includes(route)
-  );
-  const bounceCount = Number.isFinite(selectedPlan?.bounceCount) ? selectedPlan.bounceCount : 0;
   const moveDistance = Number.isFinite(selectedPlan?.planDistance)
     ? selectedPlan.planDistance
     : Math.hypot((selectedPlan?.landingX || 0) - (plane?.x || 0), (selectedPlan?.landingY || 0) - (plane?.y || 0));
   const effectiveRangePx = Math.max(1, getEffectiveFlightRangeCells(plane) * CELL_SIZE);
   const distanceRatio = moveDistance / effectiveRangePx;
-  // Negative guard: don't burn a guaranteed-hit crosshair on a very short,
-  // non-precision shot — the spread can't deflect it enough to matter.
-  if(distanceRatio < AI_CROSSHAIR_MIN_DISTANCE_RATIO && !hasPrecisionRoute && bounceCount <= 0){
-    return false;
-  }
-  const mediumOrLongShot = distanceRatio >= 0.45;
-  const predictedHitValue = Number.isFinite(selectedPlan?.score) && selectedPlan.score >= 0.25;
-  const hasTargetPoint = Number.isFinite(selectedPlan?.targetPoint?.x) && Number.isFinite(selectedPlan?.targetPoint?.y);
-  return hasPrecisionRoute || bounceCount > 0 || ((mediumOrLongShot && usefulIntent) || (hasTargetPoint && predictedHitValue));
+  // Hard distance gate: nothing below ~80% of range justifies a crosshair.
+  if(distanceRatio < AI_CROSSHAIR_MIN_DISTANCE_RATIO) return false;
+  // Near-max shot: use it only for a meaningful aimed shot (attack / pickup /
+  // flag / precision route), not an aimless long drift to center.
+  const precisionIntent = [
+    "attack", "enemy", "cargo", "pickup", "flag",
+    "ricochet", "gap", "bounce", "bank", "multi_target",
+  ].some((word) => goalText.includes(word) || routeClass.includes(word));
+  return precisionIntent;
 }
 
 function shouldAiUseWingsForSelectedPlan(context, selectedPlan){
@@ -29049,9 +29042,6 @@ function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, avail
   const moveRangeRatio = baseRangePx > 0 ? moveDistance / baseRangePx : 0;
   const goalText = getAiSelectedPlanIntentText(selectedPlan);
   const routeClass = `${selectedPlan?.routeClass || "direct"}`.toLowerCase();
-  const precisionRoute = ["ricochet", "gap", "bank", "bounce"].some((word) =>
-    routeClass.includes(word) || goalText.includes(word)
-  );
   const contactIntent = [
     "attack", "enemy", "cargo", "pickup", "flag",
     "gap", "ricochet", "bounce", "bank",
@@ -29138,7 +29128,10 @@ function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, avail
   }
 
   // Crosshair and wings are evaluated independently and can combine with each other and with fuel.
-  if(crosshairAvailable && (precisionRoute || shouldAiUseCrosshairForSelectedPlan(context, selectedPlan))){
+  // The distance gate now lives entirely in shouldAiUseCrosshairForSelectedPlan
+  // (crosshair only near max range). No precision-route bypass — a short
+  // ricochet/gap must clear the distance gate too.
+  if(crosshairAvailable && shouldAiUseCrosshairForSelectedPlan(context, selectedPlan)){
     candidates.push({ itemType: INVENTORY_ITEM_TYPES.CROSSHAIR, reason: "selected_plan_precision_support" });
   }
 

--- a/scripts/smoke-ai-crosshair-short-guard.js
+++ b/scripts/smoke-ai-crosshair-short-guard.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 'use strict';
 
-// Smoke test: Step 3 — crosshair short-shot negative guard.
+// Smoke test: Step 3 — crosshair only on near-max-range shots.
 //
-// shouldAiUseCrosshairForSelectedPlan must NOT request a guaranteed-hit crosshair
-// on a very short, non-precision shot (spread barely deflects it), but must still
-// use it on long shots and on genuine bounce/gap/ricochet routes (precision
-// matters there even when short).
+// Exercises the real caller (pickAiBuffsForSelectedPlan), since the bug was its
+// `precisionRoute ||` bypass that handed a crosshair to ANY ricochet/gap route
+// regardless of distance. Crosshair (guaranteed hit) only matters near max
+// range; below ~80% of range it's pointless — including short ricochets.
 
 const fs = require('fs');
 const vm = require('vm');
@@ -32,52 +32,69 @@ function assert(condition, message){
 }
 
 const source = fs.readFileSync('script.js', 'utf8');
-const fnSrc = extractFunctionSource(source, 'shouldAiUseCrosshairForSelectedPlan');
 
-const plane = { x: 0, y: 0 };
+const plane = { x: 0, y: 0, activeTurnBuffs: {} };
+const INVENTORY_ITEM_TYPES = { FUEL: 'fuel', CROSSHAIR: 'crosshair', WINGS: 'wings', INVISIBILITY: 'invisible', MINE: 'mine', DYNAMITE: 'dynamite' };
+
 const context = {
   Math,
   Number,
   CELL_SIZE: 20,
-  AI_CROSSHAIR_MIN_DISTANCE_RATIO: 0.3, // module-scope const in script.js
+  AI_CROSSHAIR_MIN_DISTANCE_RATIO: 0.8, // module-scope const in script.js
+  INVENTORY_ITEM_TYPES,
   getEffectiveFlightRangeCells: () => 30, // effectiveRangePx = 600
   getAiSelectedPlanIntentText: (plan) =>
     `${plan?.goalName || ''} ${plan?.decisionReason || ''} ${plan?.routeClass || ''}`.toLowerCase(),
 };
 vm.createContext(context);
-vm.runInContext(fnSrc, context);
+// Both functions share the VM context (pickAiBuffs calls shouldAiUseCrosshair).
+vm.runInContext(extractFunctionSource(source, 'shouldAiUseCrosshairForSelectedPlan'), context);
+vm.runInContext(extractFunctionSource(source, 'pickAiBuffsForSelectedPlan'), context);
 
-const callFor = (plan) => context.shouldAiUseCrosshairForSelectedPlan(context, plan);
+// Only crosshair is in inventory, so only the crosshair branch can fire.
+const usesCrosshair = (selectedPlan) => context.pickAiBuffsForSelectedPlan({
+  plane: selectedPlan.plane,
+  color: 'blue',
+  context: {},
+  selectedPlan,
+  availableCounts: { crosshair: 1 },
+}).some((c) => c.itemType === 'crosshair');
 
-// 1. Very short DIRECT shot at a target with a decent score -> NO crosshair.
-assert(callFor({
+// 1. Near-max DIRECT attack (ratio 0.85) -> crosshair.
+assert(usesCrosshair({
   plane, routeClass: 'direct', goalName: 'attack', decisionReason: 'simple_step2_direct_enemy',
-  bounceCount: 0, planDistance: 100, targetPoint: { x: 0, y: 100 }, score: 0.5,
-}) === false, '1: very short direct shot must NOT use crosshair.');
+  bounceCount: 0, planDistance: 510, targetPoint: { x: 0, y: 510 }, score: 0.5,
+}) === true, '1: near-max direct attack should use crosshair.');
 
-// 2. Long DIRECT shot at a target -> crosshair.
-assert(callFor({
+// 2. Short DIRECT attack (ratio 0.2) -> NO crosshair.
+assert(usesCrosshair({
   plane, routeClass: 'direct', goalName: 'attack', decisionReason: 'simple_step2_direct_enemy',
-  bounceCount: 0, planDistance: 350, targetPoint: { x: 0, y: 350 }, score: 0.5,
-}) === true, '2: long direct shot should use crosshair.');
+  bounceCount: 0, planDistance: 120, targetPoint: { x: 0, y: 120 }, score: 0.5,
+}) === false, '2: short direct attack must NOT use crosshair.');
 
-// 3. Very short RICOCHET (bounce) -> crosshair (precision needed even when short).
-assert(callFor({
+// 3. Short RICOCHET (ratio 0.2) -> NO crosshair (the reported bug: the
+//    precisionRoute bypass used to grant it regardless of distance).
+assert(usesCrosshair({
   plane, routeClass: 'ricochet', goalName: 'attack', decisionReason: 'simple_step2_ricochet_enemy',
-  bounceCount: 1, planDistance: 100, targetPoint: { x: 50, y: 80 }, score: 0.5,
-}) === true, '3: short ricochet must still use crosshair.');
+  bounceCount: 1, planDistance: 120, targetPoint: { x: 40, y: 90 }, score: 0.5,
+}) === false, '3: short ricochet must NOT use crosshair (bypass removed).');
 
-// 4. Very short GAP route (no bounce, but a precision route) -> crosshair.
-assert(callFor({
-  plane, routeClass: 'gap', goalName: 'pickup_cargo', decisionReason: 'simple_step2_pickup_cargo',
-  bounceCount: 0, planDistance: 100, targetPoint: { x: 30, y: 90 }, score: 0.4,
-}) === true, '4: short gap (precision) route must still use crosshair.');
+// 4. Near-max RICOCHET (ratio 0.9) -> crosshair.
+assert(usesCrosshair({
+  plane, routeClass: 'ricochet', goalName: 'attack', decisionReason: 'simple_step2_ricochet_enemy',
+  bounceCount: 1, planDistance: 540, targetPoint: { x: 100, y: 500 }, score: 0.5,
+}) === true, '4: near-max ricochet should use crosshair.');
 
-// 5. Medium shot (ratio 0.35, between the short floor and 0.45) at a target ->
-//    still crosshair via target+score (only < floor is suppressed).
-assert(callFor({
+// 5. Mid-range DIRECT attack (ratio 0.5) -> NO crosshair (below the 0.8 floor).
+assert(usesCrosshair({
   plane, routeClass: 'direct', goalName: 'attack', decisionReason: 'simple_step2_direct_enemy',
-  bounceCount: 0, planDistance: 210, targetPoint: { x: 0, y: 210 }, score: 0.5,
-}) === true, '5: a medium (>= floor) targeted shot keeps crosshair.');
+  bounceCount: 0, planDistance: 300, targetPoint: { x: 0, y: 300 }, score: 0.5,
+}) === false, '5: mid-range attack below 0.8 must NOT use crosshair.');
 
-console.log('Smoke test passed: crosshair short-shot guard suppresses waste, keeps long + precision shots.');
+// 6. Near-max aimless CENTER drift (ratio 0.9, no attack/pickup intent) -> NO crosshair.
+assert(usesCrosshair({
+  plane, routeClass: 'direct', goalName: 'simple_step2_center', decisionReason: 'simple_step2_center_control',
+  bounceCount: 0, planDistance: 540, targetPoint: { x: 0, y: 540 }, score: 0.1,
+}) === false, '6: a near-max aimless center drift must NOT use crosshair.');
+
+console.log('Smoke test passed: crosshair only on near-max meaningful shots; short/ricochet/mid suppressed.');


### PR DESCRIPTION
Шаг 3, чистый отдельный PR (заменяет #2834 — там первая, нерабочая версия).

## Правило
Crosshair = гарантированное попадание (убирает угловой разброс запуска). Разброс реально уводит полёт мимо **только у максимальной дальности**; на коротких выстрелах он слишком мал, чтобы влиять → точность там бессмысленна, **включая короткие рикошеты/gap**. Правило: только на максимальных, или 80–90% от максимума при необходимости; всё короче — мусор.

## Что сделано
- `shouldAiUseCrosshairForSelectedPlan` — **жёсткий дистанционный гейт** `AI_CROSSHAIR_MIN_DISTANCE_RATIO = 0.8`: ниже 80% дальности — никогда. Выше — только для осмысленного прицельного выстрела (атака/подбор/флаг/precision/мультицель), не для бесцельного долёта к центру.
- **Убран обход** `precisionRoute || …` в `pickAiBuffsForSelectedPlan` — именно он выдавал crosshair на любом рикошете/gap **в обход дистанции**. Теперь дистанционный гейт — единственный источник правды.

Константа `0.8` — нижняя граница из формулировки; поднять к `0.9` для «только максималки» — одна цифра.

## Проверка
`scripts/smoke-ai-crosshair-short-guard.js` гоняет **реальный вызывающий код** `pickAiBuffsForSelectedPlan`:
- короткий прямой / короткий рикошет / средний (0.5) → **без** точности;
- near-max атака / near-max рикошет → с точностью;
- near-max бесцельный долёт к центру → без точности.

```
$ node scripts/smoke-ai-crosshair-short-guard.js
Smoke test passed: crosshair only on near-max meaningful shots; short/ricochet/mid suppressed.
```

«Шедевральное» применение точности (на жирных мультицель-рикошетах + топливо/крылья) — Шаг 6, поверх Шага 2 и этого гейта.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_