### PR TITLE
AI комбо (B): точность и крыло оцениваются на фуел-продлённом ходу

### DIFF
--- a/script.js
+++ b/script.js
@@ -29377,17 +29377,41 @@ function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, avail
     candidates.push({ itemType: INVENTORY_ITEM_TYPES.FUEL, reason: "selected_plan_reach_distant_target" });
   }
 
+  // Combo synergy: when fuel is being applied, the launch stretches this move to the
+  // boosted max range along the SAME launch angle (forceFuelMoveToMaxRange). So
+  // crosshair and wings must be judged on that EXTENDED move, not the short base one:
+  // the shot becomes long (crosshair earns its keep) and the bouncy path becomes
+  // longer (wings sweep more). Without this, a base-short fuel move hides the combo —
+  // crosshair/wings would be denied even though the move the plane actually flies is
+  // long. (Only the aim/span buffs use this view; fuel already decided above.)
+  const fuelWillApply = candidates.some((c) => c.itemType === INVENTORY_ITEM_TYPES.FUEL);
+  const planForAimBuffs = (() => {
+    if(!fuelWillApply) return selectedPlan;
+    const dx = Number(selectedPlan?.landingX) - plane.x;
+    const dy = Number(selectedPlan?.landingY) - plane.y;
+    const len = Math.hypot(dx, dy);
+    if(!Number.isFinite(len) || len <= 0) return selectedPlan;
+    const ux = dx / len;
+    const uy = dy / len;
+    return {
+      ...selectedPlan,
+      landingX: plane.x + ux * fuelBoostedRangePx,
+      landingY: plane.y + uy * fuelBoostedRangePx,
+      planDistance: Math.max(Number(selectedPlan?.planDistance) || 0, fuelBoostedRangePx),
+    };
+  })();
+
   // Crosshair and wings are evaluated independently and can combine with each other and with fuel.
   // The distance gate now lives entirely in shouldAiUseCrosshairForSelectedPlan
   // (crosshair only near max range). No precision-route bypass — a short
   // ricochet/gap must clear the distance gate too.
