### PR TITLE
AI: смелее использовать точность/крыло, когда их в достатке

### DIFF
--- a/script.js
+++ b/script.js
@@ -27912,8 +27912,14 @@ function logTacticalItemFinalDecision(itemType, details = {}){
 // often under-powers its launches — so 0.8 fired almost never. 0.6 = a genuinely
 // long shot; tune up toward 0.8 for max-only, down for more frequent use.
 const AI_CROSSHAIR_MIN_DISTANCE_RATIO = 0.6;
+// Boldness: a crosshair only guarantees a hit (no downside but spending one), so when
+// they are plentiful, hoarding them while shooting timidly is itself a waste. Each
+// spare beyond the first lowers the distance bar by RELAX, down to FLOOR — with a
+// stack the AI guarantees even mid/short aimed shots.
+const AI_CROSSHAIR_ABUNDANCE_RELAX = 0.15;
+const AI_CROSSHAIR_BOLD_RATIO_FLOOR = 0.2;
 
-function shouldAiUseCrosshairForSelectedPlan(context, selectedPlan){
+function shouldAiUseCrosshairForSelectedPlan(context, selectedPlan, options = {}){
   const plane = selectedPlan?.plane || null;
   if(!plane) return false;
   const routeClass = `${selectedPlan?.routeClass || "direct"}`.toLowerCase();
@@ -27928,8 +27934,14 @@ function shouldAiUseCrosshairForSelectedPlan(context, selectedPlan){
   const moveDistance = Math.max(planDistance, launchTravel);
   const effectiveRangePx = Math.max(1, getEffectiveFlightRangeCells(plane) * CELL_SIZE);
   const distanceRatio = moveDistance / effectiveRangePx;
-  // Distance gate: nothing below a genuinely long shot justifies a crosshair.
-  if(distanceRatio < AI_CROSSHAIR_MIN_DISTANCE_RATIO) return false;
+  // Distance gate: nothing below a genuinely long shot justifies a crosshair — but a
+  // stack of spare crosshairs lowers that bar (bolder use when they are plentiful).
+  const availableCount = Math.max(1, Math.trunc(Number(options?.availableCount) || 1));
+  const minDistanceRatio = Math.max(
+    AI_CROSSHAIR_BOLD_RATIO_FLOOR,
+    AI_CROSSHAIR_MIN_DISTANCE_RATIO - (availableCount - 1) * AI_CROSSHAIR_ABUNDANCE_RELAX,
+  );
+  if(distanceRatio < minDistanceRatio) return false;
   // Near-max shot: use it only for a meaningful aimed shot (attack / pickup /
   // flag / precision route), not an aimless long drift to center.
   const precisionIntent = [
@@ -27951,17 +27963,37 @@ const AI_WINGS_MIN_PICKUPS = 2;
 // targets and slapping on wings to widen the kill zone ("mass murder"), even if
 // the normal span might technically reach them. Long = this fraction of range.
 const AI_WINGS_LONG_SHOT_RATIO = 0.6;
+// Boldness: each spare wing beyond the first lowers the long-shot bar by RELAX (down
+// to FLOOR), and with a full stack wings are worth slapping onto even a SINGLE target
+// on a long uncertain shot — the wide span is miss-insurance so an imperfect long aim
+// still connects. Hoarding wings while playing safe is itself a waste.
+const AI_WINGS_ABUNDANCE_RELAX = 0.15;
+const AI_WINGS_BOLD_RATIO_FLOOR = 0.2;
+const AI_WINGS_BOLD_SINGLE_TARGET_COUNT = 3;
 
-function shouldAiUseWingsForSelectedPlan(context, selectedPlan){
+function shouldAiUseWingsForSelectedPlan(context, selectedPlan, options = {}){
   const plane = selectedPlan?.plane || null;
   if(!plane) return false;
   const landingX = Number(selectedPlan?.landingX);
   const landingY = Number(selectedPlan?.landingY);
   if(!Number.isFinite(landingX) || !Number.isFinite(landingY)) return false;
 
+  // Boldness from a stack of spare wings: lower the long-shot bar, and (when plentiful)
+  // accept a single target on a long shot as miss-insurance.
+  const availableCount = Math.max(1, Math.trunc(Number(options?.availableCount) || 1));
+  const longShotRatio = Math.max(
+    AI_WINGS_BOLD_RATIO_FLOOR,
+    AI_WINGS_LONG_SHOT_RATIO - (availableCount - 1) * AI_WINGS_ABUNDANCE_RELAX,
+  );
+  const planDistanceVal = Number.isFinite(selectedPlan?.planDistance) ? selectedPlan.planDistance : 0;
+  const launchTravelEarly = Math.hypot(landingX - plane.x, landingY - plane.y);
+  const effectiveRangeEarly = Math.max(1, getEffectiveFlightRangeCells(plane) * CELL_SIZE);
+  const isLongShot = (Math.max(planDistanceVal, launchTravelEarly) / effectiveRangeEarly) >= longShotRatio;
+  const minPickups = (availableCount >= AI_WINGS_BOLD_SINGLE_TARGET_COUNT && isLongShot) ? 1 : AI_WINGS_MIN_PICKUPS;
+
   const pickups = Array.isArray(context?.readyCargo) ? context.readyCargo.filter(Boolean) : [];
   const enemies = Array.isArray(context?.enemies) ? context.enemies.filter((enemy) => enemy && enemy.isAlive !== false) : [];
-  if(pickups.length + enemies.length < AI_WINGS_MIN_PICKUPS) return false;
+  if(pickups.length + enemies.length < minPickups) return false;
 
   // The flown path (with ricochet bounces) — unchanged by wings; only the span changes.
   const durationSec = (typeof FIELD_FLIGHT_DURATION_SEC === "number" && FIELD_FLIGHT_DURATION_SEC > 0) ? FIELD_FLIGHT_DURATION_SEC : 1;
@@ -27998,16 +28030,13 @@ function shouldAiUseWingsForSelectedPlan(context, selectedPlan){
     if(isEnemyHitWithSpan(enemy, barePlane)) bareCount += 1;
   }
 
-  if(wideCount < AI_WINGS_MIN_PICKUPS) return false;
+  if(wideCount < minPickups) return false;
   // (1) Wings strictly enable extra targets the normal span couldn't reach.
   if(wideCount > bareCount) return true;
-  // (2) Long shot with real miss-risk that sweeps over >= MIN targets — widen
-  //     the kill zone for the mass run even if the normal span might reach them.
-  const planDistanceVal = Number.isFinite(selectedPlan?.planDistance) ? selectedPlan.planDistance : 0;
-  const launchTravel = Math.hypot(landingX - plane.x, landingY - plane.y);
-  const effectiveRangePx = Math.max(1, getEffectiveFlightRangeCells(plane) * CELL_SIZE);
-  const distanceRatio = Math.max(planDistanceVal, launchTravel) / effectiveRangePx;
-  return distanceRatio >= AI_WINGS_LONG_SHOT_RATIO;
+  // (2) A long shot with real miss-risk that the wide span sweeps over — widen the kill
+  //     zone for the run (a multi-target mass, or with a stack of spares even a single
+  //     target as miss-insurance). The long-shot bar already accounts for abundance.
+  return isLongShot;
 }
 
 function shouldAiUseInvisibilityForSelectedPlan(context, selectedPlan){
@@ -29405,13 +29434,18 @@ function pickAiBuffsForSelectedPlan({ plane, color, context, selectedPlan, avail
   // The distance gate now lives entirely in shouldAiUseCrosshairForSelectedPlan
   // (crosshair only near max range). No precision-route bypass — a short
   // ricochet/gap must clear the distance gate too.
-  if(crosshairAvailable && shouldAiUseCrosshairForSelectedPlan(context, planForAimBuffs)){
+  if(crosshairAvailable && shouldAiUseCrosshairForSelectedPlan(context, planForAimBuffs, {
+    availableCount: Number(availableCounts?.[INVENTORY_ITEM_TYPES.CROSSHAIR] ?? 0),
+  })){
     candidates.push({ itemType: INVENTORY_ITEM_TYPES.CROSSHAIR, reason: "selected_plan_precision_support" });
   }
 
-  // No bare contact-intent bypass: wings are used only when they enable a
-  // multi-pickup the normal span couldn't make (see shouldAiUseWingsForSelectedPlan).
-  if(wingsAvailable && shouldAiUseWingsForSelectedPlan(context, planForAimBuffs)){
+  // No bare contact-intent bypass: wings are used only when they enable a multi-pickup
+  // the normal span couldn't make — OR, with a stack of spares, as miss-insurance on a
+  // long single-target shot (see shouldAiUseWingsForSelectedPlan).
+  if(wingsAvailable && shouldAiUseWingsForSelectedPlan(context, planForAimBuffs, {
+    availableCount: Number(availableCounts?.[INVENTORY_ITEM_TYPES.WINGS] ?? 0),
+  })){
     candidates.push({ itemType: INVENTORY_ITEM_TYPES.WINGS, reason: "selected_plan_multi_pickup_span" });
   }
 

--- a/scripts/smoke-ai-combo-aim-sees-fuel.js
+++ b/scripts/smoke-ai-combo-aim-sees-fuel.js
@@ -44,6 +44,8 @@ const context = {
   AI_FUEL_MIN_REACH_RATIO: 1.0,
   AI_FUEL_EXTEND_MIN_EXTRA_TARGETS: 1,
   AI_CROSSHAIR_MIN_DISTANCE_RATIO: 0.6,
+  AI_CROSSHAIR_ABUNDANCE_RELAX: 0.15,
+  AI_CROSSHAIR_BOLD_RATIO_FLOOR: 0.2,
   INVENTORY_ITEM_TYPES,
   getEffectiveFlightRangeCells: (p) => (p?.activeTurnBuffs?.[INVENTORY_ITEM_TYPES.FUEL] ? 60 : 30),
   getAiSelectedPlanIntentText: (plan) =>

--- a/scripts/smoke-ai-crosshair-short-guard.js
+++ b/scripts/smoke-ai-crosshair-short-guard.js
@@ -40,7 +40,9 @@ const context = {
   Math,
   Number,
   CELL_SIZE: 20,
-  AI_CROSSHAIR_MIN_DISTANCE_RATIO: 0.6, // module-scope const in script.js
+  AI_CROSSHAIR_MIN_DISTANCE_RATIO: 0.6, // module-scope consts in script.js
+  AI_CROSSHAIR_ABUNDANCE_RELAX: 0.15,
+  AI_CROSSHAIR_BOLD_RATIO_FLOOR: 0.2,
   INVENTORY_ITEM_TYPES,
   getEffectiveFlightRangeCells: () => 30, // effectiveRangePx = 600
   getAiSelectedPlanIntentText: (plan) =>

--- a/scripts/smoke-ai-inventory-boldness.js
+++ b/scripts/smoke-ai-inventory-boldness.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+'use strict';
+
+// Smoke test: inventory boldness — abundance lowers the bar to use a buff.
+//
+// Crosshair only guarantees a hit and wings only widen a span; neither wastes the
+// move, so hoarding a stack while shooting timidly is itself a waste. With spares, the
+// distance bar drops (crosshair/wings fire on mid shots), and a full stack of wings is
+// worth slapping onto even a single target on a long shot (miss-insurance). With a
+// single copy the strict thresholds are unchanged.
+
+const fs = require('fs');
+const vm = require('vm');
+
+function extractFunctionSource(source, fnName){
+  const signature = `function ${fnName}(`;
+  const start = source.indexOf(signature);
+  if(start === -1) throw new Error(`Function not found in script.js: ${fnName}`);
+  const signatureEnd = source.indexOf(')', start);
+  const bodyStart = source.indexOf('{', signatureEnd);
+  let depth = 0;
+  for(let i = bodyStart; i < source.length; i += 1){
+    const ch = source[i];
+    if(ch === '{') depth += 1;
+    if(ch === '}') depth -= 1;
+    if(depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`Function body end not found for: ${fnName}`);
+}
+
+function assert(condition, message){
+  if(!condition) throw new Error(message);
+}
+
+const source = fs.readFileSync('script.js', 'utf8');
+
+const INVENTORY_ITEM_TYPES = { FUEL: 'fuel', CROSSHAIR: 'crosshair', WINGS: 'wings', INVISIBILITY: 'invisible', MINE: 'mine', DYNAMITE: 'dynamite' };
+const plane = { x: 0, y: 0, color: 'blue', activeTurnBuffs: {} };
+
+const context = {
+  Math,
+  Number,
+  Array,
+  CELL_SIZE: 20,
+  FIELD_FLIGHT_DURATION_SEC: 1,
+  AI_FUEL_MIN_REACH_RATIO: 1.0,
+  AI_FUEL_EXTEND_MIN_EXTRA_TARGETS: 1,
+  AI_CROSSHAIR_MIN_DISTANCE_RATIO: 0.6,
+  AI_CROSSHAIR_ABUNDANCE_RELAX: 0.15,
+  AI_CROSSHAIR_BOLD_RATIO_FLOOR: 0.2,
+  AI_WINGS_MIN_PICKUPS: 2,
+  AI_WINGS_LONG_SHOT_RATIO: 0.6,
+  AI_WINGS_ABUNDANCE_RELAX: 0.15,
+  AI_WINGS_BOLD_RATIO_FLOOR: 0.2,
+  AI_WINGS_BOLD_SINGLE_TARGET_COUNT: 3,
+  INVENTORY_ITEM_TYPES,
+  getEffectiveFlightRangeCells: () => 30, // effectiveRangePx = 600
+  getAiSelectedPlanIntentText: (plan) =>
+    `${plan?.goalName || ''} ${plan?.decisionReason || ''} ${plan?.routeClass || ''}`.toLowerCase(),
+  applyItemToOwnPlane: (type, _color, p) => { p.activeTurnBuffs = { ...(p.activeTurnBuffs || {}), [type]: true }; return true; },
+  getBaseAnchor: () => ({ x: 0, y: 0 }),
+  getPlaneBeneficialGeometry: (p) => ({ hitbox: { width: (p?.activeTurnBuffs?.[INVENTORY_ITEM_TYPES.WINGS] === true) ? 96 : 36 } }),
+  getCargoVisualCenter: (c) => ({ x: c.x, y: c.y }),
+  getDistanceFromPointToSegment: (px) => px, // enemy.x encodes perpendicular distance
+  doesCargoIntersectBeneficialZoneAlongPath: () => false,
+  getAiPlannedMovePredictedPath: () => [{ x: 0, y: 0 }, { x: 0, y: 420 }],
+  isPathClear: () => true,
+};
+vm.createContext(context);
+vm.runInContext(extractFunctionSource(source, 'shouldAiUseCrosshairForSelectedPlan'), context);
+vm.runInContext(extractFunctionSource(source, 'shouldAiUseWingsForSelectedPlan'), context);
+vm.runInContext(extractFunctionSource(source, 'pickAiBuffsForSelectedPlan'), context);
+
+const picks = (selectedPlan, availableCounts, enemies = []) => {
+  plane.activeTurnBuffs = {};
+  return context.pickAiBuffsForSelectedPlan({ plane, color: 'blue', context: { enemies, readyCargo: [] }, selectedPlan, availableCounts })
+    .map((c) => c.itemType);
+};
+
+// --- Crosshair: a MID-range attack (ratio 0.4) ---
+const midShot = {
+  plane, routeClass: 'direct', goalName: 'attack', decisionReason: 'simple_step2_direct_enemy',
+  bounceCount: 0, landingX: 0, landingY: 240, planDistance: 240, targetPoint: { x: 0, y: 240 }, score: 0.5,
+};
+assert(!picks(midShot, { crosshair: 1 }).includes('crosshair'),
+  '1: a single crosshair must NOT be spent on a mid-range shot (strict bar).');
+assert(picks(midShot, { crosshair: 4 }).includes('crosshair'),
+  '2: a stack of crosshairs SHOULD be spent on the mid-range shot (bold bar).');
+
+// --- Wings: a LONG shot over a SINGLE wide-only enemy (x=50 -> only the wide span hits) ---
+const longSingle = {
+  plane, routeClass: 'direct', goalName: 'attack', decisionReason: 'simple_step2_direct_enemy',
+  bounceCount: 0, landingX: 0, landingY: 420, planDistance: 420, targetPoint: { x: 0, y: 420 }, score: 0.5,
+};
+const oneEnemy = [{ id: 'e1', isAlive: true, x: 50, y: 0 }];
+assert(!picks(longSingle, { wings: 1 }, oneEnemy).includes('wings'),
+  '3: a single wing must NOT be spent on a lone target (needs >= 2 targets).');
+assert(picks(longSingle, { wings: 3 }, oneEnemy).includes('wings'),
+  '4: a stack of wings SHOULD be spent on a lone target on a long shot (miss-insurance).');
+
+console.log('Smoke test passed: abundant crosshairs/wings are used boldly (mid shots, lone long-shot targets); a single copy keeps the strict thresholds.');

--- a/scripts/smoke-ai-wings-smart-use.js
+++ b/scripts/smoke-ai-wings-smart-use.js
@@ -45,6 +45,9 @@ const context = {
   FIELD_FLIGHT_DURATION_SEC: 1,
   AI_WINGS_MIN_PICKUPS: 2,    // module-scope consts in script.js
   AI_WINGS_LONG_SHOT_RATIO: 0.6,
+  AI_WINGS_ABUNDANCE_RELAX: 0.15,
+  AI_WINGS_BOLD_RATIO_FLOOR: 0.2,
+  AI_WINGS_BOLD_SINGLE_TARGET_COUNT: 3,
   INVENTORY_ITEM_TYPES,
   getEffectiveFlightRangeCells: () => 30,
   getAiSelectedPlanIntentText: (plan) =>


### PR DESCRIPTION
## Ответ на вопрос «что у нас с сочетаниями»

Сейчас баффы **складываются** (топливо, точность, крыло — независимые проверки, стек до 3 предметов):
- **топливо+крыло (без точности):** топливо — если ход выходит за базовую дальность; крыло — если ≥2 целей на (уже фуел-продлённом) пути; оба независимо.
- **точность+крыло (без топлива):** базовый ход; точность — если выстрел длинный; крыло — если ≥2 целей.
- **все три:** топливо решается первым (продлевает), точность/крыло судятся по продлённому ходу (PR #2855), всё до 3 влезает.

То есть механика комбо работает. Но каждый гейт использовал **фиксированный** порог независимо от того, сколько предметов на руках — отсюда «ИИ стесняется»: предметов в достатке, а на чуть-чуть не подходящей ситуации он их не тратит.

## Что меняю — смелость от изобилия

Точность лишь гарантирует попадание, крыло лишь расширяет размах — **ход они не тратят**. Копить стопку и при этом играть робко — само по себе потеря. Поэтому порог снижается с количеством:

- **Точность:** каждая лишняя копия сверх первой опускает порог дальности на 0.15, до пола 0.2. Одна копия — прежние 0.6 (только дальние); стопка — гарантирует даже средние/короткие прицельные выстрелы.
- **Крыло:** так же опускает порог «длинного выстрела»; а со стопкой (≥3) крыло не грех навесить даже на **одну** цель на длинном выстреле — широкий размах как страховка от промаха.

**Топливо намеренно не трогаю:** оно и так срабатывает всегда, когда продлевает ход за базовую дальность. «Смелее» с ним = тратить на ход в пределах 30 клеток = ровно та трата впустую, которую мы убрали раньше.

## Совместимость и проверка

Параметр `options` опциональный, по умолчанию — строгое поведение (count 1), так что существующие вызовы и смоук-тесты `crosshair-short-guard`/`wings-smart-use` не изменились. Новый `scripts/smoke-ai-inventory-boldness.js`: стопка точности/крыла срабатывает на среднем выстреле / одиночной цели на длинном, одна копия — нет. Вся AI-сюита зелёная, кроме 3 пред-существующих падений (не связаны).

Пороги — тюнабельные константы (`AI_*_ABUNDANCE_RELAX`, `AI_*_BOLD_RATIO_FLOOR`, `AI_WINGS_BOLD_SINGLE_TARGET_COUNT`), если захочешь смелее/осторожнее.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_