### PR TITLE
AI fix: бафф не теряется на «чужом» самолёте при фейловере

### DIFF
--- a/script.js
+++ b/script.js
@@ -16999,7 +16999,15 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
     }, "simple_step2_selector");
 
     if(!launchResult?.ok){
-      const failoverPlanes = launchReadyPlanes.filter((plane) => plane !== launchReadyPlane);
+      // The primary plane may already carry a consumed buff (wings/crosshair)
+      // that maybeUseInventoryBeforeLaunch applied before the launch was
+      // rejected. Try IT first on a guaranteed-advance move so the buff isn't
+      // stranded on a non-moving plane while a DIFFERENT plane launches; only
+      // then fall back to the other planes.
+      const failoverPlanes = [
+        launchReadyPlane,
+        ...launchReadyPlanes.filter((plane) => plane !== launchReadyPlane),
+      ];
       const failoverMove = failoverPlanes
         .map((plane) => buildGuaranteedAdvanceMove(plane))
         .find(Boolean);


### PR DESCRIPTION
Фикс бага из ревью крыльев: иногда крылья/точность накладывались на один самолёт, а ход потом шёл **другим**.

## Причина
`maybeUseInventoryBeforeLaunch` применяет (расходует) бафф на выбранном самолёте **до** запуска. Если запуск потом отклоняется (финальный mine-гейт / невалидный ход), планировщик в фейловере запускал **другой** самолёт (`filter(p => p !== launchReadyPlane)`) — и бафф оставался «висеть» на самолёте, который никуда не полетел.

## Фикс
В фейловере сначала пробуем **исходный (забаффленный) самолёт** на гарантированном ходе-продвижении, и только потом — остальные. Так самолёт, уже получивший крылья/точность, ходит **с ними**, а не другой без баффа.

```js
const failoverPlanes = [
  launchReadyPlane,                                   // забаффленный — первым
  ...launchReadyPlanes.filter((p) => p !== launchReadyPlane),
];
```

Изменение локальное (только порядок кандидатов фейловера). Если исходный самолёт продвинуться не может — падаем к остальным ровно как раньше. Регрессий быть не должно.

## Проверка
Юнит-теста нет: это глубоко в асинхронном launch-пайплайне (общий смоук-харнесс его надёжно не гоняет). Проверено рассуждением + нужен плейтест: бафф должен оставаться на том самолёте, который реально делает ход.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_