### PR TITLE
AI Шаг 6: топливо продлевает рикошетный свип в больший мультикилл

### DIFF
--- a/script.js
+++ b/script.js
@@ -16042,6 +16042,42 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
         ? getFallbackCandidateResponseRisk(getImmediateResponseThreatMeta({ ...aiExecutionContext, plane }, end.x, end.y, null))
         : 0;
       const ricochet = best.bounceCount > 0;
+      // Step 6: would FUEL (doubled range) sweep MORE targets along this EXACT launch
+      // line? Re-simulate the winning direction at the fuel-boosted range and count.
+      // If strictly more targets land on the longer bounce path, mark the plan so the
+      // inventory picker spends fuel; on launch forceFuelMoveToMaxRange flies this same
+      // angle to max range — i.e. precisely this boosted multikill route. Cheap: one
+      // extra sim, and only when fuel is actually on hand.
+      let aiFuelRicochetExtend = null;
+      const sweepColor = plane.color || aiColor;
+      const fuelOnHand = typeof evaluateInventoryState === "function"
+        && Number(evaluateInventoryState(sweepColor)?.counts?.[INVENTORY_ITEM_TYPES.FUEL] ?? 0) > 0
+        && !plane.activeTurnBuffs?.[INVENTORY_ITEM_TYPES.FUEL];
+      if(fuelOnHand && typeof applyItemToOwnPlane === "function"){
+        const prevBuffs = plane.activeTurnBuffs && typeof plane.activeTurnBuffs === "object" ? { ...plane.activeTurnBuffs } : {};
+        let boostedSim = null;
+        if(applyItemToOwnPlane(INVENTORY_ITEM_TYPES.FUEL, sweepColor, plane)){
+          boostedSim = simulateAIShot(plane, { dx: best.nx, dy: best.ny, scale: 1 }, { maxBounces: AI_SWEEP_MAX_BOUNCES });
+        }
+        plane.activeTurnBuffs = prevBuffs;
+        if(boostedSim && Array.isArray(boostedSim.predictedPath) && boostedSim.predictedPath.length >= 2){
+          let boostedCargo = 0;
+          let boostedEnemy = 0;
+          for(const c of sweepCargos){ if(doesCargoIntersectBeneficialZoneAlongPath(c.cargo, plane, boostedSim.predictedPath)) boostedCargo += 1; }
+          for(const e of sweepEnemies){ if(isEnemyOnPredictedPath(e.enemy, boostedSim.predictedPath)) boostedEnemy += 1; }
+          const boostedCount = boostedCargo + boostedEnemy;
+          if(boostedCount > best.count){
+            aiFuelRicochetExtend = {
+              baseCount: best.count,
+              boostedCount,
+              boostedCargo,
+              boostedEnemy,
+              boostedBounceCount: boostedSim.bounceCount,
+              boostedTravel: Number.isFinite(boostedSim.travelDistance) ? boostedSim.travelDistance : null,
+            };
+          }
+        }
+      }
       return {
         plane,
         landingX,
@@ -16057,6 +16093,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
         multiTargetEnemy: best.enemyHit,
         landingRisk,
         travel: best.travel,
+        aiFuelRicochetExtend,
       };
     };
 
@@ -16495,6 +16532,15 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
           }, selectedPlan)
         : []);
     selectedPlan.selectedInventorySequence = selectedPlanEnhancementSequence;
+    // Step 6: a fuel-extended ricochet multikill must keep its EXACT launch angle and
+    // only reach max range (forceFuelMoveToMaxRange). Mark the plan replan-done so the
+    // fuel replan below is skipped — it would aim at home/an enemy and divert the
+    // carefully simulated multikill line.
+    if(Array.isArray(selectedPlanEnhancementSequence)
+      && selectedPlanEnhancementSequence.some((entry) =>
+        entry?.itemType === INVENTORY_ITEM_TYPES.FUEL && entry?.reason === "ricochet_sweep_extend_more_targets")){
+      selectedPlan.fuelReplanned = true;
+    }
     aiThinkingTimingStageEnd("inventory_enhance");
 
     // Defensive mine planner (Layer A). One async call returns 0..2 placements
@@ -16893,6 +16939,7 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       entry?.itemType === INVENTORY_ITEM_TYPES.FUEL
     ));
     if(willApplyFuel
+      && !selectedPlan.fuelReplanned
       && typeof buildFuelReplannedMoveAsync === "function"
       && selectedPlan.plane
       && Number.isFinite(selectedPlan.landingX)
@@ -29332,11 +29379,24 @@ function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, avail
       return false;
     })();
 
+  // Step 6: fuel extends a RICOCHET multi-target sweep into a bigger multikill. The
+  // sweep builder already proved (by re-simulating the winning line at boosted range)
+  // that the doubled range catches strictly MORE targets along the bounces; spend fuel
+  // to fly that longer route. forceFuelMoveToMaxRange flies the same launch angle to
+  // max range, which is exactly the boosted route that was counted.
+  const ricochetSweepExtends = fuelAvailable
+    && selectedPlan?.aiFuelRicochetExtend
+    && Number(selectedPlan.aiFuelRicochetExtend.boostedCount) > Number(selectedPlan.aiFuelRicochetExtend.baseCount);
+
   // Fuel is evaluated independently — it can stack with crosshair and/or wings.
   // Only spend it when it buys real extra reach (advantage over not using it):
