### PR TITLE
Mine blast scores for the opponent, not the mine owner

### DIFF
--- a/script.js
+++ b/script.js
@@ -44161,11 +44161,11 @@ function handleMineForPlane(p, fp){
 
     mines.splice(i, 1);
 
-    // Self-detonation rule: stepping on your own mine destroys your plane,
-    // but does not grant a score point to the owner.
-    if(mine.owner && mine.owner !== p.color && canAwardKillPointForPlane(p)){
+    // Blowing up on a mine — anyone's, including your own — hands a point to
+    // the other player. Standard penalty: you detonated, the opponent scores.
+    if(canAwardKillPointForPlane(p)){
       markPlaneKillPointAwarded(p);
-      awardPoint(mine.owner);
+      awardPoint(p.color === "blue" ? "green" : "blue");
     }
     checkVictory();
 


### PR DESCRIPTION
A plane blowing up on a mine should hand a point to the OTHER player — standard 'you detonated, opponent scores' penalty. The old rule awarded mine.owner and explicitly skipped self-detonation, so stepping on your own mine gave nobody a point. Award the victim's opponent regardless of who owns the mine; for enemy mines this is identical to before, and self-detonation now correctly penalizes the player who blew up.

Note: the mine smoke tests (smoke-mine-segment-hit-large-step, smoke-arcade-plane-base-targetable, smoke-danger-wings-no-early-penalty) fail identically with and without this change due to pre-existing missing helpers in their vm contexts; this 4-line change adds no new dependencies.


Claude-Session: https://claude.ai/code/session_01QWep6Zsim5uEqa5br7vuHk