### PR TITLE
AI: расширить полезное использование топлива — глубокий удар-отход + продление ради лишних целей

### DIFF
--- a/script.js
+++ b/script.js
@@ -29146,13 +29146,21 @@ async function findAiDefensiveMineOpportunityAsync(selectedPlan, context){
 // BASE range (so the base move falls short and the fuel reach is actually used).
 const AI_FUEL_MIN_REACH_RATIO = 1.0;
 
-// Step 5 follow-up: the harpy strike+retreat only earns its fuel when landing AT
-// the strike point is genuinely exposed (>= this risk) AND home is at least this
-// much safer. Otherwise the strike itself is reachable within base range and the
-// retreat buys nothing — the reported "fuel + short move" (fuel used on a move the
-// plane could have made without it).
+// Step 5 follow-up: when to spend fuel on a harpy strike+retreat. EITHER (a) the
+// strike lands somewhere exposed (>= MIN_STRIKE_RISK) and home is meaningfully
+// safer (gain > MIN_SAFETY_GAIN) — a genuine escape; OR (b) the strike reaches
+// deep forward (>= DEEP_FORWARD_RATIO of base range) so the retreat brings the
+// plane back from far in the field. The original waste — a SHALLOW safe strike
+// near our own base — clears neither gate, so fuel is not spent there.
 const AI_FUEL_HARPY_MIN_STRIKE_RISK = 0.5;
 const AI_FUEL_HARPY_MIN_SAFETY_GAIN = 0.2;
+const AI_FUEL_HARPY_DEEP_FORWARD_RATIO = 0.8;
+
+// Step 5 follow-up: fuel doubles range, so flying the doubled distance along the
+// same launch line can sweep targets the base move stops short of. Spend fuel when
+// at least this many enemies/cargo sit in the EXTENSION band (beyond base range,
+// within fuel range) on the launch line — they are unreachable without it.
+const AI_FUEL_EXTEND_MIN_EXTRA_TARGETS = 1;
 
 function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, availableCounts }){
   if(!plane) return [];
@@ -29208,11 +29216,11 @@ function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, avail
     && fuelTargetDist <= fuelBoostedRangePx * 1.05;
 
   // Harpy-strike: AI flies to its planned landing (attack/flag), then returns to home base in same turn.
-  // Two gates must BOTH hold: (1) the round trip fits with fuel but NOT without (so fuel is genuinely
-  // needed for the strike+return), and (2) landing at the strike point is exposed while home is safer
-  // (so the retreat is the point — not a wasted U-turn on a strike that was safe to land on anyway).
-  // We don't require strict collinearity because for at-home planes "roundTrip == 2*legOut" is the
-  // normal case and the U-turn is exactly the harpy concept.
+  // The round trip must fit with fuel but NOT without (so fuel is genuinely needed for the strike+return),
+  // AND the retreat must be worth it: either the strike reaches deep forward, or landing at the strike
+  // point is exposed while home is safer. A shallow safe strike near our own base clears neither and is
+  // skipped (the reported waste). We don't require strict collinearity because for at-home planes
+  // "roundTrip == 2*legOut" is the normal case and the U-turn is exactly the harpy concept.
   const harpyHome = fuelAvailable && typeof getBaseAnchor === "function"
     ? getBaseAnchor(color)
     : null;
@@ -29248,6 +29256,14 @@ function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, avail
       // retreat buys nothing (the reported "fuel + short move"). selectedPlan.landingRisk
       // already measures the strike-point exposure with the struck enemy excluded; for
       // non-attack plans without it, read the strike-point threat fresh.
+      // (b) A deep forward strike (near the edge of base range) is worth retreating
+      // from regardless of who is nearby — the plane is far in the field and fuel
+      // brings it home in the same turn.
+      const deepForwardStrike = legOut >= baseRangePx * AI_FUEL_HARPY_DEEP_FORWARD_RATIO;
+      if(deepForwardStrike) return true;
+      // (a) Otherwise only when landing at the strike point is genuinely exposed AND
+      // home is meaningfully safer (the struck enemy is excluded from landingRisk, so
+      // a lone enemy near our own base scores 0 here and is correctly skipped).
       if(typeof getFallbackCandidateResponseRisk !== "function"
         || typeof getImmediateResponseThreatMeta !== "function") return false;
       const strikeRisk = Number.isFinite(selectedPlan?.landingRisk)
@@ -29259,15 +29275,65 @@ function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, avail
         && strikeRisk > homeRisk + AI_FUEL_HARPY_MIN_SAFETY_GAIN;
     })();
 