-  if(crosshairAvailable && shouldAiUseCrosshairForSelectedPlan(context, selectedPlan)){
+  if(crosshairAvailable && shouldAiUseCrosshairForSelectedPlan(context, planForAimBuffs)){
     candidates.push({ itemType: INVENTORY_ITEM_TYPES.CROSSHAIR, reason: "selected_plan_precision_support" });
   }
 
   // No bare contact-intent bypass: wings are used only when they enable a
   // multi-pickup the normal span couldn't make (see shouldAiUseWingsForSelectedPlan).
-  if(wingsAvailable && shouldAiUseWingsForSelectedPlan(context, selectedPlan)){
+  if(wingsAvailable && shouldAiUseWingsForSelectedPlan(context, planForAimBuffs)){
     candidates.push({ itemType: INVENTORY_ITEM_TYPES.WINGS, reason: "selected_plan_multi_pickup_span" });
   }
 

--- a/scripts/smoke-ai-combo-aim-sees-fuel.js
+++ b/scripts/smoke-ai-combo-aim-sees-fuel.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+'use strict';
+
+// Smoke test: combo synergy — crosshair (and wings) judge the FUEL-EXTENDED move.
+//
+// When fuel is applied, the launch stretches the move to the boosted max range along
+// the same angle. So a shot that is too short for a crosshair on the BASE move becomes
+// a long shot once fuel extends it, and should then get the crosshair. pickAiBuffs must
+// evaluate the aim/span buffs on that extended plan (planForAimBuffs), not the base one.
+
+const fs = require('fs');
+const vm = require('vm');
+
+function extractFunctionSource(source, fnName){
+  const signature = `function ${fnName}(`;
+  const start = source.indexOf(signature);
+  if(start === -1) throw new Error(`Function not found in script.js: ${fnName}`);
+  const signatureEnd = source.indexOf(')', start);
+  const bodyStart = source.indexOf('{', signatureEnd);
+  let depth = 0;
+  for(let i = bodyStart; i < source.length; i += 1){
+    const ch = source[i];
+    if(ch === '{') depth += 1;
+    if(ch === '}') depth -= 1;
+    if(depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`Function body end not found for: ${fnName}`);
+}
+
+function assert(condition, message){
+  if(!condition) throw new Error(message);
+}
+
+const source = fs.readFileSync('script.js', 'utf8');
+
+const INVENTORY_ITEM_TYPES = { FUEL: 'fuel', CROSSHAIR: 'crosshair', WINGS: 'wings', INVISIBILITY: 'invisible', MINE: 'mine', DYNAMITE: 'dynamite' };
+const plane = { x: 0, y: 0, color: 'blue', activeTurnBuffs: {} };
+
+// base range 30 cells * 20 = 600px; fuel doubles to 60 cells = 1200px.
+const context = {
+  Math,
+  Number,
+  CELL_SIZE: 20,
+  AI_FUEL_MIN_REACH_RATIO: 1.0,
+  AI_FUEL_EXTEND_MIN_EXTRA_TARGETS: 1,
+  AI_CROSSHAIR_MIN_DISTANCE_RATIO: 0.6,
+  INVENTORY_ITEM_TYPES,
+  getEffectiveFlightRangeCells: (p) => (p?.activeTurnBuffs?.[INVENTORY_ITEM_TYPES.FUEL] ? 60 : 30),
+  getAiSelectedPlanIntentText: (plan) =>
+    `${plan?.goalName || ''} ${plan?.decisionReason || ''} ${plan?.routeClass || ''}`.toLowerCase(),
+  applyItemToOwnPlane: (type, _color, p) => { p.activeTurnBuffs = { ...(p.activeTurnBuffs || {}), [type]: true }; return true; },
+  getBaseAnchor: () => ({ x: 0, y: 0 }),
+  // direct fuel-extend probe deps (unused here — context has no enemies/cargo)
+  getPlaneBeneficialGeometry: () => ({ hitbox: { width: 36 } }),
+  getCargoVisualCenter: (c) => ({ x: c.x, y: c.y }),
+  isPathClear: () => true,
+};
+vm.createContext(context);
+vm.runInContext(extractFunctionSource(source, 'shouldAiUseCrosshairForSelectedPlan'), context);
+vm.runInContext(extractFunctionSource(source, 'pickAiBuffsForSelectedPlan'), context);
+
+// A short attack (15 cells out) whose harpy round trip needs fuel. landingY 320 ->
+// base ratio 320/600 = 0.53 (< 0.6, no crosshair on base), but a harpy fires (round
+// trip 640 > base 600), so fuel extends it to 1200 (ratio 2.0 -> crosshair).
+const plan = {
+  plane, routeClass: 'direct', goalName: 'attack', decisionReason: 'simple_step2_direct_enemy',
+  bounceCount: 0, landingX: 0, landingY: 320, planDistance: 320,
+  targetPoint: { x: 0, y: 320 }, score: 0.5,
+};
+const buffs = (availableCounts) => {
+  plane.activeTurnBuffs = {};
+  return context.pickAiBuffsForSelectedPlan({ plane, color: 'blue', context: {}, selectedPlan: plan, availableCounts })
+    .map((c) => c.itemType);
+};
+
+// 1. fuel + crosshair available: fuel (harpy) fires AND extends the move, so crosshair
+//    is judged on the long extended shot and is granted -> both present.
+const withFuel = buffs({ fuel: 1, crosshair: 1 });
+assert(withFuel.includes('fuel'), '1a: the harpy round trip should spend fuel.');
+assert(withFuel.includes('crosshair'), '1b: crosshair should be granted on the fuel-extended (long) shot.');
+
+// 2. crosshair only (no fuel): nothing extends the move, so the short base shot does
+//    NOT clear the crosshair distance gate -> no crosshair.
+const noFuel = buffs({ crosshair: 1 });
+assert(!noFuel.includes('crosshair'), '2: a short shot with no fuel must NOT get a crosshair.');
+
+// 3. control: an already-long base shot still gets a crosshair without any fuel.
+const longPlan = { ...plan, landingY: 540, planDistance: 540, targetPoint: { x: 0, y: 540 } };
+plane.activeTurnBuffs = {};
+const longShot = context.pickAiBuffsForSelectedPlan({ plane, color: 'blue', context: {}, selectedPlan: longPlan, availableCounts: { crosshair: 1 } })
+  .map((c) => c.itemType);
+assert(longShot.includes('crosshair'), '3: a long base shot still gets a crosshair without fuel.');
+
+console.log('Smoke test passed: crosshair/wings are judged on the fuel-extended move — a short fuel shot now earns the crosshair, a short non-fuel shot does not.');


### PR DESCRIPTION
## Шаг B из разбора сочетаний предметов

Кроссхаир и крыло уже **складываются** с топливом, но каждый гейт оценивал **базовый** ход. А когда топливо применяется, запуск растягивает ход до удвоенной дальности по тому же углу (`forceFuelMoveToMaxRange`) — то есть реально самолёт летит **длинный** ход. Гейты же видели короткий базовый ход и **отказывали** баффам:

- короткий фуел-выстрел не получал кроссхаир (считался коротким);
- удлинённый топливом скачущий путь не получал крыло (оценивался по базовому пути).

Синергия «топливо+точность» / «топливо+крыло» пряталась.

## Фикс

Если выбран фуел-кандидат — строю `planForAimBuffs`: тот же угол запуска, растянутый до `fuelBoostedRangePx`, — и отдаю его в `shouldAiUseCrosshairForSelectedPlan` и `shouldAiUseWingsForSelectedPlan`. Теперь:
- выстрел корректно виден как длинный → кроссхаир оправдан;
- крыло считает цели на длинном пути → даётся, если широкий размах ловит больше.

Без топлива используется базовый план без изменений — не-фуел поведение не тронуто.

## Зависимость / порядок

Стоит на launch-фиксе #2853 и мультикилле #2851 — **оба уже в main**, так что это обычный PR от main. (Без #2853 добавление кроссхаира к топливу триггерило бы старый баг «не растягивается» — теперь не проблема.)

## Проверка

Новый `scripts/smoke-ai-combo-aim-sees-fuel.js`: короткая атака, чей harpy-круг тратит топливо, теперь **получает** кроссхаир (продлённый выстрел длинный); та же короткая атака **без** топлива — не получает; уже длинный базовый выстрел получает кроссхаир и без топлива. Существующие `smoke-ai-crosshair-short-guard` и `smoke-ai-wings-smart-use` зелёные (не-фуел путь не изменился). Прочие AI-смоук зелёные, кроме 3 пред-существующих падений (не связаны).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_