### PR TITLE
AI: точность вообще перестала применяться — чиню порог

### DIFF
--- a/script.js
+++ b/script.js
@@ -27765,25 +27765,31 @@ function logTacticalItemFinalDecision(itemType, details = {}){
   });
 }
 
-// Step 3: crosshair (guaranteed hit) only matters near MAX range, where the
-// launch's angular spread actually deflects the flight enough to miss. Below
-// this fraction of flight range the spread is too small to matter, so a
-// crosshair is wasted there — including on short ricochets/gaps. Per design:
-// "only on maximal shots, or 80-90% of max when needed; everything else is
-// pointless." 0.8 = lowest acceptable; raise toward 0.9 for max-only.
-const AI_CROSSHAIR_MIN_DISTANCE_RATIO = 0.8;
+// Step 3: crosshair (guaranteed hit) only matters on a LONG launch, where the
+// launch's angular spread deflects the flight enough to miss; on short shots the
+// spread is too small to matter, so it's wasted (including short ricochets/gaps).
+// Measured against how FAR the shot actually flies. NOTE: the gate is a fraction
+// of theoretical max range (~600px), which exceeds most board shots and the AI
+// often under-powers its launches — so 0.8 fired almost never. 0.6 = a genuinely
+// long shot; tune up toward 0.8 for max-only, down for more frequent use.
+const AI_CROSSHAIR_MIN_DISTANCE_RATIO = 0.6;
 
 function shouldAiUseCrosshairForSelectedPlan(context, selectedPlan){
   const plane = selectedPlan?.plane || null;
   if(!plane) return false;
   const routeClass = `${selectedPlan?.routeClass || "direct"}`.toLowerCase();
   const goalText = getAiSelectedPlanIntentText(selectedPlan);
-  const moveDistance = Number.isFinite(selectedPlan?.planDistance)
-    ? selectedPlan.planDistance
-    : Math.hypot((selectedPlan?.landingX || 0) - (plane?.x || 0), (selectedPlan?.landingY || 0) - (plane?.y || 0));
+  // Use the longer of: straight-line distance to the target, and the actual
+  // launch travel (landingX/landingY encode the launch vector). The latter
+  // matters for ricochets/sweeps whose bouncy flight is far longer than the
+  // straight line to the target — those are exactly the long shots that want a
+  // crosshair but were under-measured before.
+  const planDistance = Number.isFinite(selectedPlan?.planDistance) ? selectedPlan.planDistance : 0;
+  const launchTravel = Math.hypot((selectedPlan?.landingX ?? plane.x) - plane.x, (selectedPlan?.landingY ?? plane.y) - plane.y);
+  const moveDistance = Math.max(planDistance, launchTravel);
   const effectiveRangePx = Math.max(1, getEffectiveFlightRangeCells(plane) * CELL_SIZE);
   const distanceRatio = moveDistance / effectiveRangePx;
-  // Hard distance gate: nothing below ~80% of range justifies a crosshair.
+  // Distance gate: nothing below a genuinely long shot justifies a crosshair.
   if(distanceRatio < AI_CROSSHAIR_MIN_DISTANCE_RATIO) return false;
   // Near-max shot: use it only for a meaningful aimed shot (attack / pickup /
   // flag / precision route), not an aimless long drift to center.

--- a/scripts/smoke-ai-crosshair-short-guard.js
+++ b/scripts/smoke-ai-crosshair-short-guard.js
@@ -40,7 +40,7 @@ const context = {
   Math,
   Number,
   CELL_SIZE: 20,
-  AI_CROSSHAIR_MIN_DISTANCE_RATIO: 0.8, // module-scope const in script.js
+  AI_CROSSHAIR_MIN_DISTANCE_RATIO: 0.6, // module-scope const in script.js
   INVENTORY_ITEM_TYPES,
   getEffectiveFlightRangeCells: () => 30, // effectiveRangePx = 600
   getAiSelectedPlanIntentText: (plan) =>
@@ -85,16 +85,24 @@ assert(usesCrosshair({
   bounceCount: 1, planDistance: 540, targetPoint: { x: 100, y: 500 }, score: 0.5,
 }) === true, '4: near-max ricochet should use crosshair.');
 
-// 5. Mid-range DIRECT attack (ratio 0.5) -> NO crosshair (below the 0.8 floor).
+// 5. Short DIRECT attack (ratio 0.3) -> NO crosshair (below the 0.6 floor).
 assert(usesCrosshair({
   plane, routeClass: 'direct', goalName: 'attack', decisionReason: 'simple_step2_direct_enemy',
-  bounceCount: 0, planDistance: 300, targetPoint: { x: 0, y: 300 }, score: 0.5,
-}) === false, '5: mid-range attack below 0.8 must NOT use crosshair.');
+  bounceCount: 0, planDistance: 180, targetPoint: { x: 0, y: 180 }, score: 0.5,
+}) === false, '5: short attack below 0.6 must NOT use crosshair.');
 