+  // Capture more targets: flying the doubled distance along the SAME launch line can
+  // sweep enemies/cargo the base move stops short of. Count targets whose footpoint
+  // on the launch ray lies in the EXTENSION band (beyond base range, within fuel
+  // range) and within the sweep half-width, with a clear line to them. >=1 such
+  // target is reachable ONLY with fuel — a concrete extra capture. Direct routes
+  // only: a ricochet's extended flight is not a straight line.
+  const fuelExtendCapturesMoreTargets = fuelAvailable
+    && !routeClass.includes("ricochet")
+    && (Number(selectedPlan?.bounceCount) || 0) === 0
+    && Number.isFinite(selectedPlan?.landingX) && Number.isFinite(selectedPlan?.landingY)
+    && (() => {
+      const dx = selectedPlan.landingX - plane.x;
+      const dy = selectedPlan.landingY - plane.y;
+      const len = Math.hypot(dx, dy);
+      if(!(len > 0)) return false;
+      const ux = dx / len;
+      const uy = dy / len;
+      const beneficialWidth = typeof getPlaneBeneficialGeometry === "function"
+        ? getPlaneBeneficialGeometry(plane)?.hitbox?.width
+        : null;
+      const halfWidth = (Number.isFinite(beneficialWidth) ? beneficialWidth / 2 : CELL_SIZE) + CELL_SIZE * 0.5;
+      const points = [];
+      for(const e of (context?.enemies || [])){
+        if(e?.isAlive && Number.isFinite(e.x) && Number.isFinite(e.y)) points.push({ x: e.x, y: e.y });
+      }
+      for(const c of (context?.readyCargo || [])){
+        const ctr = typeof getCargoVisualCenter === "function" ? getCargoVisualCenter(c) : c;
+        if(Number.isFinite(ctr?.x) && Number.isFinite(ctr?.y)) points.push({ x: ctr.x, y: ctr.y });
+      }
+      let extraInBand = 0;
+      for(const p of points){
+        const px = p.x - plane.x;
+        const py = p.y - plane.y;
+        const proj = px * ux + py * uy;                 // distance along the launch ray
+        if(proj <= baseRangePx) continue;               // base move already reaches this far
+        if(proj > fuelBoostedRangePx) continue;         // beyond even fuel range
+        const perp = Math.abs(px * uy - py * ux);        // perpendicular distance to the ray
+        if(perp > halfWidth) continue;                   // not on the sweep line
+        const footX = plane.x + ux * proj;
+        const footY = plane.y + uy * proj;
+        if(typeof isPathClear === "function" && !isPathClear(plane.x, plane.y, footX, footY)) continue;
+        extraInBand += 1;
+        if(extraInBand >= AI_FUEL_EXTEND_MIN_EXTRA_TARGETS) return true;
+      }
+      return false;
+    })();
+
   // Fuel is evaluated independently — it can stack with crosshair and/or wings.
   // Only spend it when it buys real extra reach (advantage over not using it):
-  // an attack-then-retreat, or reaching a target the base move can't.
+  // an attack-then-retreat, sweeping more targets with the doubled range, or
+  // reaching a target the base move can't.
   if(harpyStrikeOpportunity){
     candidates.push({
       itemType: INVENTORY_ITEM_TYPES.FUEL,
       reason: "harpy_strike_return",
       harpyReturnTarget: { x: harpyHome.x, y: harpyHome.y, label: "harpy_return_home" },
     });
+  } else if(fuelExtendCapturesMoreTargets){
+    candidates.push({ itemType: INVENTORY_ITEM_TYPES.FUEL, reason: "extend_range_more_targets" });
   } else if(fuelReachesDistantTarget && usefulIntent){
     candidates.push({ itemType: INVENTORY_ITEM_TYPES.FUEL, reason: "selected_plan_reach_distant_target" });
   }

--- a/scripts/smoke-ai-fuel-only-when-extends.js
+++ b/scripts/smoke-ai-fuel-only-when-extends.js
@@ -1,15 +1,17 @@
 #!/usr/bin/env node
 'use strict';
 
-// Smoke test: Step 5 (+ harpy follow-up) — fuel is only spent when it actually
-// extends the move into something the base range CAN'T do.
+// Smoke test: Step 5 (+ follow-ups) — fuel is spent only when it does something the
+// BASE range can't, never on a move the plane could have made without it.
 //
