### PR TITLE
AI fuel: растягивать ход, если топливо в комбо, а не только когда применено последним

### DIFF
--- a/script.js
+++ b/script.js
@@ -31354,14 +31354,14 @@ function issueAIMoveWithInventoryUsage(context, plannedMove){
       actualReturnSafetyScore: plannedMove.aiFuelTacticalDecision.actualReturnSafetyScore,
       rejectedScenarios: plannedMove.aiFuelTacticalDecision.rejectedScenarios,
       rejectionReason: plannedMove.aiFuelTacticalDecision.rejectionReason,
-      fuelApplied: effectiveItemUsed && consumedItemType === INVENTORY_ITEM_TYPES.FUEL,
+      fuelApplied: effectiveItemUsed && consumedItemTypes.includes(INVENTORY_ITEM_TYPES.FUEL),
       consumedItemType: consumedItemType || null,
     });
   }
 
   const pendingFuelTrainingAttempt = getLatestPendingAiFuelTrainingAttempt();
   if(pendingFuelTrainingAttempt){
-    const usedFuel = effectiveItemUsed && consumedItemType === INVENTORY_ITEM_TYPES.FUEL;
+    const usedFuel = effectiveItemUsed && consumedItemTypes.includes(INVENTORY_ITEM_TYPES.FUEL);
     const reason = usedFuel
       ? "fuel_used_on_next_ai_turn"
       : (
@@ -31378,8 +31378,14 @@ function issueAIMoveWithInventoryUsage(context, plannedMove){
     });
   }
 
+  // Fuel was used if it is ANYWHERE in the consumed sequence — not only if it was the
+  // LAST item applied. pickAiBuffs returns fuel before crosshair/wings, so a combo
+  // applies fuel first and a buff last; keying on the last item (consumedItemType)
+  // skipped this whole block for combos, leaving the move un-extended — fuel consumed
+  // but the plane flew a base-range (<30-cell) move. Match the dynamite pattern above
+  // and test the full list.
   if(effectiveItemUsed
-    && consumedItemType === INVENTORY_ITEM_TYPES.FUEL
+    && consumedItemTypes.includes(INVENTORY_ITEM_TYPES.FUEL)
     && plannedMove?.plane
     && Number.isFinite(plannedMove.vx)
     && Number.isFinite(plannedMove.vy)){


### PR DESCRIPTION
## Корневая причина «топливо потрачено, а самолёт летит на <30 клеток»

Баг в коде запуска (`issueAIMoveWithInventoryUsage`). Блок, который запускает `forceFuelMoveToMaxRange` — то, что растягивает полёт до удвоенной (60 кл) дальности, — был завязан на `consumedItemType === FUEL`, где `consumedItemType` = **последний** применённый предмет в последовательности.

`pickAiBuffs` отдаёт топливо **первым**, а кроссхаир/крыло — **последними**. Значит в любом **комбо** (топливо + кроссхаир, топливо + крыло) последним был бафф, не топливо → проверка не проходила → весь блок растягивания **пропускался**: топливо списывалось, а самолёт летел на **базовые 30 клеток**.

Поэтому утечка была именно у комбо: топливо в одиночку работало (оно и было последним) — вот почему harpy (часто только топливо) выглядел нормально, а «улучшенные» мультикилл-ходы (топливо + крыло/кроссхаир) жгли топливо на коротком ходу.

## Фикс

Проверяем `consumedItemTypes.includes(FUEL)` — топливо **где угодно** в последовательности, а не только последним. Это ровно тот же приём, что уже используется для динамита парой строк выше (`consumedItemTypes.includes(DYNAMITE)`). Те же правки применены к двум родственным флагам «топливо использовано» (лог тактического плана и outcome обучения по топливу), чтобы телеметрия осталась согласованной.

Одна некорректная проверка (`=== последний` вместо `включает`). Поведенческих рисков нет: блок и так должен срабатывать всегда, когда топливо реально израсходовано.

## Проверка

`node --check` + AI-смоук-сюита зелёные (кроме 3 пред-существующих падений, не связанных с изменением). Прелонч-тесты исполнения инвентаря (`smoke-ai-prelaunch-*`) проходят.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_