-// 6. Near-max aimless CENTER drift (ratio 0.9, no attack/pickup intent) -> NO crosshair.
+// 6. Near-max aimless CENTER drift (no attack/pickup intent) -> NO crosshair.
 assert(usesCrosshair({
   plane, routeClass: 'direct', goalName: 'simple_step2_center', decisionReason: 'simple_step2_center_control',
   bounceCount: 0, planDistance: 540, targetPoint: { x: 0, y: 540 }, score: 0.1,
 }) === false, '6: a near-max aimless center drift must NOT use crosshair.');
 
-console.log('Smoke test passed: crosshair only on near-max meaningful shots; short/ricochet/mid suppressed.');
+// 7. LONG ricochet whose straight-line planDistance is short (100) but whose
+//    actual launch travel is long (landing far) -> crosshair, via the launch-
+//    travel metric (these long bouncy shots were under-measured before).
+assert(usesCrosshair({
+  plane, routeClass: 'ricochet', goalName: 'attack', decisionReason: 'simple_step2_ricochet_enemy',
+  bounceCount: 2, planDistance: 100, landingX: 0, landingY: 420, targetPoint: { x: 60, y: 90 }, score: 0.5,
+}) === true, '7: a long-travel ricochet should use crosshair even if the straight-line distance is short.');
+
+console.log('Smoke test passed: crosshair on long shots (incl. long ricochets), suppressed on short/mid/aimless.');


### PR DESCRIPTION
Отдельный PR — фикс к уже влитому #2837.

## Проблема
После #2837 ИИ **перестал использовать crosshair вообще**. Причины:
1. Порог `0.8` считался от **теоретической максимальной дальности** (~600px), которая больше типичных выстрелов на поле; плюс ИИ часто бьёт не на полную мощность → 0.8 практически недостижим.
2. Длинные **рикошетные** броски мерились по прямой до цели (короче реального полёта с отскоками) → недооценивались.

## Что сделано
- Длину выстрела меряю как `max(planDistance, реальный_бросок)`, где `реальный_бросок = hypot(landing − plane)`. Теперь длинные рикошеты/sweep-маршруты считаются по фактическому полёту, а не по прямой.
- Порог `AI_CROSSHAIR_MIN_DISTANCE_RATIO` опустил **0.8 → 0.6** (реально длинный выстрел). Короткие/средние по-прежнему без точности.

Это всё ещё «точность только на длинных», просто 0.8 от 600px было фактически «никогда». Константа одна — если на плейтесте захочешь реже (ближе к максималкам), поднимем к 0.7–0.8; чаще — опустим.

## Проверка
`scripts/smoke-ai-crosshair-short-guard.js` (реальный вызывающий код `pickAiBuffsForSelectedPlan`), порог 0.6:
- короткий прямой / короткий рикошет / короткий (0.3) → **без** точности;
- длинная атака / длинный рикошет → с точностью;
- **длинный рикошет с короткой прямой, но дальним полётом** → теперь **с** точностью (метрика по факту полёта);
- бесцельный долёт к центру → без точности.

```
$ node scripts/smoke-ai-crosshair-short-guard.js
Smoke test passed: crosshair on long shots (incl. long ricochets), suppressed on short/mid/aimless.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_