### PR TITLE
AI: доставка вражеского флага на базу — высший приоритет хода (этап A)

### DIFF
--- a/script.js
+++ b/script.js
@@ -15506,6 +15506,88 @@ function isAiTurnStillApplicable(){
   return !isGameOver && gameMode === "computer" && turnColors?.[turnIndex] === "blue";
 }
 
+// TOP-priority plan: deliver a carried enemy (green) flag to our base THIS turn — a
+// sure +5 that beats any multikill. Returns a planTier -1 move when the planned route
+// genuinely lands in the base zone (so delivery is certain): a base-range route home
+// (direct or ricochet, flown as planned), or — if home is beyond base range — a DIRECT
+// fuel-boosted route, aimed at base so the inventory picker spends fuel (reach_distant)
+// and forceFuelMoveToMaxRange flies the launch angle straight through home. Returns null
+// when the plane carries no enemy flag or cannot reach base this turn (let normal logic
+// run). Extracted from buildBestPlanForPlane so it can be unit-tested.
+function tryBuildAiFlagDeliveryPlan(plane, options = {}){
+  if(!plane || options?.flagsMode !== true) return null;
+  if(typeof getFlagById !== "function" || typeof getBaseAnchor !== "function"
+    || typeof getBaseInteractionTarget !== "function" || typeof getAiMoveLandingPoint !== "function"
+    || typeof planPathWithSpecialRouteProbe !== "function" || typeof doesPlaneZoneIntersectTargetZone !== "function"){
+    return null;
+  }
+  const carriedFlag = plane.carriedFlagId ? getFlagById(plane.carriedFlagId) : null;
+  if(!carriedFlag || carriedFlag.color !== "green") return null;
+
+  const homeAnchor = getBaseAnchor(plane.color);
+  const baseTarget = getBaseInteractionTarget(plane.color);
+  if(!homeAnchor || !Number.isFinite(homeAnchor.x) || !Number.isFinite(homeAnchor.y) || !baseTarget) return null;
+
+  const reachesBase = (move) => {
+    if(!move) return false;
+    const landing = getAiMoveLandingPoint(move);
+    if(!landing || !Number.isFinite(landing.x) || !Number.isFinite(landing.y)) return false;
+    return doesPlaneZoneIntersectTargetZone({ ...plane, x: landing.x, y: landing.y }, baseTarget);
+  };
+
+  let deliverMove = planPathWithSpecialRouteProbe(plane, homeAnchor.x, homeAnchor.y, {
+    goalName: "return_with_flag",
+    decisionReason: "return_with_flag_deliver",
+    specialAttemptBudget: 2,
+    specialRouteClasses: ["gap", "ricochet"],
+    compareLabel: ["return_with_flag", plane?.id ?? ""],
+  });
+  let deliverUsesFuel = false;
+  if(!reachesBase(deliverMove)){
+    // Home beyond base range — spend fuel to reach it, but only on a DIRECT line
+    // (forceFuelMoveToMaxRange extends the launch angle straight through home; a
+    // ricochet's bounce path would not be preserved by that extension).
+    const boosted = planPathWithSpecialRouteProbe(plane, homeAnchor.x, homeAnchor.y, {
+      goalName: "return_with_flag",
+      decisionReason: "return_with_flag_deliver_fuel",
+      useFuelBoostedRange: true,
+      specialAttemptBudget: 0,
+      compareLabel: ["return_with_flag_fuel", plane?.id ?? ""],
+    });
+    if(reachesBase(boosted) && (Number(boosted?.bounceCount) || 0) === 0){
+      deliverMove = boosted;
+      deliverUsesFuel = true;
+    } else {
+      deliverMove = null;
+    }
+  }
+  if(!deliverMove) return null;
+
+  const deliverLanding = getAiMoveLandingPoint(deliverMove);
+  if(typeof logAiDecision === "function"){
+    logAiDecision("flag_delivery_route", {
+      planeId: plane?.id ?? null,
+      homeBase: { x: Number(homeAnchor.x.toFixed(1)), y: Number(homeAnchor.y.toFixed(1)) },
+      usesFuel: deliverUsesFuel,
+      bounceCount: Number(deliverMove.bounceCount) || 0,
+      routeClass: deliverMove.routeClass || "direct",
+      landing: deliverLanding ? { x: Number(deliverLanding.x.toFixed(1)), y: Number(deliverLanding.y.toFixed(1)) } : null,
+    });
+  }
+  return {
+    ...deliverMove,
+    plane,
+    goalName: "return_with_flag",
+    decisionReason: deliverUsesFuel ? "return_with_flag_deliver_fuel" : "return_with_flag_deliver",
+    routeClass: deliverMove.routeClass || "direct",
+    targetPoint: { x: homeAnchor.x, y: homeAnchor.y, kind: "home_base" },
+    planTier: -1,
+    planDistance: Number.isFinite(deliverMove.totalDist) ? deliverMove.totalDist : 0,
+    hasDirectEnemy: false,
+    readyCargoCount: Number.isFinite(options?.readyCargoCount) ? options.readyCargoCount : 0,
+  };
+}
+
 function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayMs = AI_MOVE_INITIAL_DELAY_MS, planningContext = null){
   if(
     isGameOver
@@ -16138,6 +16220,15 @@ function scheduleComputerMoveWithCargoGate(startedAt = performance.now(), delayM
       // near-zero-cost microtask unless the 6ms frame budget is exceeded.
       await aiCoopMaybeYield();
       if(!isAiTurnStillApplicable()) return null;
+
+      // === TOP priority: deliver a carried enemy flag to our base THIS turn = a sure
+      // +5. Nothing — not even a fat multikill — beats landing the flag, so this returns
+      // ABOVE the dominate sweep (planTier -1). See tryBuildAiFlagDeliveryPlan. ===
+      const flagDeliveryPlan = tryBuildAiFlagDeliveryPlan(launchReadyPlane, {
+        flagsMode: aiExecutionContext?.shouldUseFlagsMode === true,
+        readyCargoCount: readyCargo.length,
+      });
+      if(flagDeliveryPlan) return flagDeliveryPlan;
 
       // === Priority layer: dominate multi-target route (cargo + enemies, incl.
       // ricochets). Additive — only fires when a fat route exists; otherwise the

--- a/scripts/smoke-ai-flag-delivery.js
+++ b/scripts/smoke-ai-flag-delivery.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+'use strict';
+
+// Smoke test: a flag carrier that can reach base this turn gets a TOP-priority
+// delivery plan (planTier -1), with fuel when home is just out of base range — but
+// only on a DIRECT line, and only when the planned move genuinely lands in the base
+// zone. No carried (enemy) flag, or no reachable base, yields null (normal logic runs).
+
+const fs = require('fs');
+const vm = require('vm');
+
+function extractFunctionSource(source, fnName){
+  const signature = `function ${fnName}(`;
+  const start = source.indexOf(signature);
+  if(start === -1) throw new Error(`Function not found in script.js: ${fnName}`);
+  const signatureEnd = source.indexOf(')', start);
+  const bodyStart = source.indexOf('{', signatureEnd);
+  let depth = 0;
+  for(let i = bodyStart; i < source.length; i += 1){
+    const ch = source[i];
+    if(ch === '{') depth += 1;
+    if(ch === '}') depth -= 1;
+    if(depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`Function body end not found for: ${fnName}`);
+}
+
+function assert(condition, message){
+  if(!condition) throw new Error(message);
+}
+
+const source = fs.readFileSync('script.js', 'utf8');
+
+const flags = { green1: { color: 'green' }, blue1: { color: 'blue' } };
+let baseRangeMove = null; // what the base-range route probe returns
+let boostedMove = null;   // what the fuel-boosted route probe returns
+
+const context = {
+  Math,
+  Number,
+  getFlagById: (id) => flags[id] || null,
+  getBaseAnchor: () => ({ x: 0, y: 0 }),
+  getBaseInteractionTarget: () => ({ anchor: { x: 0, y: 0 }, radius: 40 }),
+  getAiMoveLandingPoint: (move) => move?.landing || null,
+  // base zone hit = the (fake) plane at the landing is within the base radius.
+  doesPlaneZoneIntersectTargetZone: (p, target) =>
+    Math.hypot(p.x - target.anchor.x, p.y - target.anchor.y) <= target.radius,
+  planPathWithSpecialRouteProbe: (plane, tx, ty, opts) => (opts?.useFuelBoostedRange ? boostedMove : baseRangeMove),
+  logAiDecision: () => {},
+};
+vm.createContext(context);
+vm.runInContext(extractFunctionSource(source, 'tryBuildAiFlagDeliveryPlan'), context);
+
+const carrier = (carriedFlagId) => ({ id: 'p1', color: 'blue', x: 200, y: 0, carriedFlagId });
+const plan = (plane, opts, base, boosted) => {
+  baseRangeMove = base;
+  boostedMove = boosted;
+  return context.tryBuildAiFlagDeliveryPlan(plane, opts);
+};
+const reaching = { landing: { x: 5, y: 5 }, totalDist: 300, bounceCount: 0, routeClass: 'direct' };
+const farMiss = { landing: { x: 500, y: 0 }, totalDist: 600, bounceCount: 0, routeClass: 'direct' };
+
+// 1. Carrier + base reachable at base range -> top-priority delivery, no fuel.
+const p1 = plan(carrier('green1'), { flagsMode: true, readyCargoCount: 2 }, reaching, null);
+assert(p1 && p1.planTier === -1, '1: a reachable carrier should get a planTier -1 delivery.');
+assert(p1.goalName === 'return_with_flag' && p1.decisionReason === 'return_with_flag_deliver',
+  '1b: the delivery plan should be a no-fuel return_with_flag.');
+
+// 2. Not flags mode -> null.
+assert(plan(carrier('green1'), { flagsMode: false }, reaching, null) === null, '2: no delivery outside flags mode.');
+
+// 3. Not carrying a flag -> null.
+assert(plan(carrier(null), { flagsMode: true }, reaching, null) === null, '3: no flag, no delivery.');
+
+// 4. Carrying our OWN-coloured flag (not the enemy green) -> null.
+assert(plan(carrier('blue1'), { flagsMode: true }, reaching, null) === null, '4: only the enemy (green) flag scores.');
+
+// 5. Base out of base range but a DIRECT fuel-boosted route reaches -> delivery with fuel.
+const p5 = plan(carrier('green1'), { flagsMode: true }, farMiss, reaching);
+assert(p5 && p5.planTier === -1 && p5.decisionReason === 'return_with_flag_deliver_fuel',
+  '5: a direct fuel-boosted reach should deliver with fuel.');
+
+// 6. Base unreachable even with fuel -> null.
+assert(plan(carrier('green1'), { flagsMode: true }, farMiss, farMiss) === null,
+  '6: no delivery when even the boosted route falls short.');
+
+// 7. Boosted route reaches but via a RICOCHET (bounce) -> NOT trusted -> null.
+const ricochetReach = { landing: { x: 5, y: 5 }, totalDist: 1100, bounceCount: 2, routeClass: 'ricochet' };
+assert(plan(carrier('green1'), { flagsMode: true }, farMiss, ricochetReach) === null,
+  '7: a ricochet fuel-boosted reach is not trusted to deliver.');
+
+console.log('Smoke test passed: a flag carrier that can reach base delivers at top priority (fuel only on a direct over-range reach); otherwise normal logic runs.');

--- a/scripts/smoke-ai-forced-non-skip-last-chance.js
+++ b/scripts/smoke-ai-forced-non-skip-last-chance.js
@@ -52,6 +52,7 @@ function buildContext(overrides = {}){
     settings: { flagsMode: false },
     markAiTurnStarted: () => {},
     hasAnimatingCargo: () => false,
+    tryBuildAiFlagDeliveryPlan: () => null,
     getBaseAnchor: () => ({ x: 0, y: 0 }),
     getAvailableFlagsByColor: () => [],
     isPlaneLaunchStateReady: () => true,

--- a/scripts/smoke-ai-last-resort-ricochet.js
+++ b/scripts/smoke-ai-last-resort-ricochet.js
@@ -134,6 +134,7 @@ const context = {
 
   // world helpers
   hasAnimatingCargo: () => false,
+  tryBuildAiFlagDeliveryPlan: () => null, // no flag carrier in these scenarios
   getBaseAnchor: () => ({ x: 50, y: 100 }),
   getAvailableFlagsByColor: () => [],
   isPlaneLaunchStateReady: () => true,

--- a/scripts/smoke-ai-selected-plan-handoff.js
+++ b/scripts/smoke-ai-selected-plan-handoff.js
@@ -60,6 +60,7 @@ const context = {
   },
   markAiTurnStarted: () => {},
   hasAnimatingCargo: () => false,
+  tryBuildAiFlagDeliveryPlan: () => null,
   getBaseAnchor: () => ({ x: 10, y: 90 }),
   getAvailableFlagsByColor: () => [],
   isPlaneLaunchStateReady: () => true,


### PR DESCRIPTION
## Проблема (то, что ты заметил)

Самолёт-носитель флага получает **+5 очков** при достижении своей базы, но в активном селекторе (`buildBestPlanForPlane`) **не было никакого приоритета на флаг** — несущий обрабатывался как любой другой и уходил собирать грузы / делать мультикилл. Гарантированные очки оставались неиспользованными.

Вся логика `return_with_flag` лежала в `planModeDrivenAiMove`, **которая нигде не вызывается — мёртвый код.** При переходе на новый селектор флаговую логику не перенесли.

## Что сделал (этап A — только несущий)

Добавил `tryBuildAiFlagDeliveryPlan`, вызывается **самым первым** в `buildBestPlanForPlane`: если самолёт несёт вражеский (зелёный) флаг и **в этот ход может долететь до своей базы**, возвращает план с `planTier -1` — выше доминирующего свипа (tier 0). Межсамолётная сортировка (`a.planTier - b.planTier`) всегда выберет носителя → он доставляет.

Заявляет ход **только когда планируемый маршрут реально приземляется в зоне базы** (гарантированная доставка):
- маршрут в пределах обычной дальности (прямой или рикошет — летит как спланирован), либо
- если база за пределом дальности — **прямой** фуел-усиленный маршрут, нацеленный на базу, чтобы инвентарь выдал топливо (`reach_distant`), а `forceFuelMoveToMaxRange` пролетел по углу прямо через базу. Рикошет-дотягивание топливом **не доверяем** (отскоки не сохраняются при растягивании до макс-дальности).

Иначе — `null`, работает обычная логика.

## Объём

Этап A = только случай «несёт флаг». «Подобрать флаг и донести за один ход» — следующий этап (B). Логика вынесена в отдельную функцию → покрыта юнит-тестом `scripts/smoke-ai-flag-delivery.js` (7 сценариев: достижимо/недостижимо, с топливом/без, рикошет-фуел не доверяется, не тот флаг и т.д.).

## Проверка

Вся AI-смоук-сюита зелёная, кроме 3 давних падений (наследие async-миграции, к изменению не относятся). Три теста, которые извлекают весь планировщик, получили мок `tryBuildAiFlagDeliveryPlan: () => null` (носителя флага в их сценариях нет).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCekbHyyGQZ4qi8DXhHAwa)_