-  // an attack-then-retreat, sweeping more targets with the doubled range, or
-  // reaching a target the base move can't.
-  if(harpyStrikeOpportunity){
+  // extending a ricochet sweep to a bigger multikill, an attack-then-retreat,
+  // sweeping more targets along a direct line, or reaching a target the base move
+  // can't. Multikill-extend is checked first: for a sweep the kills are the point,
+  // so it wins over a retreat (whose home replan would abandon the multikill line).
+  if(ricochetSweepExtends){
+    candidates.push({ itemType: INVENTORY_ITEM_TYPES.FUEL, reason: "ricochet_sweep_extend_more_targets" });
+  } else if(harpyStrikeOpportunity){
     candidates.push({
       itemType: INVENTORY_ITEM_TYPES.FUEL,
       reason: "harpy_strike_return",

--- a/scripts/smoke-ai-fuel-ricochet-multikill.js
+++ b/scripts/smoke-ai-fuel-ricochet-multikill.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+'use strict';
+
+// Smoke test: Step 6 — fuel extends a RICOCHET sweep into a bigger multikill.
+//
+// The sweep builder re-simulates the winning launch line at fuel-boosted range and,
+// when the doubled range catches strictly MORE targets along the bounces, attaches
+// `aiFuelRicochetExtend` to the plan. pickAiBuffsForSelectedPlan must then spend fuel
+// (reason "ricochet_sweep_extend_more_targets") — and prefer that over a harpy
+// retreat, since for a sweep the extra kills are the point. No gain, or no fuel in
+// inventory, must NOT spend fuel.
+
+const fs = require('fs');
+const vm = require('vm');
+
+function extractFunctionSource(source, fnName){
+  const signature = `function ${fnName}(`;
+  const start = source.indexOf(signature);
+  if(start === -1) throw new Error(`Function not found in script.js: ${fnName}`);
+  const signatureEnd = source.indexOf(')', start);
+  const bodyStart = source.indexOf('{', signatureEnd);
+  let depth = 0;
+  for(let i = bodyStart; i < source.length; i += 1){
+    const ch = source[i];
+    if(ch === '{') depth += 1;
+    if(ch === '}') depth -= 1;
+    if(depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`Function body end not found for: ${fnName}`);
+}
+
+function assert(condition, message){
+  if(!condition) throw new Error(message);
+}
+
+const source = fs.readFileSync('script.js', 'utf8');
+
+const INVENTORY_ITEM_TYPES = { FUEL: 'fuel', CROSSHAIR: 'crosshair', WINGS: 'wings', INVISIBILITY: 'invisible', MINE: 'mine', DYNAMITE: 'dynamite' };
+const plane = { x: 0, y: 0, color: 'blue', activeTurnBuffs: {} };
+
+// base range 30 cells * 20 = 600px; fuel doubles to 60 cells = 1200px.
+const context = {
+  Math,
+  Number,
+  CELL_SIZE: 20,
+  AI_FUEL_MIN_REACH_RATIO: 1.0,
+  AI_FUEL_HARPY_MIN_STRIKE_RISK: 0.5,
+  AI_FUEL_HARPY_MIN_SAFETY_GAIN: 0.2,
+  AI_FUEL_HARPY_DEEP_FORWARD_RATIO: 0.8,
+  AI_FUEL_EXTEND_MIN_EXTRA_TARGETS: 1,
+  INVENTORY_ITEM_TYPES,
+  getEffectiveFlightRangeCells: (p) => (p?.activeTurnBuffs?.[INVENTORY_ITEM_TYPES.FUEL] ? 60 : 30),
+  getAiSelectedPlanIntentText: (plan) =>
+    `${plan?.goalName || ''} ${plan?.decisionReason || ''} ${plan?.routeClass || ''}`.toLowerCase(),
+  applyItemToOwnPlane: (type, _color, p) => { p.activeTurnBuffs = { ...(p.activeTurnBuffs || {}), [type]: true }; return true; },
+  getBaseAnchor: () => ({ x: 0, y: 0 }),
+  getFallbackCandidateResponseRisk: (meta) => (meta && Number.isFinite(meta.risk) ? meta.risk : 0),
+  getImmediateResponseThreatMeta: () => ({ risk: 0, count: 0 }),
+  getPlaneBeneficialGeometry: () => ({ hitbox: { width: 36 } }),
+  getCargoVisualCenter: (c) => ({ x: c.x, y: c.y }),
+  isPathClear: () => true,
+};
+vm.createContext(context);
+vm.runInContext(extractFunctionSource(source, 'pickAiBuffsForSelectedPlan'), context);
+
+// A ricochet multi-target sweep plan. landingY controls "deep forward" (for the
+// harpy-ordering test); aiFuelRicochetExtend carries the boosted re-sim result.
+const fuelReason = ({ landingY = 300, extend = null, fuel = 1 } = {}) => {
+  plane.activeTurnBuffs = {};
+  const out = context.pickAiBuffsForSelectedPlan({
+    plane,
+    color: 'blue',
+    context: { enemies: [], readyCargo: [] },
+    selectedPlan: {
+      plane, routeClass: 'ricochet', goalName: 'simple_step2_multi_target',
+      decisionReason: 'simple_step2_multi_target_ricochet', bounceCount: 2,
+      landingX: 0, landingY, planDistance: landingY,
+      targetPoint: { x: 0, y: landingY }, score: 0.5,
+      aiFuelRicochetExtend: extend,
+    },
+    availableCounts: { fuel },
+  }).find((c) => c.itemType === 'fuel');
+  return out ? out.reason : null;
+};
+
+// 1. Boosted re-sim catches MORE (5 > 3) -> spend fuel to extend the multikill.
+assert(fuelReason({ extend: { baseCount: 3, boostedCount: 5 } }) === 'ricochet_sweep_extend_more_targets',
+  '1: fuel should extend a ricochet sweep that catches more targets boosted.');
+
+// 2. No extra targets with fuel (5 == 5) -> NO fuel.
+assert(fuelReason({ extend: { baseCount: 5, boostedCount: 5 } }) === null,
+  '2: no fuel when the boosted ricochet sweep catches no more than the base.');
+
+// 3. Extra targets, but NO fuel in inventory -> NO fuel.
+assert(fuelReason({ extend: { baseCount: 3, boostedCount: 5 }, fuel: 0 }) === null,
+  '3: no fuel spent when there is none in inventory.');
+
+// 4. No aiFuelRicochetExtend flag at all -> NO ricochet-extend fuel.
+assert(fuelReason({ extend: null }) === null,
+  '4: a sweep with no boosted gain flag must not trigger ricochet-extend fuel.');
+
+// 5. Ordering: a DEEP sweep (would also be a harpy) with a boosted gain must pick the
+//    multikill extend, NOT the harpy retreat (the kills are the point).
+assert(fuelReason({ landingY: 540, extend: { baseCount: 3, boostedCount: 5 } }) === 'ricochet_sweep_extend_more_targets',
+  '5: multikill-extend should win over a harpy retreat on a deep sweep.');
+
+console.log('Smoke test passed: fuel extends a ricochet sweep only when the boosted range catches more targets, never without a gain or without fuel, and the multikill wins over a retreat.');


### PR DESCRIPTION
## Зачем

«Загруженная карта, топливо на максимум, мультикилл с рикошетами» — это и есть самый сок. Но повод «собрать больше целей топливом» (#2849) работал **только на прямых маршрутах**: у рикошета продлённый полёт — не прямая, проекция целей на луч запуска неверна. Поэтому топливо **никогда** не удлиняло скачущий мультицель-свип ради лишних целей. Этот PR закрывает дыру — финал роадмапа (Шаг 6).

## Как (решаем там, где уже есть симуляция)

**1. `buildBestMultiTargetSweepCandidate`** — после выбора лучшего направления на базовой дальности пересимулирую **то же направление** на удвоенной (fuel) дальности (временный fuel-бафф → `simulateAIShot` → снять) и считаю цели на длинном скачущем пути. Если ловит строго БОЛЬШЕ — вешаю на план `aiFuelRicochetExtend{baseCount, boostedCount, …}`. Базовый маршрут сохраняю, так что без топлива ход остаётся валидным.

**2. `pickAiBuffsForSelectedPlan`** — при флаге тратит топливо (причина `ricochet_sweep_extend_more_targets`), проверяется **раньше harpy**: для свипа важны лишние килы, а harpy-replan домой увёл бы линию мультикилла. По-прежнему стыкуется с точностью/крылом.

**3. Запуск** — чтобы лететь ровно по симулированному маршруту, надо сохранить угол и лишь дотянуть до макс-дальности (`forceFuelMoveToMaxRange`). Поэтому для этой причины помечаю план `fuelReplanned=true` и пропускаю fuel-replan (он целился бы в дом/врага и сбил бы линию). `forceFuelMoveToMaxRange` растягивает лучший угол до boosted-max = ровно посчитанный маршрут (и `getEffectiveFlightRangeCells` на запуске уже с топливом, так что дальности совпадают).

Работает и для dominate-свипа (≥3, tier 0), и для 2-целевого (tier 1) — оба несут флаг через spread `...sweepCandidate`. Доп. стоимость — одна симуляция на самолёт, только когда топливо реально в наличии; при этом для этого пути я fuel-replan **пропускаю** (меньше работы, чем у обычного топлива — без фриза).

## Проверка

Новый `scripts/smoke-ai-fuel-ricochet-multikill.js`: топливо тратится только когда boosted-свип ловит строго больше; не тратится без выигрыша и без топлива в инвентаре; мультикилл выигрывает у harpy-отхода на глубоком свипе.

Все `scripts/smoke-ai-*.js` зелёные, кроме 3 пред-существующих падений (`selected-plan-handoff`, `forced-non-skip-last-chance`, `temporary-item-candidate`) — падают и на чистом `main` (наследие async-миграции), к этому изменению отношения не имеют.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_