### PR TITLE
AI шаг 4: широкие крылья только когда включают мульти-сбор

### DIFF
--- a/script.js
+++ b/script.js
@@ -27794,50 +27794,44 @@ function shouldAiUseCrosshairForSelectedPlan(context, selectedPlan){
   return precisionIntent;
 }
 
+// Step 4: wide wings widen the BENEFICIAL pickup span (96px vs 36px), so they
+// pay off only when the route sweeps MORE cargo with the wide span than without
+// — i.e. a multi-pickup run the plane couldn't make on a normal span. At least
+// this many cargo must be collected WITH wings (and strictly more than without).
+const AI_WINGS_MIN_PICKUPS = 2;
+
 function shouldAiUseWingsForSelectedPlan(context, selectedPlan){
   const plane = selectedPlan?.plane || null;
   if(!plane) return false;
-  const landingPoint = {
-    x: Number(selectedPlan?.landingX),
-    y: Number(selectedPlan?.landingY),
-  };
-  if(!Number.isFinite(landingPoint.x) || !Number.isFinite(landingPoint.y)) return false;
+  const landingX = Number(selectedPlan?.landingX);
+  const landingY = Number(selectedPlan?.landingY);
+  if(!Number.isFinite(landingX) || !Number.isFinite(landingY)) return false;
 
-  const routeClass = `${selectedPlan?.routeClass || "direct"}`.toLowerCase();
-  const goalText = getAiSelectedPlanIntentText(selectedPlan);
-  const contactIntent = [
-    "attack", "enemy", "cargo", "pickup", "flag",
-    "gap", "ricochet", "bounce", "bank",
-  ].some((word) => goalText.includes(word) || routeClass.includes(word));
+  const pickups = Array.isArray(context?.readyCargo) ? context.readyCargo.filter(Boolean) : [];
+  if(pickups.length < AI_WINGS_MIN_PICKUPS) return false;
 
-  const pointsOfInterest = [];
-  if(Array.isArray(context?.enemies)){
-    pointsOfInterest.push(...context.enemies.filter((enemy) => Number.isFinite(enemy?.x) && Number.isFinite(enemy?.y)).map((enemy) => ({ x: enemy.x, y: enemy.y })));
-  }
-  if(Array.isArray(context?.readyCargo)){
-    for(const cargo of context.readyCargo){
-      const center = typeof getCargoVisualCenter === "function" ? getCargoVisualCenter(cargo) : null;
-      if(Number.isFinite(center?.x) && Number.isFinite(center?.y)){
-        pointsOfInterest.push({ x: center.x, y: center.y });
-      }
-    }
-  }
-  if(Array.isArray(context?.availableEnemyFlags)){
-    pointsOfInterest.push(...context.availableEnemyFlags.filter((flag) => Number.isFinite(flag?.x) && Number.isFinite(flag?.y)).map((flag) => ({ x: flag.x, y: flag.y })));
-  }
-  const runtimeColliders = typeof colliders !== "undefined" ? colliders : null;
-  if(Array.isArray(runtimeColliders)){
-    pointsOfInterest.push(...runtimeColliders.filter((item) => Number.isFinite(item?.cx) && Number.isFinite(item?.cy)).slice(0, 32).map((item) => ({ x: item.cx, y: item.cy })));
+  // The flown path (with ricochet bounces) — unchanged by wings; only the pickup
+  // span changes.
+  const durationSec = (typeof FIELD_FLIGHT_DURATION_SEC === "number" && FIELD_FLIGHT_DURATION_SEC > 0) ? FIELD_FLIGHT_DURATION_SEC : 1;
+  const move = { vx: (landingX - plane.x) / durationSec, vy: (landingY - plane.y) / durationSec };
+  const path = typeof getAiPlannedMovePredictedPath === "function"
+    ? getAiPlannedMovePredictedPath(plane, move)
+    : [{ x: plane.x, y: plane.y }, { x: landingX, y: landingY }];
+  if(!Array.isArray(path) || path.length < 2) return false;
+
+  const widePlane = { ...plane, activeTurnBuffs: { ...(plane.activeTurnBuffs || {}), [INVENTORY_ITEM_TYPES.WINGS]: true } };
+  const barePlane = { ...plane, activeTurnBuffs: { ...(plane.activeTurnBuffs || {}), [INVENTORY_ITEM_TYPES.WINGS]: false } };
+
+  let wideCount = 0;
+  let bareCount = 0;
+  for(const cargo of pickups){
+    if(doesCargoIntersectBeneficialZoneAlongPath(cargo, widePlane, path)) wideCount += 1;
+    if(doesCargoIntersectBeneficialZoneAlongPath(cargo, barePlane, path)) bareCount += 1;
   }
 
-  const nearestDistance = pointsOfInterest
-    .map((point) => dist(landingPoint, point))
-    .filter((value) => Number.isFinite(value))
-    .sort((a, b) => a - b)[0] ?? Number.POSITIVE_INFINITY;
-
-  const nearContactThresholdPx = CELL_SIZE * 2.3;
-  const nearContact = nearestDistance <= nearContactThresholdPx;
-  return nearContact || contactIntent;
+  // Wings are "по делу" only if the wide span turns this into a multi-pickup the
+  // normal span couldn't make (a move impossible without them).
+  return wideCount >= AI_WINGS_MIN_PICKUPS && wideCount > bareCount;
 }
 
 function shouldAiUseInvisibilityForSelectedPlan(context, selectedPlan){
@@ -29135,8 +29129,10 @@ function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, avail
     candidates.push({ itemType: INVENTORY_ITEM_TYPES.CROSSHAIR, reason: "selected_plan_precision_support" });
   }
 
-  if(wingsAvailable && (contactIntent || shouldAiUseWingsForSelectedPlan(context, selectedPlan))){
-    candidates.push({ itemType: INVENTORY_ITEM_TYPES.WINGS, reason: "selected_plan_contact_margin" });
+  // No bare contact-intent bypass: wings are used only when they enable a
+  // multi-pickup the normal span couldn't make (see shouldAiUseWingsForSelectedPlan).
+  if(wingsAvailable && shouldAiUseWingsForSelectedPlan(context, selectedPlan)){
+    candidates.push({ itemType: INVENTORY_ITEM_TYPES.WINGS, reason: "selected_plan_multi_pickup_span" });
   }
 
   if(invisibilityAvailable && shouldAiUseInvisibilityForSelectedPlan(context, selectedPlan)){

--- a/script.js
+++ b/script.js
@@ -27794,10 +27794,12 @@ function shouldAiUseCrosshairForSelectedPlan(context, selectedPlan){
   return precisionIntent;
 }
 
-// Step 4: wide wings widen the BENEFICIAL pickup span (96px vs 36px), so they
-// pay off only when the route sweeps MORE cargo with the wide span than without
-// — i.e. a multi-pickup run the plane couldn't make on a normal span. At least
-// this many cargo must be collected WITH wings (and strictly more than without).
+// Step 4: wide wings widen the BENEFICIAL span (96px vs 36px). That span is what
+// collects cargo AND what kills enemy planes in flight (checkPlaneHits uses
+// getPlaneBeneficialGeometry for both planes). So wings pay off only when the
+// wide span sweeps MORE targets (cargo + enemy planes) than the normal span — a
+// multi-target run the plane couldn't make otherwise. At least this many targets
+// must be reached WITH wings (and strictly more than without).
 const AI_WINGS_MIN_PICKUPS = 2;
 
 function shouldAiUseWingsForSelectedPlan(context, selectedPlan){
@@ -27808,10 +27810,10 @@ function shouldAiUseWingsForSelectedPlan(context, selectedPlan){
   if(!Number.isFinite(landingX) || !Number.isFinite(landingY)) return false;
 
   const pickups = Array.isArray(context?.readyCargo) ? context.readyCargo.filter(Boolean) : [];
-  if(pickups.length < AI_WINGS_MIN_PICKUPS) return false;
+  const enemies = Array.isArray(context?.enemies) ? context.enemies.filter((enemy) => enemy && enemy.isAlive !== false) : [];
+  if(pickups.length + enemies.length < AI_WINGS_MIN_PICKUPS) return false;
 
-  // The flown path (with ricochet bounces) — unchanged by wings; only the pickup
-  // span changes.
+  // The flown path (with ricochet bounces) — unchanged by wings; only the span changes.
   const durationSec = (typeof FIELD_FLIGHT_DURATION_SEC === "number" && FIELD_FLIGHT_DURATION_SEC > 0) ? FIELD_FLIGHT_DURATION_SEC : 1;
   const move = { vx: (landingX - plane.x) / durationSec, vy: (landingY - plane.y) / durationSec };
   const path = typeof getAiPlannedMovePredictedPath === "function"
@@ -27822,15 +27824,32 @@ function shouldAiUseWingsForSelectedPlan(context, selectedPlan){
   const widePlane = { ...plane, activeTurnBuffs: { ...(plane.activeTurnBuffs || {}), [INVENTORY_ITEM_TYPES.WINGS]: true } };
   const barePlane = { ...plane, activeTurnBuffs: { ...(plane.activeTurnBuffs || {}), [INVENTORY_ITEM_TYPES.WINGS]: false } };
 
+  // An enemy is killed when the flying plane's beneficial span sweeps over it
+  // (the same span checkPlaneHits uses). Approximate the swept overlap by the
+  // perpendicular distance from the enemy to the path vs the combined half-spans.
+  const isEnemyHitWithSpan = (enemy, attackerPlane) => {
+    const attackerHalf = getPlaneBeneficialGeometry(attackerPlane).hitbox.width / 2;
+    const enemyHalf = getPlaneBeneficialGeometry(enemy).hitbox.width / 2;
+    const threshold = attackerHalf + enemyHalf;
+    for(let i = 0; i < path.length - 1; i += 1){
+      if(getDistanceFromPointToSegment(enemy.x, enemy.y, path[i].x, path[i].y, path[i + 1].x, path[i + 1].y) <= threshold) return true;
+    }
+    return false;
+  };
+
   let wideCount = 0;
   let bareCount = 0;
   for(const cargo of pickups){
     if(doesCargoIntersectBeneficialZoneAlongPath(cargo, widePlane, path)) wideCount += 1;
     if(doesCargoIntersectBeneficialZoneAlongPath(cargo, barePlane, path)) bareCount += 1;
   }
+  for(const enemy of enemies){
+    if(isEnemyHitWithSpan(enemy, widePlane)) wideCount += 1;
+    if(isEnemyHitWithSpan(enemy, barePlane)) bareCount += 1;
+  }
 
-  // Wings are "по делу" only if the wide span turns this into a multi-pickup the
-  // normal span couldn't make (a move impossible without them).
+  // Wings are "по делу" only if the wide span turns this into a multi-target run
+  // the normal span couldn't make (a move impossible without them).
   return wideCount >= AI_WINGS_MIN_PICKUPS && wideCount > bareCount;
 }
 

--- a/scripts/smoke-ai-wings-smart-use.js
+++ b/scripts/smoke-ai-wings-smart-use.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+'use strict';
+
+// Smoke test: Step 4 — wide wings only when they enable a multi-pickup.
+//
+// Wings widen the BENEFICIAL pickup span (96px vs 36px). They should be used
+// only when the route collects MORE cargo with the wide span than without — a
+// multi-pickup the plane couldn't make otherwise ("impossible without them") —
+// never on a short single-target hop. Drives the real caller
+// pickAiBuffsForSelectedPlan (the bug was its `contactIntent ||` bypass).
+
+const fs = require('fs');
+const vm = require('vm');
+
+function extractFunctionSource(source, fnName){
+  const signature = `function ${fnName}(`;
+  const start = source.indexOf(signature);
+  if(start === -1) throw new Error(`Function not found in script.js: ${fnName}`);
+  const signatureEnd = source.indexOf(')', start);
+  const bodyStart = source.indexOf('{', signatureEnd);
+  let depth = 0;
+  for(let i = bodyStart; i < source.length; i += 1){
+    const ch = source[i];
+    if(ch === '{') depth += 1;
+    if(ch === '}') depth -= 1;
+    if(depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`Function body end not found for: ${fnName}`);
+}
+
+function assert(condition, message){
+  if(!condition) throw new Error(message);
+}
+
+const source = fs.readFileSync('script.js', 'utf8');
+
+const plane = { x: 0, y: 0, color: 'blue', activeTurnBuffs: {} };
+const INVENTORY_ITEM_TYPES = { FUEL: 'fuel', CROSSHAIR: 'crosshair', WINGS: 'wings', INVISIBILITY: 'invisible', MINE: 'mine', DYNAMITE: 'dynamite' };
+
+const context = {
+  Math,
+  Number,
+  Array,
+  CELL_SIZE: 20,
+  FIELD_FLIGHT_DURATION_SEC: 1,
+  AI_WINGS_MIN_PICKUPS: 2, // module-scope const in script.js
+  INVENTORY_ITEM_TYPES,
+  getEffectiveFlightRangeCells: () => 30,
+  getAiSelectedPlanIntentText: (plan) =>
+    `${plan?.goalName || ''} ${plan?.decisionReason || ''} ${plan?.routeClass || ''}`.toLowerCase(),
+  getAiPlannedMovePredictedPath: () => [{ x: 0, y: 0 }, { x: 0, y: 400 }],
+  // A cargo's `reach` says whether the path collects it: 'both' (either span),
+  // 'wide' (only with wings), or 'none'.
+  doesCargoIntersectBeneficialZoneAlongPath: (cargo, p) => {
+    const hasWings = p?.activeTurnBuffs?.[INVENTORY_ITEM_TYPES.WINGS] === true;
+    if(cargo.reach === 'both') return true;
+    if(cargo.reach === 'wide') return hasWings;
+    return false;
+  },
+};
+vm.createContext(context);
+vm.runInContext(extractFunctionSource(source, 'shouldAiUseWingsForSelectedPlan'), context);
+vm.runInContext(extractFunctionSource(source, 'pickAiBuffsForSelectedPlan'), context);
+
+const cargo = (reach) => ({ id: `c-${reach}-${Math.random()}`, state: 'ready', reach, x: 10, y: 100 });
+const usesWings = (cargos) => context.pickAiBuffsForSelectedPlan({
+  plane,
+  color: 'blue',
+  context: { readyCargo: cargos },
+  selectedPlan: {
+    plane, routeClass: 'direct', goalName: 'cargo', decisionReason: 'simple_step2_pickup_cargo',
+    landingX: 0, landingY: 400, planDistance: 400,
+  },
+  availableCounts: { wings: 1 },
+}).some((c) => c.itemType === 'wings');
+
+// A: 1 reachable on a normal span + 1 only reachable with the wide span ->
+//    wings turn it into a 2-pickup -> USE.
+assert(usesWings([cargo('both'), cargo('wide')]) === true, 'A: wings should be used when they enable a 2nd pickup.');
+
+// B: 2 cargo already reachable on a normal span -> wings add nothing -> NO.
+assert(usesWings([cargo('both'), cargo('both')]) === false, 'B: wings add nothing when both are already reachable.');
+
+// C: a single reachable cargo -> not a multi-pickup -> NO (the "short, one target" waste).
+assert(usesWings([cargo('both')]) === false, 'C: a single-target pickup must NOT use wings.');
+
+// D: a single cargo that only the wide span reaches -> still only 1 pickup -> NO.
+assert(usesWings([cargo('wide')]) === false, 'D: one wings-only pickup is not enough (needs a multi-pickup).');
+
+// E: 2 cargo that ONLY the wide span reaches -> wings enable a 2-pickup -> USE.
+assert(usesWings([cargo('wide'), cargo('wide')]) === true, 'E: wings should be used when they enable two pickups.');
+
+console.log('Smoke test passed: wings only when the wide span enables a multi-pickup, never a single-target hop.');

--- a/scripts/smoke-ai-wings-smart-use.js
+++ b/scripts/smoke-ai-wings-smart-use.js
@@ -57,16 +57,25 @@ const context = {
     if(cargo.reach === 'wide') return hasWings;
     return false;
   },
+  // Enemy kill span = beneficial geometry (wings-widened, like checkPlaneHits).
+  // Mock: enemy.x encodes the perpendicular distance to the path; the segment
+  // distance mock just returns that x. bare threshold = 18+18=36, wide = 48+18=66.
+  getPlaneBeneficialGeometry: (p) => ({ hitbox: { width: (p?.activeTurnBuffs?.[INVENTORY_ITEM_TYPES.WINGS] === true) ? 96 : 36 } }),
+  getDistanceFromPointToSegment: (px) => px,
 };
 vm.createContext(context);
 vm.runInContext(extractFunctionSource(source, 'shouldAiUseWingsForSelectedPlan'), context);
 vm.runInContext(extractFunctionSource(source, 'pickAiBuffsForSelectedPlan'), context);
 
 const cargo = (reach) => ({ id: `c-${reach}-${Math.random()}`, state: 'ready', reach, x: 10, y: 100 });
-const usesWings = (cargos) => context.pickAiBuffsForSelectedPlan({
+// Enemy reach encoded as perpendicular distance to the path (mock returns x):
+// 20 -> within either span; 50 -> only the wide span; 200 -> neither.
+const enemyDist = { both: 20, wide: 50, none: 200 };
+const enemy = (reach) => ({ id: `e-${reach}-${Math.random()}`, isAlive: true, x: enemyDist[reach], y: 0 });
+const usesWings = (cargos = [], enemies = []) => context.pickAiBuffsForSelectedPlan({
   plane,
   color: 'blue',
-  context: { readyCargo: cargos },
+  context: { readyCargo: cargos, enemies },
   selectedPlan: {
     plane, routeClass: 'direct', goalName: 'cargo', decisionReason: 'simple_step2_pickup_cargo',
     landingX: 0, landingY: 400, planDistance: 400,
@@ -74,20 +83,32 @@ const usesWings = (cargos) => context.pickAiBuffsForSelectedPlan({
   availableCounts: { wings: 1 },
 }).some((c) => c.itemType === 'wings');
 
-// A: 1 reachable on a normal span + 1 only reachable with the wide span ->
+// A: 1 cargo on a normal span + 1 cargo only reachable with the wide span ->
 //    wings turn it into a 2-pickup -> USE.
-assert(usesWings([cargo('both'), cargo('wide')]) === true, 'A: wings should be used when they enable a 2nd pickup.');
+assert(usesWings([cargo('both'), cargo('wide')]) === true, 'A: wings should be used when they enable a 2nd cargo.');
 
 // B: 2 cargo already reachable on a normal span -> wings add nothing -> NO.
 assert(usesWings([cargo('both'), cargo('both')]) === false, 'B: wings add nothing when both are already reachable.');
 
-// C: a single reachable cargo -> not a multi-pickup -> NO (the "short, one target" waste).
-assert(usesWings([cargo('both')]) === false, 'C: a single-target pickup must NOT use wings.');
+// C: a single reachable cargo -> not a multi-target -> NO (the "short, one target" waste).
+assert(usesWings([cargo('both')]) === false, 'C: a single target must NOT use wings.');
 
-// D: a single cargo that only the wide span reaches -> still only 1 pickup -> NO.
-assert(usesWings([cargo('wide')]) === false, 'D: one wings-only pickup is not enough (needs a multi-pickup).');
+// D: a single cargo that only the wide span reaches -> still only 1 -> NO.
+assert(usesWings([cargo('wide')]) === false, 'D: one wings-only target is not enough.');
 
 // E: 2 cargo that ONLY the wide span reaches -> wings enable a 2-pickup -> USE.
-assert(usesWings([cargo('wide'), cargo('wide')]) === true, 'E: wings should be used when they enable two pickups.');
+assert(usesWings([cargo('wide'), cargo('wide')]) === true, 'E: wings should be used when they enable two cargo.');
 
-console.log('Smoke test passed: wings only when the wide span enables a multi-pickup, never a single-target hop.');
+// F: ENEMIES count too. 1 enemy in either span + 1 enemy only the wide span
+//    kills -> wings enable a 2nd kill -> USE.
+assert(usesWings([], [enemy('both'), enemy('wide')]) === true, 'F: wings should be used when the wide span enables a 2nd enemy kill.');
+
+// G: MIXED — 1 cargo (wide-only) + 1 enemy (wide-only) -> wings enable a
+//    2-target run (1 cargo + 1 kill) -> USE.
+assert(usesWings([cargo('wide')], [enemy('wide')]) === true, 'G: wings should be used for a wide-span cargo+enemy run.');
+
+// H: a single enemy already killable on the normal span -> NO (single target,
+//    wings add nothing).
+assert(usesWings([], [enemy('both')]) === false, 'H: a single normal-span enemy must NOT use wings.');
+
+console.log('Smoke test passed: wings only when the wide span enables a multi-target run (cargo AND enemies).');


### PR DESCRIPTION
Шаг 4 — умные крылья.

## Проблема
ИИ лепил крылья на любой контактный ход — даже короткий тычок в одну цель — впустую тратя предмет (обход `contactIntent ||`).

## Ключевой факт (проверено по коду)
Широкая зона крыльев (96px против 36px) — это **beneficial**-зона, и именно она и собирает грузы, **и убивает врагов в полёте**: `checkPlaneHits` (вызывается в полётном цикле, script.js:44067) использует `getPlaneBeneficialGeometry` для обоих самолётов. То есть крылья реально **расширяют поражение врагов**. `getPlaneDangerGeometry` (36px) идёт на мины/радиус, не на убийство.

## Что сделано
- `shouldAiUseWingsForSelectedPlan`: строю реальную траекторию хода (с отскоками) и считаю, сколько **целей = грузы + вражеские самолёты** достаёт **широкий** захват против **обычного**. Крылья включаю, только если широкий захват даёт **≥ `AI_WINGS_MIN_PICKUPS` (2)** целей **и строго больше**, чем обычный — то есть мульти-сбор/мульти-килл, **невозможный без них**.
  - враги: попадание широкой зоной аппроксимируется перпендикулярным расстоянием от врага до траектории против суммы полу-захватов (как в `checkPlaneHits`).
- **Убран обход** `contactIntent ||` в `pickAiBuffsForSelectedPlan`. Тег решения → `selected_plan_multi_pickup_span`.

Так видно, что крылья применены «по делу»: сделан длинный прямой/рикошетный заход, собирающий/добивающий несколько целей, который без крыльев не состоялся бы.

## Проверка
`scripts/smoke-ai-wings-smart-use.js` (реальный вызывающий код `pickAiBuffsForSelectedPlan`):
- грузы: включают 2-й → да; и так оба берутся → нет; одиночный → нет; 2 только широким → да;
- **враги**: широкий захват добивает 2-го врага → да; одиночный враг и так в обычной зоне → нет;
- **микс**: 1 груз + 1 враг только широким захватом → да.

```
$ node scripts/smoke-ai-wings-smart-use.js
Smoke test passed: wings only when the wide span enables a multi-target run (cargo AND enemies).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)