### PR TITLE
AI: spend harpy fuel only when the retreat reaches a safer landing

### DIFF
--- a/script.js
+++ b/script.js
@@ -29146,6 +29146,14 @@ async function findAiDefensiveMineOpportunityAsync(selectedPlan, context){
 // BASE range (so the base move falls short and the fuel reach is actually used).
 const AI_FUEL_MIN_REACH_RATIO = 1.0;
 
+// Step 5 follow-up: the harpy strike+retreat only earns its fuel when landing AT
+// the strike point is genuinely exposed (>= this risk) AND home is at least this
+// much safer. Otherwise the strike itself is reachable within base range and the
+// retreat buys nothing — the reported "fuel + short move" (fuel used on a move the
+// plane could have made without it).
+const AI_FUEL_HARPY_MIN_STRIKE_RISK = 0.5;
+const AI_FUEL_HARPY_MIN_SAFETY_GAIN = 0.2;
+
 function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, availableCounts }){
   if(!plane) return [];
 
@@ -29200,9 +29208,11 @@ function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, avail
     && fuelTargetDist <= fuelBoostedRangePx * 1.05;
 
   // Harpy-strike: AI flies to its planned landing (attack/flag), then returns to home base in same turn.
-  // The fuel range constraint (round trip fits with fuel, not without) is the primary gate; we don't
-  // require strict collinearity because for at-home planes "roundTrip == 2*legOut" is the normal case
-  // and the U-turn is exactly the harpy concept.
+  // Two gates must BOTH hold: (1) the round trip fits with fuel but NOT without (so fuel is genuinely
+  // needed for the strike+return), and (2) landing at the strike point is exposed while home is safer
+  // (so the retreat is the point — not a wasted U-turn on a strike that was safe to land on anyway).
+  // We don't require strict collinearity because for at-home planes "roundTrip == 2*legOut" is the
+  // normal case and the U-turn is exactly the harpy concept.
   const harpyHome = fuelAvailable && typeof getBaseAnchor === "function"
     ? getBaseAnchor(color)
     : null;
@@ -29228,14 +29238,25 @@ function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, avail
       const fitsWithFuel = roundTrip <= boostedRangePx * 1.02;
       const fitsWithoutFuel = roundTrip <= baseRangePx * 1.02;
       if(!fitsWithFuel || fitsWithoutFuel) return false;
-      const flagPickupIntent = goalText.includes("flag") || goalText.includes("pickup") || goalText.includes("cargo");
-      if(contactIntent || flagPickupIntent) return true;
-      if(typeof getImmediateResponseThreatMeta === "function"){
-        const baseThreat = getImmediateResponseThreatMeta(context, tgtX, tgtY, null);
-        const homeThreat = getImmediateResponseThreatMeta(context, harpyHome.x, harpyHome.y, null);
-        return (baseThreat?.count > 0) && ((homeThreat?.count ?? 0) < (baseThreat?.count ?? 0));
-      }
-      return false;
+      const usefulHarpyIntent = contactIntent
+        || goalText.includes("flag") || goalText.includes("pickup") || goalText.includes("cargo");
+      if(!usefulHarpyIntent) return false;
+      // The harpy only earns its fuel when landing AT THE STRIKE POINT is genuinely
+      // exposed AND returning home is meaningfully safer — a real "strike and retreat
+      // to safety". A strike the plane could simply land on (e.g. a lone enemy near
+      // our own base) needs no fuel: the kill is already within base range and the
+      // retreat buys nothing (the reported "fuel + short move"). selectedPlan.landingRisk
+      // already measures the strike-point exposure with the struck enemy excluded; for
+      // non-attack plans without it, read the strike-point threat fresh.
+      if(typeof getFallbackCandidateResponseRisk !== "function"
+        || typeof getImmediateResponseThreatMeta !== "function") return false;
+      const strikeRisk = Number.isFinite(selectedPlan?.landingRisk)
+        ? selectedPlan.landingRisk
+        : getFallbackCandidateResponseRisk(getImmediateResponseThreatMeta(context, tgtX, tgtY, null));
+      const homeRisk = getFallbackCandidateResponseRisk(
+        getImmediateResponseThreatMeta(context, harpyHome.x, harpyHome.y, null));
+      return strikeRisk >= AI_FUEL_HARPY_MIN_STRIKE_RISK
+        && strikeRisk > homeRisk + AI_FUEL_HARPY_MIN_SAFETY_GAIN;
     })();
 
   // Fuel is evaluated independently — it can stack with crosshair and/or wings.

--- a/scripts/smoke-ai-fuel-only-when-extends.js
+++ b/scripts/smoke-ai-fuel-only-when-extends.js
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 'use strict';
 
-// Smoke test: Step 5 — fuel is only spent when it actually extends the move.
+// Smoke test: Step 5 (+ harpy follow-up) — fuel is only spent when it actually
+// extends the move into something the base range CAN'T do.
 //
 // Fuel doubles range. It is worth spending only when the move USES more than the