-// Fuel doubles range. It is worth spending only when the move USES more than the
-// base range: an attack-then-retreat (harpy) where landing at the strike point is
-// genuinely exposed and home is safer, OR reaching a target the base move can't.
-// Applying fuel to a move that already fits in base range — or a harpy whose
-// strike point was safe to land on anyway — is pure waste (the reported "fuel +
-// 30-cell move"). Drives the real caller pickAiBuffsForSelectedPlan.
+// Three legitimate advantages, all gated so they never waste fuel:
+//   1. Harpy strike+retreat — round trip needs fuel, AND either the strike reaches
+//      deep forward OR the strike point is exposed while home is safer.
+//   2. Capture more targets — flying the doubled distance along the launch line
+//      sweeps enemies/cargo the base move stops short of.
+//   3. Reach a distant target the base move falls short of.
+// A SHALLOW, safe strike near our own base clears none of these -> no fuel (the
+// reported "fuel + short move"). Drives the real caller pickAiBuffsForSelectedPlan.
 
 const fs = require('fs');
 const vm = require('vm');
@@ -38,7 +40,7 @@ const source = fs.readFileSync('script.js', 'utf8');
 
 const INVENTORY_ITEM_TYPES = { FUEL: 'fuel', CROSSHAIR: 'crosshair', WINGS: 'wings', INVISIBILITY: 'invisible', MINE: 'mine', DYNAMITE: 'dynamite' };
 const plane = { x: 0, y: 0, color: 'blue', activeTurnBuffs: {} };
-let homeY = 0;        // controls getBaseAnchor per scenario
+let homeY = 0;          // controls getBaseAnchor per scenario
 let homeThreatRisk = 0; // controls the (home) risk read by getImmediateResponseThreatMeta
 
 // base range 30 cells * 20 = 600px; fuel doubles to 60 cells = 1200px.
@@ -46,34 +48,40 @@ const context = {
   Math,
   Number,
   CELL_SIZE: 20,
-  AI_FUEL_MIN_REACH_RATIO: 1.0,        // module-scope consts in script.js
+  AI_FUEL_MIN_REACH_RATIO: 1.0,             // module-scope consts in script.js
   AI_FUEL_HARPY_MIN_STRIKE_RISK: 0.5,
   AI_FUEL_HARPY_MIN_SAFETY_GAIN: 0.2,
+  AI_FUEL_HARPY_DEEP_FORWARD_RATIO: 0.8,
+  AI_FUEL_EXTEND_MIN_EXTRA_TARGETS: 1,
   INVENTORY_ITEM_TYPES,
   getEffectiveFlightRangeCells: (p) => (p?.activeTurnBuffs?.[INVENTORY_ITEM_TYPES.FUEL] ? 60 : 30),
   getAiSelectedPlanIntentText: (plan) =>
     `${plan?.goalName || ''} ${plan?.decisionReason || ''} ${plan?.routeClass || ''}`.toLowerCase(),
   applyItemToOwnPlane: (type, _color, p) => { p.activeTurnBuffs = { ...(p.activeTurnBuffs || {}), [type]: true }; return true; },
   getBaseAnchor: () => ({ x: 0, y: homeY }),
-  // The harpy compares the strike-point exposure (selectedPlan.landingRisk, supplied
-  // per scenario) against the HOME exposure read here. Pass the risk straight through.
+  // Harpy compares the strike-point exposure (selectedPlan.landingRisk, per scenario)
+  // against the HOME exposure read here. Pass the risk straight through.
   getFallbackCandidateResponseRisk: (meta) => (meta && Number.isFinite(meta.risk) ? meta.risk : 0),
   getImmediateResponseThreatMeta: () => ({ risk: homeThreatRisk, count: homeThreatRisk > 0 ? 1 : 0 }),
+  // For the "capture more targets" extension probe.
+  getPlaneBeneficialGeometry: () => ({ hitbox: { width: 36 } }), // half-width 18 (+10 margin)
+  getCargoVisualCenter: (c) => ({ x: c.x, y: c.y }),
+  isPathClear: () => true,
 };
 vm.createContext(context);
 vm.runInContext(extractFunctionSource(source, 'pickAiBuffsForSelectedPlan'), context);
 
