### PR TITLE
AI шаг 5: топливо тратится только если реально удлиняет ход

### DIFF
--- a/script.js
+++ b/script.js
@@ -29142,15 +29142,15 @@ async function findAiDefensiveMineOpportunityAsync(selectedPlan, context){
   };
 }
 
+// Step 5: fuel is only spent when the move's target is past this fraction of the
+// BASE range (so the base move falls short and the fuel reach is actually used).
+const AI_FUEL_MIN_REACH_RATIO = 1.0;
+
 function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, availableCounts }){
   if(!plane) return [];
 
   const baseRangeCells = getEffectiveFlightRangeCells(plane);
   const baseRangePx = Math.max(1, baseRangeCells * CELL_SIZE);
-  const moveDistance = Number.isFinite(selectedPlan?.planDistance)
-    ? selectedPlan.planDistance
-    : Math.hypot((selectedPlan?.landingX || 0) - (plane?.x || 0), (selectedPlan?.landingY || 0) - (plane?.y || 0));
-  const moveRangeRatio = baseRangePx > 0 ? moveDistance / baseRangePx : 0;
   const goalText = getAiSelectedPlanIntentText(selectedPlan);
   const routeClass = `${selectedPlan?.routeClass || "direct"}`.toLowerCase();
   const contactIntent = [
@@ -29173,18 +29173,31 @@ function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, avail
 
   const candidates = [];
 
-  const fuelNeededForRange = fuelAvailable && moveRangeRatio >= 0.85;
-  const fuelUnlocksBetterMove = fuelAvailable && (() => {
+  // Step 5: fuel doubles range, so it is only worth spending when the move
+  // ACTUALLY uses more than the base range — either a harpy strike+retreat
+  // (below) or reaching/passing a target that is BEYOND base range (the base
+  // move falls short of it). Applying fuel to a move that already fits in base
+  // range is pure waste (the reported "fuel + 30-cell move").
+  const fuelBoostedRangePx = (() => {
+    if(!fuelAvailable) return baseRangePx;
     const previousBuffs = plane.activeTurnBuffs && typeof plane.activeTurnBuffs === "object"
       ? { ...plane.activeTurnBuffs }
       : {};
-    let unlocks = false;
+    let boosted = baseRangePx;
     if(applyItemToOwnPlane(INVENTORY_ITEM_TYPES.FUEL, color, plane)){
-      unlocks = getEffectiveFlightRangeCells(plane) > baseRangeCells;
+      boosted = getEffectiveFlightRangeCells(plane) * CELL_SIZE;
     }
     plane.activeTurnBuffs = previousBuffs;
-    return unlocks;
+    return boosted;
   })();
+  const fuelTargetPoint = selectedPlan?.targetPoint;
+  const fuelTargetDist = (Number.isFinite(fuelTargetPoint?.x) && Number.isFinite(fuelTargetPoint?.y))
+    ? Math.hypot(fuelTargetPoint.x - plane.x, fuelTargetPoint.y - plane.y)
+    : 0;
+  // Target is past base range (base move falls short) yet within fuel range.
+  const fuelReachesDistantTarget = fuelAvailable
+    && fuelTargetDist > baseRangePx * AI_FUEL_MIN_REACH_RATIO
+    && fuelTargetDist <= fuelBoostedRangePx * 1.05;
 
   // Harpy-strike: AI flies to its planned landing (attack/flag), then returns to home base in same turn.
   // The fuel range constraint (round trip fits with fuel, not without) is the primary gate; we don't
@@ -29226,16 +29239,16 @@ function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, avail
     })();
 
   // Fuel is evaluated independently — it can stack with crosshair and/or wings.
+  // Only spend it when it buys real extra reach (advantage over not using it):
+  // an attack-then-retreat, or reaching a target the base move can't.
   if(harpyStrikeOpportunity){
     candidates.push({
       itemType: INVENTORY_ITEM_TYPES.FUEL,
       reason: "harpy_strike_return",
       harpyReturnTarget: { x: harpyHome.x, y: harpyHome.y, label: "harpy_return_home" },
     });
-  } else if(fuelNeededForRange){
-    candidates.push({ itemType: INVENTORY_ITEM_TYPES.FUEL, reason: "selected_plan_range_critical" });
-  } else if(fuelAvailable && fuelUnlocksBetterMove && usefulIntent && moveRangeRatio >= 0.35){
-    candidates.push({ itemType: INVENTORY_ITEM_TYPES.FUEL, reason: "selected_plan_range_support" });
+  } else if(fuelReachesDistantTarget && usefulIntent){
+    candidates.push({ itemType: INVENTORY_ITEM_TYPES.FUEL, reason: "selected_plan_reach_distant_target" });
   }
 
   // Crosshair and wings are evaluated independently and can combine with each other and with fuel.

--- a/scripts/smoke-ai-fuel-only-when-extends.js
+++ b/scripts/smoke-ai-fuel-only-when-extends.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+'use strict';
+
+// Smoke test: Step 5 — fuel is only spent when it actually extends the move.
+//
+// Fuel doubles range. It is worth spending only when the move USES more than the
+// base range: an attack-then-retreat (harpy) or reaching a target the base move
+// can't. Applying fuel to a move that already fits in base range is pure waste
+// (the reported "fuel + 30-cell move"). Drives the real caller
+// pickAiBuffsForSelectedPlan.
+
+const fs = require('fs');
+const vm = require('vm');
+
+function extractFunctionSource(source, fnName){
+  const signature = `function ${fnName}(`;
+  const start = source.indexOf(signature);
+  if(start === -1) throw new Error(`Function not found in script.js: ${fnName}`);
+  const signatureEnd = source.indexOf(')', start);
+  const bodyStart = source.indexOf('{', signatureEnd);
+  let depth = 0;
+  for(let i = bodyStart; i < source.length; i += 1){
+    const ch = source[i];
+    if(ch === '{') depth += 1;
+    if(ch === '}') depth -= 1;
+    if(depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`Function body end not found for: ${fnName}`);
+}
+
+function assert(condition, message){
+  if(!condition) throw new Error(message);
+}
+
+const source = fs.readFileSync('script.js', 'utf8');
+
+const INVENTORY_ITEM_TYPES = { FUEL: 'fuel', CROSSHAIR: 'crosshair', WINGS: 'wings', INVISIBILITY: 'invisible', MINE: 'mine', DYNAMITE: 'dynamite' };
+const plane = { x: 0, y: 0, color: 'blue', activeTurnBuffs: {} };
+let homeY = 0; // controls getBaseAnchor per scenario
+
+// base range 30 cells * 20 = 600px; fuel doubles to 60 cells = 1200px.
+const context = {
+  Math,
+  Number,
+  CELL_SIZE: 20,
+  AI_FUEL_MIN_REACH_RATIO: 1.0, // module-scope const in script.js
+  INVENTORY_ITEM_TYPES,
+  getEffectiveFlightRangeCells: (p) => (p?.activeTurnBuffs?.[INVENTORY_ITEM_TYPES.FUEL] ? 60 : 30),
+  getAiSelectedPlanIntentText: (plan) =>
+    `${plan?.goalName || ''} ${plan?.decisionReason || ''} ${plan?.routeClass || ''}`.toLowerCase(),
+  applyItemToOwnPlane: (type, _color, p) => { p.activeTurnBuffs = { ...(p.activeTurnBuffs || {}), [type]: true }; return true; },
+  getBaseAnchor: () => ({ x: 0, y: homeY }),
+  getImmediateResponseThreatMeta: () => ({ count: 0 }),
+};
+vm.createContext(context);
+vm.runInContext(extractFunctionSource(source, 'pickAiBuffsForSelectedPlan'), context);
+
+const fuelReason = (targetDist, landingDist, home = 0) => {
+  homeY = home;
+  plane.activeTurnBuffs = {};
+  const out = context.pickAiBuffsForSelectedPlan({
+    plane,
+    color: 'blue',
+    context: {},
+    selectedPlan: {
+      plane, routeClass: 'direct', goalName: 'attack', decisionReason: 'simple_step2_direct_enemy',
+      landingX: 0, landingY: landingDist, planDistance: landingDist,
+      targetPoint: { x: 0, y: targetDist }, score: 0.5,
+    },
+    availableCounts: { fuel: 1 },
+  }).find((c) => c.itemType === 'fuel');
+  return out ? out.reason : null;
+};
+
+// 1. Move that fits in base range, round trip home fits WITHOUT fuel -> NO fuel
+//    (this is the wasteful "fuel + short move" the change kills).
+assert(fuelReason(300, 300, 0) === null, '1: a within-range move must NOT spend fuel.');
+
+// 2. Deep attack: round trip home needs fuel and fits with it -> harpy strike+retreat.
+assert(fuelReason(500, 500, 0) === 'harpy_strike_return', '2: a deep attack should use fuel to strike and retreat.');
+
+// 3. Target beyond base range, home too far for a harpy round trip -> reach the
+//    distant target (fuel genuinely extends the reach).
+assert(fuelReason(800, 600, -700) === 'selected_plan_reach_distant_target', '3: fuel should reach a target beyond base range.');
+
+// 4. Target beyond even the fuel-boosted range -> unreachable, NO fuel.
+assert(fuelReason(1300, 600, -700) === null, '4: do not spend fuel on an unreachable target.');
+
+console.log('Smoke test passed: fuel spent only to strike+retreat or reach a distant target; never on a within-range move.');


### PR DESCRIPTION
Шаг 5 — топливо.

## Проблема (по твоему уточнению)
Топливо удваивает дальность (30 → 60 клеток), но ИИ накладывал его на ходы, которые и так влезают в 30 клеток — то есть **трата впустую** («топливо + ход на 30 клеток или меньше»). Причина: решение о топливе смотрело `moveRangeRatio >= 0.85` от **базовой** дальности (`fuelNeededForRange`) и почти-всегда-true пробу `fuelUnlocksBetterMove`, поэтому топливо тратилось на ход, которому лишняя дальность не нужна, а затем `forceFuelMoveToMaxRange` гнал на максимум (таран в базу).

## Принцип (как с крыльями)
Топливо должно давать **преимущество** по сравнению с ходом без него — либо **удар+отход** в безопасность, либо **дотянуться** до того, что без топлива недостижимо.

## Что сделано
`pickAiBuffsForSelectedPlan` тратит топливо только если **ЛИБО**:
- **harpy** (удар, и топливный «круг» уводит самолёт обратно в безопасность) — оставил как есть; теперь это основное применение для глубоких ударов **вместо тарана на макс-дальность**;
- **цель за пределами базовой дальности**, но в пределах топливной (`selected_plan_reach_distant_target`) — топливо реально расширяет досягаемость.

Удалил ветки `fuelNeededForRange` и `fuelUnlocksBetterMove` (источники траты) и неиспользуемые `moveDistance`/`moveRangeRatio`.

Новая константа `AI_FUEL_MIN_REACH_RATIO` (1.0 = цель должна быть дальше базовой дальности).

> Побочный эффект: глубокие удары, которые раньше уходили в таран базы, теперь идут через **harpy-отход** (удар → откат к своим) — ровно то, что ты описывал.

## Проверка
`scripts/smoke-ai-fuel-only-when-extends.js` (реальный `pickAiBuffsForSelectedPlan`):
- ход в пределах базовой дальности → **без** топлива (трата убрана);
- глубокий удар (круг домой нужен и влезает с топливом) → `harpy_strike_return`;
- цель за базовой дальностью, домой не вернуться → `selected_plan_reach_distant_target`;
- цель дальше даже топливной дальности → без топлива.

```
$ node scripts/smoke-ai-fuel-only-when-extends.js
Smoke test passed: fuel spent only to strike+retreat or reach a distant target; never on a within-range move.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_