-// base range: an attack-then-retreat (harpy) or reaching a target the base move
-// can't. Applying fuel to a move that already fits in base range is pure waste
-// (the reported "fuel + 30-cell move"). Drives the real caller
-// pickAiBuffsForSelectedPlan.
+// base range: an attack-then-retreat (harpy) where landing at the strike point is
+// genuinely exposed and home is safer, OR reaching a target the base move can't.
+// Applying fuel to a move that already fits in base range — or a harpy whose
+// strike point was safe to land on anyway — is pure waste (the reported "fuel +
+// 30-cell move"). Drives the real caller pickAiBuffsForSelectedPlan.
 
 const fs = require('fs');
 const vm = require('vm');
@@ -36,27 +38,34 @@ const source = fs.readFileSync('script.js', 'utf8');
 
 const INVENTORY_ITEM_TYPES = { FUEL: 'fuel', CROSSHAIR: 'crosshair', WINGS: 'wings', INVISIBILITY: 'invisible', MINE: 'mine', DYNAMITE: 'dynamite' };
 const plane = { x: 0, y: 0, color: 'blue', activeTurnBuffs: {} };
-let homeY = 0; // controls getBaseAnchor per scenario
+let homeY = 0;        // controls getBaseAnchor per scenario
+let homeThreatRisk = 0; // controls the (home) risk read by getImmediateResponseThreatMeta
 
 // base range 30 cells * 20 = 600px; fuel doubles to 60 cells = 1200px.
 const context = {
   Math,
   Number,
   CELL_SIZE: 20,
-  AI_FUEL_MIN_REACH_RATIO: 1.0, // module-scope const in script.js
+  AI_FUEL_MIN_REACH_RATIO: 1.0,        // module-scope consts in script.js
+  AI_FUEL_HARPY_MIN_STRIKE_RISK: 0.5,
+  AI_FUEL_HARPY_MIN_SAFETY_GAIN: 0.2,
   INVENTORY_ITEM_TYPES,
   getEffectiveFlightRangeCells: (p) => (p?.activeTurnBuffs?.[INVENTORY_ITEM_TYPES.FUEL] ? 60 : 30),
   getAiSelectedPlanIntentText: (plan) =>
     `${plan?.goalName || ''} ${plan?.decisionReason || ''} ${plan?.routeClass || ''}`.toLowerCase(),
   applyItemToOwnPlane: (type, _color, p) => { p.activeTurnBuffs = { ...(p.activeTurnBuffs || {}), [type]: true }; return true; },
   getBaseAnchor: () => ({ x: 0, y: homeY }),
-  getImmediateResponseThreatMeta: () => ({ count: 0 }),
+  // The harpy compares the strike-point exposure (selectedPlan.landingRisk, supplied
+  // per scenario) against the HOME exposure read here. Pass the risk straight through.
+  getFallbackCandidateResponseRisk: (meta) => (meta && Number.isFinite(meta.risk) ? meta.risk : 0),
+  getImmediateResponseThreatMeta: () => ({ risk: homeThreatRisk, count: homeThreatRisk > 0 ? 1 : 0 }),
 };
 vm.createContext(context);
 vm.runInContext(extractFunctionSource(source, 'pickAiBuffsForSelectedPlan'), context);
 