-const fuelReason = (targetDist, landingDist, { home = 0, landingRisk = 0, homeRisk = 0 } = {}) => {
+const fuelReason = (targetDist, landingDist, { home = 0, landingRisk = 0, homeRisk = 0, enemies = [], readyCargo = [] } = {}) => {
   homeY = home;
   homeThreatRisk = homeRisk;
   plane.activeTurnBuffs = {};
   const out = context.pickAiBuffsForSelectedPlan({
     plane,
     color: 'blue',
-    context: {},
+    context: { enemies, readyCargo },
     selectedPlan: {
       plane, routeClass: 'direct', goalName: 'attack', decisionReason: 'simple_step2_direct_enemy',
-      landingX: 0, landingY: landingDist, planDistance: landingDist,
+      bounceCount: 0, landingX: 0, landingY: landingDist, planDistance: landingDist,
       landingRisk,
       targetPoint: { x: 0, y: targetDist }, score: 0.5,
     },
@@ -82,32 +90,49 @@ const fuelReason = (targetDist, landingDist, { home = 0, landingRisk = 0, homeRi
   return out ? out.reason : null;
 };
 
-// 1. Move that fits in base range, round trip home fits WITHOUT fuel -> NO fuel
-//    (this is the wasteful "fuel + short move" the change kills).
+// 1. Move that fits in base range, round trip home fits WITHOUT fuel -> NO fuel.
 assert(fuelReason(300, 300, { home: 0 }) === null, '1: a within-range move must NOT spend fuel.');
 
-// 2. Deep attack: round trip needs fuel AND the strike point is exposed while home
-//    is safe -> harpy strike+retreat (the legit "strike and retreat to safety").
-assert(fuelReason(500, 500, { home: 0, landingRisk: 0.8, homeRisk: 0.1 }) === 'harpy_strike_return',
-  '2: a deep, exposed strike with a safe home should use fuel to strike and retreat.');
+// 2. SHALLOW strike whose round trip needs fuel but is NOT deep and lands somewhere
+//    safe -> NO fuel. This is the reported waste: fuel on a strike reachable without it.
+assert(fuelReason(420, 420, { home: 0, landingRisk: 0.0, homeRisk: 0.0 }) === null,
+  '2: a shallow, safe strike must NOT spend fuel (the reported waste).');
 
-// 3. Deep attack whose round trip needs fuel BUT the strike point is safe to land
-//    on (e.g. a lone enemy near our base; landingRisk 0 because the struck enemy is
-//    excluded) -> NO fuel. This is exactly the reported waste: fuel on a move the
-//    plane could have made without it (the kill is within base range).
-assert(fuelReason(500, 500, { home: 0, landingRisk: 0.0, homeRisk: 0.0 }) === null,
-  '3: a deep strike with a SAFE landing must NOT spend fuel (the reported waste).');
+// 3. DEEP forward strike (>= 0.8 of base range) -> harpy strike+retreat, even with a
+//    safe landing: the plane is far in the field and fuel brings it home this turn.
+assert(fuelReason(540, 540, { home: 0, landingRisk: 0.0 }) === 'harpy_strike_return',
+  '3: a deep forward strike should use fuel to strike and retreat home.');
 
-// 3b. Strike point exposed, but home is just as exposed -> retreat gains nothing -> NO fuel.
-assert(fuelReason(500, 500, { home: 0, landingRisk: 0.8, homeRisk: 0.75 }) === null,
-  '3b: no fuel when the retreat does not reach a meaningfully safer home.');
+// 4. Mid-range strike that is EXPOSED, with a safe home -> harpy (escape branch).
+assert(fuelReason(420, 420, { home: 0, landingRisk: 0.8, homeRisk: 0.1 }) === 'harpy_strike_return',
+  '4: an exposed mid strike with a safe home should use fuel to retreat.');
 
-// 4. Target beyond base range, home too far for a harpy round trip -> reach the
-//    distant target (fuel genuinely extends the reach).
+// 5. Exposed strike but home is just as exposed -> retreat gains nothing -> NO fuel.
+assert(fuelReason(420, 420, { home: 0, landingRisk: 0.8, homeRisk: 0.75 }) === null,
+  '5: no fuel when the retreat does not reach a meaningfully safer home.');
+
+// 6. Capture more targets: a short shot (no harpy), but an enemy sits ON the launch
+//    line BEYOND base range and within fuel range -> extend with fuel to sweep it.
+assert(fuelReason(300, 300, { home: 0, enemies: [{ x: 0, y: 900, isAlive: true }] }) === 'extend_range_more_targets',
+  '6: fuel should extend the move to sweep a target beyond base range on the line.');
+
+// 6b. Ready cargo in the extension band on the line -> extend with fuel.
+assert(fuelReason(300, 300, { home: 0, readyCargo: [{ x: 0, y: 1000, state: 'ready' }] }) === 'extend_range_more_targets',
+  '6b: fuel should extend to sweep cargo beyond base range on the line.');
+
+// 7. A target beyond range but OFF the launch line -> not swept -> NO extend fuel.
+assert(fuelReason(300, 300, { home: 0, enemies: [{ x: 500, y: 900, isAlive: true }] }) === null,
+  '7: a target off the launch line must NOT trigger extension fuel.');
+
+// 8. A target already WITHIN base range -> base move reaches it -> NO extend fuel.
+assert(fuelReason(300, 300, { home: 0, enemies: [{ x: 0, y: 400, isAlive: true }] }) === null,
+  '8: a target the base move already reaches must NOT trigger extension fuel.');
+
+// 9. Distant target, home too far for a harpy round trip -> reach the distant target.
 assert(fuelReason(800, 600, { home: -700 }) === 'selected_plan_reach_distant_target',
-  '4: fuel should reach a target beyond base range.');
+  '9: fuel should reach a target beyond base range.');
 
-// 5. Target beyond even the fuel-boosted range -> unreachable, NO fuel.
-assert(fuelReason(1300, 600, { home: -700 }) === null, '5: do not spend fuel on an unreachable target.');
+// 10. Target beyond even the fuel-boosted range -> unreachable, NO fuel.
+assert(fuelReason(1300, 600, { home: -700 }) === null, '10: do not spend fuel on an unreachable target.');
 
-console.log('Smoke test passed: fuel spent only to retreat from an exposed strike to a safer home, or to reach a distant target; never on a move the base range already covers.');
+console.log('Smoke test passed: fuel spent to retreat (deep/exposed), to sweep extra targets on the line, or to reach a distant target; never on a shallow safe move the base range already covers.');


### PR DESCRIPTION
## Зачем (продолжение после #2848)

После #2848 (он уже смержен) топливо стало тратиться корректно, но **почти никогда**: harpy срабатывал только когда у точки удара есть ДРУГИЕ враги (редко), а повода «захват большего числа целей» в решении о топливе не было вовсе. Эта правка возвращает частое, но по-прежнему **неубыточное** использование топлива.

> Важно: эта правка была сделана как follow-up к #2848, но #2848 успели смержить раньше, чем follow-up-коммит долетел до ветки — поэтому он остался висеть вне main. Этот PR переносит его в main отдельной веткой.

## Что добавлено (оба повода из обсуждения)

**1. Глубокий удар + отход.** Harpy теперь срабатывает, если удар достаёт глубоко вперёд (`legOut >= AI_FUEL_HARPY_DEEP_FORWARD_RATIO` = 0.8 базовой дальности) — отход домой оправдан сам по себе, без требования «других врагов рядом». Ветка «открытая точка удара + безопасный дом» сохранена для средних дистанций. **Мелкий безопасный удар у своей базы по-прежнему топливо не тратит** — это была изначальная трата.

**2. Захват большего числа целей.** Топливо удваивает дальность, поэтому пролёт удвоенной дистанции по той же (прямой) линии запуска собирает цели, до которых базовый ход не дотягивает. Считаю врагов + готовые грузы, чья проекция на луч запуска попадает в **полосу расширения** (за базовой дальностью, в пределах фуел-дальности), лежит в пределах полуширины захвата и достижима по чистой линии. Хотя бы `AI_FUEL_EXTEND_MIN_EXTRA_TARGETS` (1) такая цель → конкретный лишний захват, недостижимый без топлива. Новая причина `extend_range_more_targets`. Рикошеты исключены (их продлённый полёт — не прямая).

Порядок в решении: `harpy_strike_return` → `extend_range_more_targets` → `selected_plan_reach_distant_target`.

## Проверка

`scripts/smoke-ai-fuel-only-when-extends.js` расширен до 10 сценариев:
- глубокий удар (≥0.8) и цель на линии за базовой дальностью → топливо тратится;
- **мелкий безопасный удар** у базы, цель **вне** линии, цель **уже в пределах** базовой дальности → топливо НЕ тратится;
- открытый средний удар при безопасном доме → harpy; дом не безопаснее → без топлива; дальняя цель → reach_distant; недосягаемая → без топлива.

Все `scripts/smoke-ai-*.js` зелёные, кроме 3 пред-существующих падений (`selected-plan-handoff`, `forced-non-skip-last-chance`, `temporary-item-candidate`) — они падают и на чистом `main` (наследие async-миграции), к этому изменению отношения не имеют.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_