-const fuelReason = (targetDist, landingDist, home = 0) => {
+const fuelReason = (targetDist, landingDist, { home = 0, landingRisk = 0, homeRisk = 0 } = {}) => {
   homeY = home;
+  homeThreatRisk = homeRisk;
   plane.activeTurnBuffs = {};
   const out = context.pickAiBuffsForSelectedPlan({
     plane,
@@ -65,6 +74,7 @@ const fuelReason = (targetDist, landingDist, home = 0) => {
     selectedPlan: {
       plane, routeClass: 'direct', goalName: 'attack', decisionReason: 'simple_step2_direct_enemy',
       landingX: 0, landingY: landingDist, planDistance: landingDist,
+      landingRisk,
       targetPoint: { x: 0, y: targetDist }, score: 0.5,
     },
     availableCounts: { fuel: 1 },
@@ -74,16 +84,30 @@ const fuelReason = (targetDist, landingDist, home = 0) => {
 
 // 1. Move that fits in base range, round trip home fits WITHOUT fuel -> NO fuel
 //    (this is the wasteful "fuel + short move" the change kills).
-assert(fuelReason(300, 300, 0) === null, '1: a within-range move must NOT spend fuel.');
+assert(fuelReason(300, 300, { home: 0 }) === null, '1: a within-range move must NOT spend fuel.');
 
-// 2. Deep attack: round trip home needs fuel and fits with it -> harpy strike+retreat.
-assert(fuelReason(500, 500, 0) === 'harpy_strike_return', '2: a deep attack should use fuel to strike and retreat.');
+// 2. Deep attack: round trip needs fuel AND the strike point is exposed while home
+//    is safe -> harpy strike+retreat (the legit "strike and retreat to safety").
+assert(fuelReason(500, 500, { home: 0, landingRisk: 0.8, homeRisk: 0.1 }) === 'harpy_strike_return',
+  '2: a deep, exposed strike with a safe home should use fuel to strike and retreat.');
 
-// 3. Target beyond base range, home too far for a harpy round trip -> reach the
+// 3. Deep attack whose round trip needs fuel BUT the strike point is safe to land
+//    on (e.g. a lone enemy near our base; landingRisk 0 because the struck enemy is
+//    excluded) -> NO fuel. This is exactly the reported waste: fuel on a move the
+//    plane could have made without it (the kill is within base range).
+assert(fuelReason(500, 500, { home: 0, landingRisk: 0.0, homeRisk: 0.0 }) === null,
+  '3: a deep strike with a SAFE landing must NOT spend fuel (the reported waste).');
+
+// 3b. Strike point exposed, but home is just as exposed -> retreat gains nothing -> NO fuel.
+assert(fuelReason(500, 500, { home: 0, landingRisk: 0.8, homeRisk: 0.75 }) === null,
+  '3b: no fuel when the retreat does not reach a meaningfully safer home.');
+
+// 4. Target beyond base range, home too far for a harpy round trip -> reach the
 //    distant target (fuel genuinely extends the reach).
-assert(fuelReason(800, 600, -700) === 'selected_plan_reach_distant_target', '3: fuel should reach a target beyond base range.');
+assert(fuelReason(800, 600, { home: -700 }) === 'selected_plan_reach_distant_target',
+  '4: fuel should reach a target beyond base range.');
 
-// 4. Target beyond even the fuel-boosted range -> unreachable, NO fuel.
-assert(fuelReason(1300, 600, -700) === null, '4: do not spend fuel on an unreachable target.');
+// 5. Target beyond even the fuel-boosted range -> unreachable, NO fuel.
+assert(fuelReason(1300, 600, { home: -700 }) === null, '5: do not spend fuel on an unreachable target.');
 
-console.log('Smoke test passed: fuel spent only to strike+retreat or reach a distant target; never on a within-range move.');
+console.log('Smoke test passed: fuel spent only to retreat from an exposed strike to a safer home, or to reach a distant target; never on a move the base range already covers.');


### PR DESCRIPTION
## Проблема (follow-up к Step 5 / #2847)

ИИ по-прежнему **иногда ходит с топливом на ход короче базовой дальности** — на дистанцию, которую он мог бы пройти и без топлива. Топливо тратилось впустую.

## Причина

Гейт «harpy strike+retreat» (удар и возврат домой) в `pickAiBuffsForSelectedPlan` срабатывал почти на **любом** плане с контактным намерением:

```js
if(contactIntent || flagPickupIntent) return true;  // ← фактически "всегда"
```

`contactIntent` истинно для «attack»/«enemy»/«cargo»/«ricochet»/… — то есть почти для всех ударов. Гейт **не проверял, даёт ли возврат домой реальную безопасность**. Удар по одиночному врагу в ~15–29 клетках рядом со своей базой запускал топливо, хотя:

- сам удар — в пределах базовой дальности (долетел бы и без топлива),
- точка приземления и так безопасна, возврат ничего не даёт.

Это и есть наблюдаемый «расход топлива на короткий ход».

## Решение

Топливо на harpy тратится только когда **возврат действительно уводит в безопасность**. Используем уже посчитанную на плане экспозицию точки удара (`selectedPlan.landingRisk` — она исключает сбиваемого врага, см. `buildSimulatedEnemyCandidate`):

- приземление в точке удара реально под угрозой — `strikeRisk >= AI_FUEL_HARPY_MIN_STRIKE_RISK` (0.5),
- дом ощутимо безопаснее — `strikeRisk > homeRisk + AI_FUEL_HARPY_MIN_SAFETY_GAIN` (0.2).

Когда единственная угроза у точки удара — это сам сбиваемый враг, `landingRisk == 0`, и harpy (вместе с топливом) корректно **не запускается**. Гейт «круг нужен только с топливом» (`fitsWithFuel && !fitsWithoutFuel`) сохранён — легитимный глубокий «удар и отход в безопасность» работает как прежде. Путь «дотянуться до дальней цели» не тронут.

Два новых тюнабла рядом с `AI_FUEL_MIN_REACH_RATIO`.

## Проверка

`scripts/smoke-ai-fuel-only-when-extends.js` расширен ключевым регресс-гардом:

- глубокий удар с **безопасной** посадкой → топливо **НЕ** тратится (та самая фиксируемая трата);
- глубокий удар, где дом не безопаснее → топливо **НЕ** тратится;
- глубокий **открытый** удар при безопасном доме → harpy с топливом (легитимный отход);
- ход в пределах дальности → без топлива; дальняя цель → `reach_distant`; недосягаемая → без топлива.

Прогон всех `scripts/smoke-ai-*.js` зелёный, кроме 3 пред-существующих падений (`selected-plan-handoff`, `forced-non-skip-last-chance`, `temporary-item-candidate`) — они падают и на чистом `main` (наследие async-миграции), к этому изменению отношения не имеют.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_